### PR TITLE
feat: Add epic styles to estilos_condado.css

### DIFF
--- a/css/estilos_condado.css
+++ b/css/estilos_condado.css
@@ -1,0 +1,123 @@
+/* css/estilos_condado.css - Estilos épicos y ancestrales para el Condado */
+
+/* 1. Importación de Fuentes Épicas */
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Lora:ital,wght@0,400;0,700;1,400&display=swap');
+
+/* 2. Variables de Color del Condado */
+:root {
+  --condado-primario: #4A0D67; /* Púrpura profundo, como el estandarte real */
+  --condado-secundario: #B8860B; /* Oro oscuro, como tesoros antiguos */
+  --condado-acento: #FFD700; /* Oro brillante, para detalles destacados */
+  --condado-texto: #2c1d12; /* Marrón oscuro, como tinta en pergamino */
+  --condado-fondo: #f0e9e0; /* Beige claro, como piedra antigua o pergamino */
+  --condado-sombra-texto: rgba(0, 0, 0, 0.5); /* Sombra para texto épico */
+
+  --condado-font-principal: 'Lora', serif;
+  --condado-font-titulos: 'Cinzel', serif;
+}
+
+/* 3. Estilos Básicos del Cuerpo */
+body {
+  font-family: var(--condado-font-principal);
+  color: var(--condado-texto);
+  background-color: var(--condado-fondo);
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+/* 4. Estilos de Encabezados Ancestrales */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--condado-font-titulos);
+  color: var(--condado-primario);
+  text-shadow: 1px 1px 2px var(--condado-sombra-texto);
+  margin-top: 1.5em;
+  margin-bottom: 0.8em;
+  line-height: 1.2;
+}
+
+h1 {
+  font-size: 3.2em;
+  color: var(--condado-primario);
+}
+
+h2 {
+  font-size: 2.6em;
+  color: var(--condado-secundario);
+}
+
+h3 {
+  font-size: 2.1em;
+}
+
+h4 {
+  font-size: 1.7em;
+}
+
+h5 {
+  font-size: 1.4em;
+}
+
+h6 {
+  font-size: 1.2em;
+}
+
+/* 5. Estilos de Párrafos */
+p {
+  margin-bottom: 1.2em;
+  line-height: 1.7; /* Ligeramente mayor para mejorar legibilidad con Lora */
+}
+
+/* 6. Estilos de Enlaces del Condado */
+a {
+  color: var(--condado-acento);
+  text-decoration: none;
+  transition: color 0.3s ease, text-shadow 0.3s ease;
+}
+
+a:hover,
+a:focus {
+  color: var(--condado-secundario);
+  text-decoration: underline;
+  text-shadow: 0 0 5px var(--condado-acento);
+}
+
+/* 7. Contenedor Principal del Condado */
+.container-condado {
+  width: 90%;
+  max-width: 1200px; /* Un ancho máximo para contenido épico */
+  margin: 2em auto; /* Centrado y con espacio */
+  padding: 1em 2em;
+  background-color: rgba(255, 255, 255, 0.1); /* Un sutil fondo interior si es necesario */
+  border-radius: 5px; /* Bordes suaves para el contenedor */
+}
+
+/* 8. Clases de Utilidad Épicas */
+
+/* Borde Dorado Prominente */
+.border-epic-dorado {
+  border: 4px solid var(--condado-acento);
+  box-shadow: 0 0 15px var(--condado-acento);
+  padding: 1em;
+  border-radius: 8px;
+}
+
+/* Texto Púrpura Real */
+.text-epic-purpura {
+  color: var(--condado-primario);
+  font-weight: bold;
+  font-family: var(--condado-font-titulos); /* Usar la fuente de títulos para impacto */
+}
+
+/* Fondo de Pergamino */
+.background-parchment {
+  background-color: #fdf5e6; /* Un color pergamino más específico */
+  color: var(--condado-texto); /* Asegurar contraste */
+  padding: 1.5em;
+  border: 1px solid #e0d8c6; /* Un borde sutil para el pergamino */
+  box-shadow: 2px 2px 5px rgba(0,0,0,0.1);
+}
+
+/* Comentarios adicionales para futuras expansiones */
+/* Podríamos añadir estilos para botones, listas, tablas, etc. con la misma temática */
+/* También se podrían definir animaciones sutiles para elementos clave */


### PR DESCRIPTION
Populates the css/estilos_condado.css file with thematic "epic" styles. This includes:
- Importing 'Lora' and 'Cinzel' fonts.
- Defining a root color palette (purples, golds, stone).
- Basic styles for body, headings, paragraphs, and links.
- A .container-condado class.
- Utility classes like .border-epic-dorado, .text-epic-purpura, and .background-parchment.

This addresses your feedback to make the CSS file more aligned with the site's historical theme.