### PR TITLE
Organize CSS stylesheet usage across HTML files

### DIFF
--- a/camino_santiago/camino_santiago.html
+++ b/camino_santiago/camino_santiago.html
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
-    <link rel="stylesheet" href="/css/estilos_condado.css">
+    <link rel="stylesheet" href="/assets/css/estilos.css">
 </head>
 <body>
 

--- a/contacto/contacto.html
+++ b/contacto/contacto.html
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
-    <link rel="stylesheet" href="/css/estilos_condado.css">
+    <link rel="stylesheet" href="/assets/css/estilos.css">
 </head>
 <body>
 

--- a/css/estilos_condado.css
+++ b/css/estilos_condado.css
@@ -1,0 +1,1873 @@
+/* --- Variables de Color (Paleta de historia.html integrada y refinada) --- */
+:root {
+    --color-primario-purpura: #5B1A7D;
+    --color-secundario-dorado: #B8860B;
+    --color-acento-amarillo: #FFD700;  /* Estrella y brillos */
+    --color-piedra-clara: #EAE0C8;   
+    --color-piedra-media: #D2B48C;   
+    --color-texto-principal: #2c1d12;  
+    --color-fondo-pagina: #fdfaf6;   /* Alabastro muy claro para secciones */
+    --color-fondo-body-base: #f0e9e0; /* Tono alabastro para fallback del body si la imagen no carga */
+    
+    --color-negro-contraste: #1A1A1A;
+    --color-overlay-seccion-oscura: rgba(30, 20, 10, 0.65); /* Overlay más oscuro por defecto */
+    --color-linterna-haz: rgba(248, 245, 238, 0.35); /* Color del haz de la linterna, más sutil */
+    --color-linterna-centro: rgba(255, 255, 240, 0.55); /* Centro más brillante de la linterna */
+
+
+    --color-primario-purpura-rgb: 74, 13, 103;
+    --color-negro-contraste-rgb: 10, 10, 10; 
+    --color-dorado-rgb: 184, 134, 11;
+    --color-acento-amarillo-rgb: 255, 215, 0;
+    --color-alabastro-glow-rgb: 248, 245, 238; 
+    --color-fondo-pagina-rgb: 253, 250, 246; 
+    --color-error: #d9534f; 
+    --color-success: #5cb85c;
+
+
+    --font-principal: 'Lora', serif;
+    --font-titulos: 'Georgia', serif;
+
+    --transition-speed: 0.45s; 
+    --transition-speed-fast: 0.25s;
+    --border-radius-suave: 5px; 
+    --border-radius-medio: 10px;
+    --box-shadow-sutil: 0 4px 10px rgba(var(--color-primario-purpura-rgb), 0.07);
+    --box-shadow-medio: 0 6px 18px rgba(var(--color-primario-purpura-rgb), 0.1);
+    --box-shadow-elevado: 0 10px 35px rgba(var(--color-negro-contraste-rgb), 0.2);
+
+    /* CSS Custom Properties para la linterna */
+    --spotlight-x: 50%;
+    --spotlight-y: 50%;
+    --spotlight-size: 0px; /* Tamaño inicial de la linterna (se activará con JS) */
+    --spotlight-opacity: 0;
+}
+
+/* --- Reseteo y Estilos Globales --- */
+*, *::before, *::after {
+    box-sizing: border-box; 
+    margin: 0;
+    padding: 0;
+}
+
+html {
+    scroll-behavior: smooth; 
+    font-size: 100%; 
+}
+
+body {
+    font-family: var(--font-principal);
+    line-height: 1.8; 
+    color: var(--color-texto-principal);
+    background-image: url('/assets/img/alabastro.jpg'); 
+    background-size: cover; 
+    background-repeat: no-repeat; 
+    background-attachment: fixed;
+    background-position: center center;
+    background-color: var(--color-fondo-pagina); 
+    
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-titulos);
+    color: var(--color-primario-purpura);
+    margin-top: 2em; 
+    margin-bottom: 1em; 
+    line-height: 1.2; 
+    font-weight: 700; 
+    text-wrap: balance; 
+}
+
+h1 { font-size: clamp(2.6em, 6vw, 4em); text-align: center; } 
+h2 { font-size: clamp(2.2em, 5vw, 3.2em); } 
+h3 { font-size: clamp(1.7em, 4vw, 2.4em); }
+h4 { font-size: clamp(1.3em, 3vw, 1.8em); margin-top: 1.5em; margin-bottom: 0.6em;}
+
+
+p {
+    margin-bottom: 1.8em; 
+    max-width: 68ch; 
+}
+
+a {
+    color: var(--color-secundario-dorado); 
+    text-decoration: none;
+    transition: color var(--transition-speed) ease, opacity var(--transition-speed) ease;
+}
+
+a:focus-visible { 
+    color: var(--color-acento-amarillo); 
+    text-decoration: none; 
+    outline: 3px solid var(--color-acento-amarillo);
+    outline-offset: 4px;
+}
+a:hover {
+    color: var(--color-acento-amarillo); 
+    opacity: 0.85;
+    text-decoration: none; 
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+    border-radius: var(--border-radius-medio); 
+    display: block; 
+    margin-left: auto; 
+    margin-right: auto; 
+    margin-top: 1em; 
+    margin-bottom: 1em; 
+}
+
+.container {
+    width: 90%; 
+    max-width: 1200px; 
+    margin: 0 auto;
+    padding: 0 20px; 
+}
+
+/* --- Barra de Navegación --- */
+.navbar {
+    background-color: rgba(var(--color-primario-purpura-rgb), 0.97); 
+    padding: 0.5em 0; 
+    box-shadow: 0 6px 20px rgba(var(--color-negro-contraste-rgb), 0.35); 
+    position: sticky; 
+    top: 0;
+    z-index: 1000;
+    border-bottom: 2px solid rgba(var(--color-dorado-rgb), 0.3); 
+}
+
+.navbar .container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center; 
+}
+
+.navbar .logo-link {
+    display: inline-block; 
+    line-height: 0; 
+    padding: 5px 0; 
+}
+.navbar .logo-image { 
+    height: auto; 
+    max-height: 40px; 
+    width: auto; 
+    max-width: 170px; 
+    border-radius: 0; 
+    transition: transform var(--transition-speed) ease, filter var(--transition-speed) ease;
+    margin: 0; 
+}
+.navbar .logo-link:hover .logo-image, 
+.navbar .logo-link:focus-visible .logo-image {
+    transform: scale(1.03); 
+    filter: brightness(1.15); 
+    outline: none; 
+}
+
+.nav-links {
+    list-style: none;
+    display: flex;
+    align-items: center; 
+    flex-wrap: wrap; 
+    justify-content: flex-end; 
+}
+
+.nav-links li {
+    margin-left: clamp(5px, 1vw, 12px); 
+    margin-top: 5px; 
+    margin-bottom: 5px;
+}
+
+.nav-links a {
+    color: var(--color-piedra-clara);
+    font-weight: 700; 
+    font-size: clamp(0.65em, 1.2vw, 0.8em); 
+    text-transform: uppercase;
+    padding: 0.6em 0.7em; 
+    border-radius: var(--border-radius-suave);
+    letter-spacing: 0.7px; 
+    transition: background-color var(--transition-speed) ease, color var(--transition-speed) ease, transform var(--transition-speed) ease;
+}
+.nav-links a i { 
+    margin-right: 5px; 
+    font-size: 1.1em; 
+}
+
+.nav-links a:hover, .nav-links a:focus-visible, .nav-links a.active-link { 
+    color: var(--color-primario-purpura);
+    background-color: var(--color-acento-amarillo); 
+    transform: translateY(-2px); 
+    outline: none; 
+}
+
+.nav-toggle {
+    display: none; 
+    font-size: 2.2em; 
+    color: var(--color-piedra-clara);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.2em;
+}
+.nav-toggle:focus-visible {
+    outline: 2px solid var(--color-acento-amarillo);
+    outline-offset: 2px;
+}
+
+/* --- Estilos para Encabezados de Página Interna --- */
+.page-header.hero { 
+    background-image: 
+        linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.8), rgba(var(--color-negro-contraste-rgb), 0.9)), 
+        url('/assets/img/hero_default_background.jpg'); 
+    min-height: 45vh; 
+    padding: clamp(60px, 15vh, 100px) 20px; 
+    border-bottom-width: 10px; 
+}
+.page-header.hero[style*="/imagenes/hero_historia_background.jpg"],
+.page-header.hero[style*="/imagenes/hero_alfoz_background.jpg"],
+.page-header.hero[style*="/imagenes/hero_lugares_background.jpg"], 
+.page-header.hero[style*="/imagenes/hero_personajes_background.jpg"],
+.page-header.hero[style*="/imagenes/hero_camino_santiago.jpg"],
+.page-header.hero[style*="/imagenes/hero_cultura_background.jpg"], 
+.page-header.hero[style*="/imagenes/hero_visitas_background.jpg"], 
+.page-header.hero[style*="/imagenes/hero_contacto_background.jpg"],
+.page-header.hero[style*="/imagenes/hero_museo_background.jpg"],
+.page-header.hero[style*="/imagenes/hero_galeria_background.jpg"] { 
+    /* No se necesita nada aquí si el style inline ya define el background-image específico */
+}
+
+.page-header.hero .hero-content { 
+    padding: clamp(25px, 4vw, 45px);
+    background-color: rgba(var(--color-negro-contraste-rgb), 0.7); 
+}
+.page-header.hero .hero-content h1 {
+    font-size: clamp(2.5em, 6vw, 4em); 
+    margin-bottom: 0.3em;
+}
+.page-header.hero .hero-content p { 
+    font-size: clamp(1.05em, 2.2vw, 1.4em);
+    margin-bottom: 0; 
+    color: var(--color-piedra-clara);
+    text-shadow: 0 1px 5px rgba(var(--color-negro-contraste-rgb), 0.7);
+}
+.page-header.hero .decorative-star-header { 
+    width: clamp(50px, 8vw, 70px);
+    height: auto;
+    margin: 0 auto 15px auto;
+    opacity: 0.8;
+    filter: drop-shadow(0 0 10px rgba(var(--color-acento-amarillo-rgb), 0.5));
+}
+
+.decorative-star-header-highlighted { /* Specific for Cerezo de Rio Tiron header star */
+    filter: drop-shadow(0 0 12px rgba(var(--color-acento-amarillo-rgb), 0.75)) !important; /* Ensure it overrides */
+    width: clamp(60px, 10vw, 80px) !important; /* Example of keeping a slight size variation if needed */
+    margin-bottom: 20px !important;
+}
+
+
+/* --- Hero Section (Página de Inicio) --- */
+.hero { 
+    background-image: 
+        linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.82), rgba(var(--color-negro-contraste-rgb), 0.95)), 
+        url('/assets/img/hero_mis_tierras.jpg'); 
+    background-color: var(--color-primario-purpura); 
+    background-size: cover;
+    background-position: center center; 
+    color: var(--color-texto-hero); 
+    padding: clamp(80px, 22vh, 160px) 20px; 
+    text-align: center;
+    border-bottom: 15px solid var(--color-secundario-dorado); 
+    min-height: 95vh; 
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    position: relative; 
+    overflow: hidden;
+}
+
+.hero-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center; 
+    gap: 25px; 
+    max-width: 950px; 
+    background-color: rgba(var(--color-negro-contraste-rgb), 0.85); 
+    padding: clamp(40px, 7vw, 70px); 
+    border-radius: var(--border-radius-medio);
+    box-shadow: 0 15px 50px rgba(var(--color-negro-contraste-rgb), 0.6);
+    position: relative; 
+    z-index: 1;
+    border: 3px solid rgba(var(--color-dorado-rgb), 0.6); 
+}
+
+.hero-escudo { 
+    width: clamp(180px, 30vw, 280px); 
+    height: auto;
+    margin-bottom: 30px; 
+    animation: fadeInScaleUp 1.4s cubic-bezier(0.19, 1, 0.22, 1) forwards; 
+    filter: drop-shadow(0px 12px 28px rgba(var(--color-negro-contraste-rgb), 0.8)); 
+    border: 7px solid var(--color-secundario-dorado); 
+    padding: 10px; 
+    background-color: rgba(var(--color-primario-purpura-rgb), 0.65); 
+    box-shadow: 0 0 25px rgba(var(--color-secundario-dorado), 0.7), inset 0 0 18px rgba(var(--color-negro-contraste-rgb),0.5); 
+}
+
+@keyframes fadeInScaleUp {
+    from { opacity: 0; transform: scale(0.5) translateY(50px) rotate(-5deg); } 
+    to { opacity: 1; transform: scale(1) translateY(0) rotate(0deg); }
+}
+
+.hero h1 {
+    font-size: clamp(3.2em, 10vw, 6em); 
+    color: var(--color-alabastro); 
+    margin-top: 0; 
+    margin-bottom: 0.5em; 
+    text-shadow: 0 5px 15px rgba(var(--color-negro-contraste-rgb), 1), 0 0 50px rgba(var(--color-acento-amarillo),0.95); 
+    line-height: 1.1; 
+    text-align: center; 
+}
+
+.hero p {
+    font-size: clamp(1.25em, 3.5vw, 1.9em); 
+    margin-bottom: 55px; 
+    color: var(--color-piedra-clara); 
+    text-shadow: 0 3px 20px rgba(var(--color-negro-contraste-rgb), 1); 
+    line-height: 1.75;
+    max-width: 50ch; 
+    text-align: center; 
+}
+
+.cta-button {
+    background-image: linear-gradient(145deg, var(--color-acento-amarillo), var(--color-secundario-dorado) 70%); 
+    color: var(--color-primario-purpura);
+    padding: clamp(20px, 3vh, 26px) clamp(50px, 8vw, 65px); 
+    font-size: clamp(1.3em, 3.5vw, 1.7em); 
+    font-weight: 700; 
+    border-radius: 50px; 
+    border: 3px solid var(--color-primario-purpura); 
+    box-shadow: 0 8px 25px rgba(var(--color-negro-contraste-rgb), 0.4), inset 0 -4px 6px rgba(var(--color-negro-contraste-rgb), 0.25);
+    text-transform: uppercase; 
+    letter-spacing: 1.8px; 
+    transition: all var(--transition-speed) cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    display: inline-block; 
+}
+
+.cta-button:hover, .cta-button:focus-visible {
+    background-image: linear-gradient(145deg, var(--color-primario-purpura), #380A54); 
+    color: var(--color-acento-amarillo); 
+    border-color: var(--color-acento-amarillo);
+    transform: translateY(-6px) scale(1.08); 
+    box-shadow: 0 16px 40px rgba(var(--color-negro-contraste-rgb), 0.5), inset 0 -2px 3px rgba(var(--color-negro-contraste-rgb), 0.1);
+    outline: none; 
+}
+
+/* Smaller CTA button variant */
+.cta-button-small {
+    padding: clamp(12px, 2vh, 18px) clamp(25px, 5vw, 45px);
+    font-size: clamp(0.9em, 2.2vw, 1.2em);
+    letter-spacing: 1.2px;
+}
+/* Ensure hover/focus for small buttons are consistent if not already covered by general .cta-button:hover */
+.cta-button-small:hover, .cta-button-small:focus-visible {
+    /* Inherits transform and shadow changes from .cta-button:hover */
+    /* Specific background/color can be set here if different from large CTA */
+}
+
+
+/* --- Sección de Video --- */
+.video-section {
+    padding: clamp(60px, 10vh, 80px) 0; 
+}
+.video-container {
+    max-width: 1100px; 
+    margin: 25px auto; 
+    border: 8px solid var(--color-fondo-pagina); 
+    border-radius: var(--border-radius-medio); 
+    box-shadow: var(--box-shadow-elevado), 0 0 30px rgba(var(--color-alabastro-glow-rgb), 0.25); 
+    aspect-ratio: 16 / 9; 
+    overflow: hidden; 
+}
+.video-container iframe {
+    width: 100%;
+    height: 100%;
+    display: block; 
+}
+.video-section h2 { 
+     margin-bottom: 45px; 
+     color: var(--color-primario-purpura);
+}
+
+/* --- Secciones Generales con Efecto de Linterna --- */
+.section {
+    padding: clamp(70px, 12vh, 100px) 0; 
+    position: relative; 
+    background-image: url('/assets/img/alabastro.jpg'); 
+    background-size: cover;
+    background-position: center center;
+    background-attachment: local; 
+    z-index: 1; 
+    border-radius: var(--border-radius-medio); 
+    margin: 30px 0; 
+    box-shadow: var(--box-shadow-sutil);
+    overflow: hidden; /* Para contener los pseudo-elementos */
+}
+
+/* Overlay oscuro por defecto */
+.section::before { 
+    content: "";
+    position: absolute;
+    top: 0; left: 0; width: 100%; height: 100%;
+    background-color: var(--color-overlay-seccion-oscura); 
+    mix-blend-mode: multiply; 
+    opacity: 1; 
+    transition: opacity var(--transition-speed-fast) ease-out; /* Transición más rápida para el overlay */
+    z-index: 0; 
+    border-radius: inherit; 
+    pointer-events: none; 
+}
+
+/* Efecto Linterna (Spotlight) */
+.section::after {
+    content: '';
+    position: absolute;
+    inset: 0; /* Cubre toda la sección */
+    background: radial-gradient(
+        circle calc(var(--spotlight-size, 0px) * 1.5) at var(--spotlight-x, -9999px) var(--spotlight-y, -9999px),
+        var(--color-linterna-centro) 0%,       /* Centro brillante */
+        var(--color-linterna-haz) 30%,         /* Haz principal */
+        transparent 60%                        /* Borde difuminado */
+    );
+    opacity: var(--spotlight-opacity, 0);
+    pointer-events: none;
+    transition: opacity var(--transition-speed-fast) ease-out; /* Transición para la aparición/desaparición */
+    z-index: 0; /* Mismo nivel que el overlay oscuro, el contenido del container estará encima */
+    border-radius: inherit;
+}
+
+.section > .container { 
+    position: relative;
+    z-index: 1; /* Asegura que el contenido del container esté sobre los pseudo-elementos */
+    background-color: rgba(var(--color-fondo-pagina-rgb), 0.9); 
+    padding: 30px; 
+    border-radius: var(--border-radius-suave); 
+    box-shadow: 0 0 15px rgba(var(--color-negro-contraste-rgb), 0.1);
+}
+
+/* No se necesita :hover en .section ya que JS controlará la opacidad de ::after */
+/* Y el ::before se queda como está, el spotlight se superpone */
+
+
+/* SECCIÓN DE INTRODUCCIÓN DETALLADA y Bloques de Contenido de Página Interna */
+.detailed-intro-section .container,
+.page-content-block { 
+    background-color: rgba(var(--color-fondo-pagina-rgb), 0.96); 
+    padding: clamp(30px, 5vw, 50px);
+    border-radius: var(--border-radius-medio);
+    box-shadow: var(--box-shadow-medio);
+    margin-top: 0; 
+    margin-bottom: 0; 
+}
+.detailed-intro-section h2,
+.page-content-block h2 { 
+    text-align: center;
+    font-size: clamp(2.2em, 5.5vw, 3.2em);
+    margin-bottom: 1.3em; 
+}
+.detailed-intro-section p,
+.page-content-block p {
+    font-size: clamp(1.05em, 2.3vw, 1.2em);
+    line-height: 1.85; 
+    text-align: justify; 
+    margin-bottom: 1.6em;
+    color: var(--color-texto-principal); 
+}
+.detailed-intro-section p:first-of-type,
+.page-content-block .intro-paragraph { 
+    font-size: clamp(1.2em, 2.8vw, 1.4em); 
+    color: var(--color-primario-purpura); 
+    font-style: italic;
+    text-align: center; 
+    border-left: 4px solid var(--color-secundario-dorado);
+    border-right: 4px solid var(--color-secundario-dorado);
+    padding: 0.7em 1.2em; 
+    background-color: rgba(var(--color-piedra-arena-rgb, 200, 187, 174), 0.15); 
+    border-radius: var(--border-radius-suave);
+}
+
+
+/* Galería dentro de la introducción detallada */
+.image-gallery-intro {
+    display: grid; 
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); 
+    gap: 25px; 
+    margin-top: 40px;
+}
+.image-gallery-intro img {
+    border: 6px solid var(--color-piedra-media); 
+    box-shadow: var(--box-shadow-medio);
+    transition: transform 0.4s ease, box-shadow 0.4s ease, filter 0.4s ease;
+    margin: 0 auto; 
+}
+.image-gallery-intro img:hover {
+    transform: scale(1.08) rotate(-2deg); 
+    box-shadow: var(--box-shadow-elevado);
+    filter: sepia(50%) contrast(1.1) brightness(0.85); 
+}
+
+
+/* Sección de tarjetas con fondo alterno y patrón de estrella sutil */
+.section.alternate-bg > .container::before { /* Estrella de fondo sutil, ahora en el container para estar debajo del contenido */
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 300px; 
+    height: 300px;
+    background-image: url('/assets/img/estrella.png'); 
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    transform: translate(-50%, -50%) rotate(15deg);
+    z-index: -1; /* Detrás del contenido del .container pero sobre el fondo de alabastro de .section */
+    opacity: 0.06; 
+}
+
+
+.section-title {
+    text-align: center;
+    font-size: clamp(2.2em, 5.5vw, 3.2em); 
+    margin-bottom: 25px; 
+}
+
+/* Estrella de 8 puntas como separador (Venus / Lucero del Alba) usando imagen */
+.section-title::after {
+    content: '';
+    display: block;
+    width: 55px; 
+    height: 55px;
+    background-image: url('/assets/img/estrella.png');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    margin: 30px auto 60px auto; 
+    position: relative;
+    animation: pulseStar 3.8s infinite ease-in-out; 
+    filter: drop-shadow(0 0 8px rgba(var(--color-acento-amarillo-rgb), 0.6));
+}
+@keyframes pulseStar {
+    0%, 100% { transform: scale(1) rotate(0deg); opacity: 0.8; }
+    50% { transform: scale(1.08) rotate(10deg); opacity: 1; }
+}
+
+
+/* --- Tarjetas --- */
+.card-grid {
+    display: grid; 
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 40px; 
+}
+
+.card {
+    background-color: var(--color-fondo-pagina); 
+    border: 2px solid var(--color-piedra-media); 
+    border-radius: var(--border-radius-medio); 
+    box-shadow: 8px 8px 0px -2px var(--color-piedra-media), 16px 16px 28px rgba(var(--color-morado-emperador-rgb), 0.18); 
+    overflow: hidden; 
+    transition: transform 0.4s ease, box-shadow 0.4s ease; 
+    position: relative; 
+    z-index: 1;
+    display: flex; 
+    flex-direction: column; 
+}
+
+.card:hover {
+    transform: translateY(-18px) translateX(-9px) rotate(1.5deg); 
+    box-shadow: 12px 12px 0px -2px var(--color-secundario-dorado), 22px 22px 35px rgba(var(--color-morado-emperador-rgb), 0.25);
+}
+
+.card img {
+    border-bottom: 6px solid var(--color-secundario-dorado); 
+    border-radius: var(--border-radius-medio) var(--border-radius-medio) 0 0; 
+    filter: grayscale(70%) sepia(40%) contrast(1.1) brightness(0.85); 
+    transition: transform 0.45s cubic-bezier(0.165, 0.84, 0.44, 1), filter 0.45s ease-out;
+    margin: 0; 
+    width: 100%; 
+}
+.card:hover img {
+    transform: scale(1.15); 
+    filter: grayscale(10%) sepia(10%) contrast(1.05) brightness(1); 
+}
+
+.card-content {
+    padding: 30px; 
+    text-align: center; 
+    display: flex; 
+    flex-direction: column; 
+    flex-grow: 1; 
+}
+.card-content h3::before {
+    content: '';
+    display: inline-block;
+    width: 14px; 
+    height: 14px;
+    background-image: url('/assets/img/estrella.png');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    margin-right: 10px; 
+    vertical-align: middle; 
+    opacity: 0.75;
+    transform: translateY(-2px) rotate(-12deg); 
+}
+
+
+.card-content h3 {
+    font-size: clamp(1.4em, 3vw, 1.8em); 
+    margin-bottom: 15px;
+    color: var(--color-primario-purpura);
+}
+
+.card-content p {
+    font-size: clamp(1em, 2vw, 1.05em); 
+    line-height: 1.7;
+    color: var(--color-texto-secundario);
+    text-align: center; 
+    margin-bottom: 1.5em; 
+    flex-grow: 1; 
+}
+
+.card-content .read-more {
+    background-color: transparent; 
+    color: var(--color-secundario-dorado);
+    border: 2px solid var(--color-secundario-dorado);
+    padding: 10px 20px; 
+    font-size: 0.9em; 
+    font-weight: 700; 
+    margin-top: auto; 
+    align-self: center; 
+    text-decoration: none; 
+}
+.card-content .read-more:hover, .card-content .read-more:focus-visible {
+    background-color: var(--color-secundario-dorado);
+    color: var(--color-primario-purpura);
+    text-decoration: none; 
+    outline: none; 
+}
+
+/* --- Sección de Inmersión --- */
+.immersion-section {
+    background-color: var(--color-primario-purpura);
+    color: var(--color-alabastro);
+    padding: clamp(60px, 12vh, 100px) 20px;
+    background-image: 
+        linear-gradient(rgba(var(--color-primario-purpura-rgb),0.92), rgba(var(--color-primario-purpura-rgb),0.97)),
+        repeating-linear-gradient(
+            45deg,
+            transparent,
+            transparent 10px,
+            rgba(var(--color-negro-contraste-rgb), 0.04) 10px,
+            rgba(var(--color-negro-contraste-rgb), 0.04) 20px 
+        ); 
+    filter: none !important; 
+    margin: 30px 0;
+    border-radius: var(--border-radius-medio);
+}
+.immersion-section::before { /* Quitar overlay oscuro de .section */
+    opacity: 0 !important;
+}
+.immersion-section::after { /* Quitar efecto linterna de .section */
+    opacity: 0 !important;
+}
+
+
+.immersion-section h2 {
+    color: var(--color-acento-amarillo); 
+    font-size: clamp(2em, 5vw, 3em);
+}
+.immersion-section p {
+    font-size: clamp(1.15em, 2.8vw, 1.5em);
+    max-width: 850px;
+    line-height: 1.7;
+    text-align: center; 
+}
+.immersion-section .cta-button {
+    background-image: linear-gradient(to bottom, var(--color-acento-amarillo), var(--color-secundario-dorado));
+    color: var(--color-primario-purpura);
+    border-color: var(--color-alabastro); 
+}
+.immersion-section .cta-button:hover, .immersion-section .cta-button:focus-visible {
+    background-image: linear-gradient(to bottom, var(--color-alabastro), #e0dccc);
+    color: var(--color-morado-emperador);
+    border-color: var(--color-morado-emperador);
+    outline: none;
+}
+
+/* --- Estilos para la Línea de Tiempo --- */
+.timeline-section {
+    /* Hereda de .section */
+}
+.timeline-intro {
+    text-align: center;
+    max-width: 75ch;
+    margin-left: auto;
+    margin-right: auto;
+    font-size: clamp(1.1em, 2.3vw, 1.25em);
+    margin-bottom: 3.5em; 
+    color: var(--color-texto-secundario);
+}
+.timeline {
+    list-style: none;
+    padding: 0;
+    margin: 0 auto;
+    max-width: 800px; 
+    position: relative;
+}
+.timeline::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 38px; 
+    width: 4px;
+    background-color: var(--color-piedra-media);
+    border-radius: 2px;
+    box-shadow: 0 0 5px rgba(var(--color-piedra-media-rgb, 210, 180, 140), 0.5); 
+}
+
+.timeline-item {
+    position: relative;
+    margin-bottom: 50px; 
+    padding-left: 95px; 
+}
+.timeline-item:last-child {
+    margin-bottom: 0;
+}
+
+.timeline-icon {
+    position: absolute;
+    left: 0;
+    top: 0; 
+    width: 76px; 
+    height: 76px; 
+    background-color: var(--color-alabastro);
+    border: 3px solid var(--color-secundario-dorado);
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1;
+    box-shadow: 0 0 18px rgba(var(--color-dorado-rgb), 0.4);
+}
+.timeline-icon img { 
+    width: 50px; 
+    height: 50px;
+    object-fit: contain;
+    border-radius: 0; 
+    border: none;
+    box-shadow: none;
+    filter: drop-shadow(0 0 3px rgba(var(--color-acento-amarillo-rgb), 0.5));
+    margin: 0; 
+}
+
+.timeline-content {
+    background-color: var(--color-alabastro);
+    padding: 25px 30px; 
+    border-radius: var(--border-radius-medio);
+    box-shadow: var(--box-shadow-medio);
+    border: 1px solid var(--color-piedra-media);
+}
+.timeline-content h3 {
+    margin-top: 0;
+    font-size: clamp(1.4em, 3vw, 2em);
+    color: var(--color-primario-purpura);
+}
+.timeline-content p {
+    font-size: clamp(0.95em, 1.8vw, 1.05em);
+    color: var(--color-texto-secundario);
+    text-align: left; 
+    margin-bottom: 1em;
+}
+.timeline-read-more {
+    display: inline-block;
+    font-size: 0.9em;
+    font-weight: bold;
+    color: var(--color-secundario-dorado);
+    padding: 8px 15px;
+    border: 1px solid var(--color-secundario-dorado);
+    border-radius: 20px;
+    transition: background-color var(--transition-speed) ease, color var(--transition-speed) ease;
+}
+.timeline-read-more:hover {
+    background-color: var(--color-secundario-dorado);
+    color: var(--color-alabastro);
+    text-decoration: none;
+}
+
+
+/* --- Footer --- */
+.footer {
+    background-color: var(--color-texto-principal); 
+    color: var(--color-piedra-clara); 
+    padding: 70px 20px 50px 20px; 
+    border-top: 12px solid var(--color-secundario-dorado); 
+    position: relative; 
+}
+.footer::before {
+    content: '';
+    display: block;
+    width: 70px; 
+    height: 70px;
+    background-image: url('/assets/img/estrella.png');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    margin: -115px auto 35px auto; 
+    position: relative;
+    transform: rotate(12.5deg); 
+    opacity: 0.18; 
+    filter: grayscale(60%) brightness(1.3);
+}
+
+
+.footer p {
+    font-size: clamp(0.95em, 2vw, 1.05em);
+}
+
+.footer a { 
+    color: var(--color-acento-amarillo);
+}
+.footer a:focus-visible {
+    color: var(--color-alabastro);
+    outline: 1px dashed var(--color-acento-amarillo);
+}
+.footer a:hover {
+    color: var(--color-alabastro);
+}
+
+.footer .social-links {
+    margin-top: 25px; 
+}
+.footer .social-links a { 
+    font-size: 2.2em; 
+    color: var(--color-acento-amarillo); 
+    margin: 0 15px; 
+}
+.footer .social-links a:hover, .footer .social-links a:focus-visible {
+    color: var(--color-alabastro); 
+    transform: scale(1.15); 
+}
+       
+
+/* --- Responsive Design --- */
+@media (max-width: 768px) {
+    .navbar .container {
+        flex-direction: row; 
+    }
+    .nav-links {
+        flex-direction: column;
+        width: 100%;
+        position: absolute; 
+        top: 100%; 
+        left: 0;
+        background-color: var(--color-primario-purpura); 
+        padding: 0; 
+        box-shadow: 0 4px 8px rgba(var(--color-negro-contraste-rgb),0.2);
+        max-height: 0; 
+        overflow: hidden; 
+        transition: max-height 0.45s ease-in-out, padding 0.45s ease-in-out; 
+    }
+    .nav-links.active {
+        max-height: 60vh; 
+        padding: 10px 0;
+    }
+    .nav-links li {
+        margin: 0; 
+        width: 100%;
+        border-bottom: 1px solid rgba(var(--color-piedra-clara),0.1); 
+    }
+    .nav-links li:last-child {
+        border-bottom: none;
+    }
+    .nav-links a {
+         padding: 15px; 
+         display: block; 
+         text-align: center;
+         font-size: 1.1em;
+    }
+    .nav-toggle { display: block; }
+
+    .hero-content {
+        padding: 20px; 
+    }
+    .hero-escudo {
+        width: clamp(150px, 35vw, 200px); 
+    }
+    .hero h1 { font-size: clamp(2.4em, 7vw, 3.5em); }
+    .hero p { font-size: clamp(1.05em, 3.5vw, 1.4em); max-width: 90%;}
+
+    .detailed-intro-section p { text-align: left; } 
+    .section-title::after { width: 40px; height: 40px; margin: 20px auto 35px auto; } 
+
+    .timeline::before { left: 20px; }
+    .timeline-item { padding-left: 60px; margin-bottom: 40px; }
+    .timeline-icon { width: 40px; height: 40px; left: 0; }
+    .timeline-icon img { width: 60%; height: 60%; }
+}
+@media (max-width: 480px) { 
+    .navbar .logo-image { max-height: 35px; max-width: 160px; } 
+    .nav-links li { margin-left: 8px;} 
+    .nav-links a { font-size: clamp(0.75em, 1.4vw, 0.85em); padding: 0.5em 0.6em;}
+
+
+    .hero h1 { font-size: clamp(2.2em, 10vw, 3em); }
+    .hero p { font-size: clamp(1em, 4vw, 1.2em); }
+    .cta-button { padding: 15px 30px; font-size: clamp(1em, 4vw, 1.2em); }
+    .detailed-intro-section h2, .section-title { font-size: clamp(1.8em, 6vw, 2.5em); }
+    .card-content { padding: 20px; }
+    .section-title::after { width: 35px; height: 35px; } 
+    .footer::before { width: 50px; height: 50px; margin: -80px auto 20px auto; } 
+}
+
+/* Estilos específicos para la página de Camino de Santiago */
+.camino-content-block {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 30px;
+    align-items: center;
+    margin-bottom: 3em;
+}
+.camino-content-block.reverse {
+    flex-direction: row-reverse;
+}
+.camino-text {
+    flex: 1;
+    min-width: 300px; 
+}
+.camino-text p {
+    text-align: justify;
+    font-size: clamp(1em, 2.1vw, 1.15em);
+    color: var(--color-texto-secundario);
+}
+.camino-image {
+    flex: 1;
+    min-width: 280px;
+    text-align: center;
+}
+.camino-image img {
+    border: 4px solid var(--color-piedra-media);
+    box-shadow: var(--box-shadow-medio);
+    max-width: 100%; 
+    margin: 1em auto; 
+}
+.camino-image .image-caption {
+    font-size: 0.9em;
+    color: var(--color-texto-secundario);
+    font-style: italic;
+    margin-top: 0.8em;
+}
+.camino-image .image-caption i {
+    margin-right: 6px;
+    color: var(--color-secundario-dorado);
+}
+
+.camino-cta-block {
+    text-align: center;
+    padding: 30px;
+    background-color: rgba(var(--color-piedra-clara-rgb, 234, 224, 200), 0.3); 
+    border-radius: var(--border-radius-medio);
+    margin-top: 3em;
+    border: 2px dashed var(--color-secundario-dorado);
+}
+.camino-cta-block .decorative-star-cta {
+    width: 50px;
+    height: 50px;
+    margin: 0 auto 15px auto;
+    opacity: 0.7;
+}
+.camino-cta-block p {
+    font-size: clamp(1.1em, 2.3vw, 1.3em);
+    color: var(--color-primario-purpura);
+    margin-bottom: 1.5em;
+}
+
+/* Estilos para la página de historia.html y otras páginas internas (cabecera) */
+.page-header.hero[style*="/imagenes/hero_historia_background.jpg"] h1,
+.page-header.hero[style*="/imagenes/hero_alfoz_background.jpg"] h1,
+.page-header.hero[style*="/imagenes/hero_personajes_background.jpg"] h1,
+.page-header.hero[style*="/imagenes/hero_camino_santiago.jpg"] h1,
+.page-header.hero[style*="/imagenes/hero_cultura_background.jpg"] h1,
+.page-header.hero[style*="/imagenes/hero_visitas_background.jpg"] h1,
+.page-header.hero[style*="/imagenes/hero_contacto_background.jpg"] h1,
+.page-header.hero[style*="/imagenes/hero_museo_background.jpg"] h1,
+.page-header.hero[style*="/imagenes/hero_galeria_background.jpg"] h1 { 
+    font-size: clamp(2.8em, 7vw, 4.5em) !important; 
+}
+.page-header.hero[style*="/imagenes/hero_historia_background.jpg"] p,
+.page-header.hero[style*="/imagenes/hero_alfoz_background.jpg"] p,
+.page-header.hero[style*="/imagenes/hero_personajes_background.jpg"] p,
+.page-header.hero[style*="/imagenes/hero_camino_santiago.jpg"] p,
+.page-header.hero[style*="/imagenes/hero_cultura_background.jpg"] p,
+.page-header.hero[style*="/imagenes/hero_visitas_background.jpg"] p,
+.page-header.hero[style*="/imagenes/hero_contacto_background.jpg"] p,
+.page-header.hero[style*="/imagenes/hero_museo_background.jpg"] p,
+.page-header.hero[style*="/imagenes/hero_galeria_background.jpg"] p {
+    font-size: clamp(1.1em, 2.5vw, 1.5em) !important;
+}
+
+/* Estilos para el índice de personajes y bloques de contenido de página interna */
+.page-content-block { 
+    background-color: rgba(var(--color-fondo-pagina-rgb), 0.96); /* Corrected variable */
+    padding: clamp(30px, 5vw, 50px);
+    border-radius: var(--border-radius-medio);
+    box-shadow: var(--box-shadow-medio);
+    margin-top: 0; 
+    margin-bottom: 0; 
+}
+.page-content-block .intro-paragraph {
+    font-style: normal; 
+    border: none;
+    background-color: transparent;
+    padding: 0;
+    margin-bottom: 2em;
+}
+
+.indice-categorias {
+    list-style: none;
+    padding: 0;
+}
+.indice-categorias li {
+    margin-bottom: 2em;
+    padding-bottom: 1.5em;
+    border-bottom: 1px solid var(--color-piedra-media);
+}
+.indice-categorias li:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+}
+.indice-categorias h3 { 
+    font-size: clamp(1.5em, 3.5vw, 2em); 
+    color: var(--color-primario-purpura);
+    margin-bottom: 0.8em;
+    border-left: 4px solid var(--color-secundario-dorado);
+    padding-left: 15px;
+}
+.indice-categorias h3 i {
+    margin-right: 10px;
+    color: var(--color-secundario-dorado);
+}
+.indice-personajes-lista { 
+    list-style: none; 
+    padding-left: 20px; 
+}
+.indice-personajes-lista li {
+    margin-bottom: 0.7em;
+    border-bottom: none; 
+    padding-bottom: 0;
+}
+.indice-personajes-lista li::before { 
+    content: '';
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    background-image: url('/assets/img/estrella.png');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    margin-right: 10px;
+    opacity: 0.8;
+}
+.indice-personajes-lista li a {
+    font-size: clamp(1em, 2vw, 1.15em);
+    color: var(--color-texto-principal); 
+}
+.indice-personajes-lista li a:hover {
+    color: var(--color-secundario-dorado);
+}
+.back-to-link { 
+    display: inline-block;
+    margin-top: 2em;
+    padding: 12px 25px;
+    background-color: var(--color-secundario-dorado);
+    color: var(--color-primario-purpura) !important; 
+    border-radius: 25px;
+    font-family: "Cinzel", serif;
+    font-weight: bold;
+    text-align: center;
+    text-decoration: none;
+    border: 2px solid var(--color-primario-purpura);
+    transition: background-color var(--transition-speed) ease, color var(--transition-speed) ease, transform var(--transition-speed) ease;
+}
+.back-to-link:hover {
+    background-color: var(--color-primario-purpura);
+    color: var(--color-acento-amarillo) !important; 
+    text-decoration: none;
+    transform: translateY(-2px);
+}
+
+/* Styles for Character Detail Pages (within .page-content-block.personaje-detail-content) */
+.page-content-block.personaje-detail-content img.personaje-imagen-principal {
+    max-width: 300px; 
+    margin: 1em auto 2em auto; /* Adjusted margin */
+    border: 6px solid var(--color-piedra-media); /* Thicker border */
+    border-radius: 50%; 
+    object-fit: cover;
+    height: 300px; 
+    background-color: var(--color-piedra-clara); 
+    box-shadow: var(--box-shadow-elevado); /* Added shadow */
+}
+
+.page-content-block.personaje-detail-content h2 {
+    text-align: left; 
+    border-bottom: 3px solid var(--color-secundario-dorado); /* Thicker border */
+    padding-bottom: 0.4em; /* Adjusted padding */
+    margin-top: 0; /* Remove top margin if it's the first element */
+    margin-bottom: 1.2em; 
+    font-size: clamp(1.9em, 4.5vw, 2.6em); /* Slightly larger */
+    color: var(--color-primario-purpura); /* Ensure color consistency */
+}
+.page-content-block.personaje-detail-content h2::after { 
+    display: none !important; 
+}
+
+.page-content-block.personaje-detail-content h3 { /* Added styling for H3 based on Gonzalo Tellez page */
+    font-size: clamp(1.5em, 3.5vw, 2em);
+    color: var(--color-primario-purpura);
+    margin-top: 1.8em;
+    margin-bottom: 0.8em;
+    border-bottom: 1px solid var(--color-piedra-media);
+    padding-bottom: 0.2em;
+}
+
+
+.page-content-block.personaje-detail-content p, 
+.page-content-block.personaje-detail-content ul {
+    text-align: justify;
+    margin-bottom: 1.6em; 
+    font-size: clamp(1.05em, 2.2vw, 1.18em); /* Slightly larger */
+    line-height: 1.85; /* More line height */
+}
+.page-content-block.personaje-detail-content ul {
+    list-style-position: outside; 
+    padding-left: 30px; /* More padding for lists */
+}
+.page-content-block.personaje-detail-content ul li {
+    margin-bottom: 0.7em; 
+}
+
+/* Specific header style for personaje pages, if using hero_personajes_background.jpg */
+.page-header.hero[style*="hero_personajes_background.jpg"] .hero-content h1 {
+    color: #fff; 
+    text-shadow: 2px 2px 8px rgba(var(--color-negro-contraste-rgb), 0.75); 
+    font-size: clamp(2.8em, 6.5vw, 4.2em); /* Adjusted size */
+}
+.page-header.hero[style*="hero_personajes_background.jpg"] .hero-content p { /* For potential subtitles */
+    font-size: clamp(1.1em, 2.3vw, 1.4em);
+    color: var(--color-piedra-clara);
+}
+
+
+/* Styles for .page-header-indice (if used on indice_personajes.html based on original embedded styles) */
+/* This assumes .page-header-indice would be structured like .page-header.hero */
+.page-header-indice .hero-content h1 { 
+     color: #fff;
+     text-shadow: 2px 2px 6px var(--color-negro-contraste);
+}
+
+
+/* Estilos para la página de Alfoz (bibliografía, citas, etc.) */
+.bibliografia-referencias {
+    margin-top: 3em;
+    padding-top: 2em;
+    border-top: 1px solid var(--color-piedra-media);
+}
+.bibliografia-referencias h3 {
+    font-size: clamp(1.4em, 3vw, 1.9em);
+    margin-bottom: 0.8em;
+}
+.bibliografia-referencias ul, .bibliografia-referencias ol {
+    padding-left: 25px;
+    margin-bottom: 1.5em;
+}
+.bibliografia-referencias ul li, .bibliografia-referencias ol li {
+    margin-bottom: 0.6em;
+    font-size: clamp(0.9em, 1.8vw, 1em);
+    color: var(--color-texto-secundario);
+}
+.datos-historicos-alcazar {
+    margin-top: 3em;
+    padding: 20px;
+    background-color: rgba(var(--color-piedra-arena-rgb, 200, 187, 174), 0.2);
+    border-left: 5px solid var(--color-secundario-dorado);
+    border-radius: var(--border-radius-suave);
+}
+.datos-historicos-alcazar h3, .datos-historicos-alcazar h4 {
+    margin-top: 0.5em;
+}
+.cita-latin {
+    display: block;
+    margin: 1em 0 1em 2em;
+    padding: 0.8em 1em;
+    background-color: rgba(var(--color-piedra-clara-rgb,234,224,208), 0.5);
+    border-left: 3px solid var(--color-secundario-dorado);
+    font-style: italic;
+    color: var(--color-texto-principal);
+    font-size: 0.95em;
+}
+
+/* Estilos para la página de contacto */
+.contact-section .container.page-content-block { 
+    /* Los estilos de .page-content-block ya se aplican */
+}
+.contact-info {
+    text-align: center;
+    margin-bottom: 40px;
+    font-size: clamp(1em, 2.2vw, 1.15em);
+}
+.contact-info p {
+    margin-bottom: 10px;
+}
+.contact-info .email-link {
+    font-weight: bold;
+    color: var(--color-primario-purpura);
+}
+.contact-info .email-link:hover {
+    color: var(--color-secundario-dorado);
+}
+
+.contact-form-container {
+    max-width: 700px;
+    margin: 0 auto;
+    background-color: var(--color-fondo-pagina); 
+    padding: 30px 40px;
+    border-radius: var(--border-radius-medio);
+    box-shadow: var(--box-shadow-elevado);
+    border: 1px solid var(--color-piedra-media);
+}
+.contact-form-container h2 {
+    text-align: center;
+    margin-top: 0;
+    margin-bottom: 30px;
+}
+
+.form-group {
+    margin-bottom: 25px;
+}
+
+.form-group label {
+    display: block;
+    font-family: var(--font-titulos);
+    font-weight: 700;
+    color: var(--color-primario-purpura);
+    margin-bottom: 8px;
+    font-size: 1.1em;
+}
+.form-group label i { 
+    margin-right: 8px;
+    color: var(--color-secundario-dorado);
+}
+
+.form-group input[type="text"],
+.form-group input[type="email"],
+.form-group textarea {
+    width: 100%;
+    padding: 12px 15px;
+    border: 1px solid var(--color-piedra-media);
+    border-radius: var(--border-radius-suave);
+    font-family: var(--font-principal);
+    font-size: 1em;
+    color: var(--color-texto-principal);
+    background-color: rgba(var(--color-fondo-pagina-base-rgb), 0.7); 
+    transition: border-color var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+}
+.form-group input[type="text"]:focus,
+.form-group input[type="email"]:focus,
+.form-group textarea:focus {
+    border-color: var(--color-secundario-dorado);
+    box-shadow: 0 0 0 3px rgba(var(--color-dorado-rgb), 0.25); 
+    outline: none;
+    background-color: var(--color-fondo-pagina);
+}
+
+.form-group textarea {
+    min-height: 150px;
+    resize: vertical;
+}
+
+.submit-button { 
+    width: 100%;
+    margin-top: 10px;
+}
+
+/* Estilos para la página del Museo Colaborativo y Galería Colaborativa */
+.upload-section .container.page-content-block,
+.museum-gallery-section .container.page-content-block,
+.upload-section-galeria .container.page-content-block, 
+.photo-gallery-section .container.page-content-block { 
+    background-color: rgba(var(--color-fondo-pagina-rgb), 0.92);
+}
+
+.upload-form-container { 
+    max-width: 750px;
+    margin: 0 auto;
+    background-color: var(--color-fondo-pagina);
+    padding: 30px 40px;
+    border-radius: var(--border-radius-medio);
+    box-shadow: var(--box-shadow-elevado);
+    border: 1px solid var(--color-piedra-media);
+}
+.upload-form-container h2 { /* This also applies to contact form h2 */
+    text-align: center;
+    margin-top: 0; /* Remove default h2 top margin if it's the first child */
+    margin-bottom: 30px;
+}
+.upload-form-container .form-group label i {
+    color: var(--color-secundario-dorado);
+}
+.upload-form-container .submit-button { 
+    width: 100%;
+    margin-top: 15px;
+}
+.preview-container img { /* Applies to both museo and galeria previews */
+    max-height: 200px;
+    margin: 0 auto 10px auto; /* Centered preview */
+    border: 2px solid var(--color-piedra-media);
+    border-radius: var(--border-radius-suave); /* Softer radius for previews */
+    display: block; /* Ensure block for centering */
+}
+
+.museum-gallery-grid {
+    /* Los estilos de .card-grid ya se aplican */
+}
+.museum-piece-card img {
+    cursor: pointer; 
+    filter: grayscale(50%) sepia(25%) contrast(1.05) brightness(0.9); 
+}
+.museum-piece-card:hover img {
+    filter: grayscale(0%) sepia(0%) contrast(1) brightness(1);
+}
+.museum-piece-card .piece-author {
+    font-size: 0.9em;
+    color: var(--color-texto-secundario);
+    margin-top: -10px; 
+    margin-bottom: 10px;
+}
+.museum-piece-card .piece-description {
+    font-size: 0.95em;
+    color: var(--color-texto-principal);
+    text-align: center;
+    min-height: 60px; 
+}
+.no-pieces-message,
+.no-photos-message { 
+    grid-column: 1 / -1; 
+    text-align: center;
+    font-style: italic;
+    color: var(--color-texto-secundario);
+    padding: 40px;
+}
+
+/* Estilos específicos para la Galería de Fotos Colaborativa */
+.photo-gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); 
+    gap: 20px;
+}
+.photo-card {
+    background-color: var(--color-fondo-pagina);
+    border: 1px solid var(--color-piedra-media);
+    border-radius: var(--border-radius-suave);
+    box-shadow: var(--box-shadow-sutil);
+    overflow: hidden;
+    transition: transform var(--transition-speed-fast) ease, box-shadow var(--transition-speed-fast) ease;
+    display: flex;
+    flex-direction: column;
+}
+.photo-card:hover {
+    transform: translateY(-5px) scale(1.02);
+    box-shadow: var(--box-shadow-medio);
+}
+.photo-card img {
+    width: 100%;
+    height: 200px; 
+    object-fit: cover;
+    border-radius: var(--border-radius-suave) var(--border-radius-suave) 0 0;
+    margin: 0;
+    cursor: pointer;
+}
+.photo-card-caption {
+    padding: 15px;
+    text-align: center;
+}
+.photo-card-caption h4 {
+    font-size: clamp(1.1em, 2.5vw, 1.4em);
+    margin-top: 0;
+    margin-bottom: 8px;
+    color: var(--color-primario-purpura);
+}
+.photo-card-caption p {
+    font-size: 0.9em;
+    color: var(--color-texto-secundario);
+    margin-bottom: 5px;
+    line-height: 1.4;
+}
+.photo-author-gallery { 
+    font-size: 0.8em !important;
+    font-style: italic;
+    color: var(--color-piedra-media) !important;
+    margin-top: 5px;
+}
+
+
+/* Modal para imágenes */
+.modal {
+  display: none; 
+  position: fixed; 
+  z-index: 2000; 
+  padding-top: 50px; 
+  left: 0;
+  top: 0;
+  width: 100%; 
+  height: 100%; 
+  overflow: auto; 
+  background-color: rgba(var(--color-negro-contraste-rgb), 0.92); 
+}
+.modal-content {
+  margin: auto;
+  display: block;
+  width: 80%;
+  max-width: 750px;
+  max-height: 85vh;
+  animation-name: zoomModal;
+  animation-duration: 0.5s;
+  border: 5px solid var(--color-piedra-clara);
+  border-radius: var(--border-radius-suave);
+}
+@keyframes zoomModal {
+  from {transform:scale(0.8)} 
+  to {transform:scale(1)}
+}
+#modalCaption {
+  margin: auto;
+  display: block;
+  width: 80%;
+  max-width: 700px;
+  text-align: center;
+  color: var(--color-piedra-clara);
+  padding: 15px 0;
+  font-family: var(--font-titulos);
+  font-size: 1.2em;
+}
+.modal-close-button {
+  position: absolute;
+  top: 15px;
+  right: 35px;
+  color: var(--color-piedra-clara);
+  font-size: 40px;
+  font-weight: bold;
+  transition: 0.3s;
+}
+.modal-close-button:hover,
+.modal-close-button:focus {
+  color: var(--color-acento-amarillo);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+/* --- Styles for Content Subsections and Figures --- */
+.content-subsection {
+    margin-bottom: 3.5em; /* Add space between subsections */
+    padding-bottom: 2em;
+    border-bottom: 1px solid rgba(var(--color-piedra-media-rgb, 210, 180, 140), 0.3); /* Subtle separator */
+}
+
+.content-subsection:last-of-type {
+    border-bottom: none; /* No border for the last subsection */
+    margin-bottom: 1em;
+}
+
+.content-subsection h3 {
+    font-size: clamp(1.6em, 3.8vw, 2.2em); /* Slightly larger H3 for subsections */
+    color: var(--color-primario-purpura);
+    margin-bottom: 1em;
+    padding-bottom: 0.3em;
+    border-bottom: 2px solid var(--color-secundario-dorado); /* Accent under H3 */
+    display: inline-block; /* So border only spans the text width */
+}
+
+.content-subsection h3 i {
+    margin-right: 12px; /* Space for FontAwesome icons in H3 */
+    color: var(--color-secundario-dorado);
+}
+
+.content-subsection p {
+    font-size: clamp(1em, 2.2vw, 1.15em); /* Consistent paragraph text */
+    line-height: 1.75;
+    margin-bottom: 1.5em;
+}
+
+.content-subsection .image-gallery-intro {
+    margin-top: 1.5em;
+    margin-bottom: 2em;
+}
+
+.content-subsection figure {
+    margin: 0; /* Reset default figure margin */
+    background-color: rgba(var(--color-fondo-pagina-rgb), 0.5); /* Slight background tint for figures */
+    padding: 10px;
+    border-radius: var(--border-radius-suave);
+    box-shadow: var(--box-shadow-sutil);
+    border: 1px solid rgba(var(--color-piedra-media-rgb, 210, 180, 140), 0.4);
+}
+
+.content-subsection figure img {
+    border: none; /* Remove default image border if any, rely on figure's border */
+    margin-bottom: 0.5em; /* Space between image and caption */
+    border-radius: var(--border-radius-suave); /* Consistent border radius */
+}
+
+.content-subsection figcaption {
+    font-size: clamp(0.85em, 1.8vw, 0.95em);
+    text-align: center;
+    color: var(--color-texto-principal);
+    font-style: italic;
+    padding: 0.5em 0;
+}
+
+/* Ensure these styles don't negatively impact existing galleries if .image-gallery-intro is nested */
+.page-content-block .content-subsection .image-gallery-intro img {
+    border: none; /* Override general .image-gallery-intro img border for this specific context */
+}
+
+/* --- Styles for Comments Section --- */
+#comments-section {
+    background-color: rgba(var(--color-fondo-pagina-rgb), 0.7); /* Slightly different background for emphasis */
+    padding: 25px;
+    border-radius: var(--border-radius-suave);
+    margin-top: 2em;
+}
+
+#comments-section h3 {
+    border-bottom: none; /* Remove bottom border from subsection h3 if not desired here */
+    text-align: center;
+}
+
+#comments-section .contact-form-container { /* Re-using for comment form styling */
+    box-shadow: none; /* Remove excessive shadow if inherited */
+    border: 1px solid rgba(var(--color-piedra-media-rgb), 0.3);
+}
+
+.comment-item {
+    background-color: var(--color-fondo-pagina);
+    padding: 15px;
+    border-radius: var(--border-radius-suave);
+    margin-bottom: 15px;
+    border: 1px solid var(--color-piedra-media);
+    box-shadow: var(--box-shadow-sutil);
+}
+
+.comment-item p {
+    margin-bottom: 0.5em;
+    font-size: 1em;
+    line-height: 1.6;
+    text-align: left; /* Override centered intro paragraph style */
+}
+
+.comment-item strong {
+    color: var(--color-primario-purpura);
+    font-family: var(--font-titulos);
+}
+
+.comment-item small {
+    font-size: 0.8em;
+    color: var(--color-texto-secundario);
+    display: block;
+    text-align: right;
+    margin-top: 5px;
+}
+
+/* --- Styles for Participation Sections (Share Story, Quiz, Gallery Promo) --- */
+#share-story-section, #quiz-section, #gallery-promo-section {
+    margin-top: 2.5em;
+    padding-top: 1.5em;
+}
+
+#share-story-section h3, #quiz-section h3, #gallery-promo-section h3 {
+    text-align: center; /* Center titles for these new sections */
+    border-bottom: none; /* Override default from .content-subsection if not desired */
+    margin-bottom: 1.2em;
+}
+
+.quiz-container {
+    background-color: rgba(var(--color-fondo-pagina-rgb), 0.8);
+    padding: 20px;
+    border-radius: var(--border-radius-suave);
+    border: 1px solid rgba(var(--color-piedra-media-rgb), 0.4);
+}
+
+.quiz-question {
+    margin-bottom: 20px;
+    padding-bottom: 15px;
+    border-bottom: 1px dashed rgba(var(--color-piedra-media-rgb), 0.3);
+}
+.quiz-question:last-of-type {
+    border-bottom: none;
+    margin-bottom: 0;
+}
+
+.quiz-question p strong {
+    font-family: var(--font-principal); /* Main font for question text */
+    color: var(--color-texto-principal);
+}
+
+.quiz-options {
+    list-style: none;
+    padding: 0;
+    margin: 10px 0 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.quiz-options button {
+    display: block;
+    width: 100%;
+    padding: 10px 15px;
+    font-family: var(--font-principal);
+    font-size: 0.95em;
+    background-color: var(--color-piedra-clara);
+    color: var(--color-texto-principal);
+    border: 1px solid var(--color-piedra-media);
+    border-radius: var(--border-radius-suave);
+    cursor: pointer;
+    transition: background-color var(--transition-speed-fast), color var(--transition-speed-fast);
+    text-align: left;
+}
+
+.quiz-options button:hover:not(:disabled) {
+    background-color: var(--color-secundario-dorado);
+    color: var(--color-primario-purpura);
+}
+
+.quiz-options button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+}
+
+#quiz-feedback {
+    min-height: 20px; /* Reserve space for feedback text */
+    font-size: 1.1em;
+    color: var(--color-primario-purpura);
+    text-align: center; /* Ensure it's centered if not already */
+    opacity: 0; /* Start hidden for fade-in */
+    transform: translateY(10px); /* Start slightly lower for slide-in */
+    transition: opacity 0.4s ease-out, transform 0.4s ease-out;
+}
+
+#quiz-feedback.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+#gallery-promo-section .image-gallery-intro figure {
+    border: 2px solid var(--color-piedra-clara); /* Lighter border for promo images */
+}
+#gallery-promo-section .image-gallery-intro figcaption {
+    font-size: 0.9em;
+    color: var(--color-texto-secundario);
+}
+
+/* --- Scroll Animation Styling --- */
+.animate-on-scroll {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: opacity 0.7s ease-out, transform 0.7s ease-out;
+    transition-delay: 0.2s; /* Slight delay before animation starts */
+}
+
+.animate-on-scroll.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* --- Subtle Hover Effects for Figures in Content Subsections --- */
+.content-subsection figure img {
+    /* Ensure existing transitions from .image-gallery-intro img are not entirely overridden, 
+       or define a new specific transition here if needed.
+       The previous step already added some figure img styling, this enhances it. */
+    transition: transform var(--transition-speed-fast) ease-in-out, 
+                box-shadow var(--transition-speed-fast) ease-in-out,
+                filter var(--transition-speed-fast) ease-in-out; /* Added filter for completeness */
+}
+
+.content-subsection figure:hover img {
+    transform: scale(1.05); /* Slight zoom effect */
+    box-shadow: var(--box-shadow-medio); /* Use pre-defined medium shadow */
+    /* Optional: Slightly change filter if desired, e.g., a subtle brightness or contrast change */
+    /* filter: brightness(1.05); */
+}
+
+/* Refine existing .image-gallery-intro img hover effect if it's too aggressive
+   or ensure it doesn't conflict. The specificity of .content-subsection figure:hover img 
+   should generally take precedence for these specific images. */
+
+/* The following rule was added in a previous step of the *first* plan:
+.image-gallery-intro img:hover {
+    transform: scale(1.08) rotate(-2deg); 
+    box-shadow: var(--box-shadow-elevado);
+    filter: sepia(50%) contrast(1.1) brightness(0.85); 
+}
+   This is fine, the new rule is more specific for figures inside content-subsections.
+   If any .image-gallery-intro is directly inside a .content-subsection (which they are),
+   and the img is directly inside a figure, the new rule for figure:hover img will apply.
+*/
+
+/* --- Sidebar Styles --- */
+#sidebar {
+    position: fixed;
+    top: 0;
+    left: -280px; /* Initial hidden state, slightly wider to accommodate padding */
+    width: 280px;
+    height: 100vh;
+    background-color: var(--color-primario-purpura); /* Using existing primary color */
+    padding: 20px;
+    box-shadow: 4px 0 15px rgba(var(--color-negro-contraste-rgb), 0.3);
+    transition: left 0.35s ease-in-out;
+    overflow-y: auto;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+}
+
+#sidebar.sidebar-visible {
+    left: 0;
+}
+
+#sidebar-toggle {
+    position: fixed;
+    top: 15px;
+    left: 15px;
+    font-size: 1.8em; /* Adjusted size */
+    color: var(--color-piedra-clara);
+    background-color: var(--color-primario-purpura);
+    border: 2px solid var(--color-secundario-dorado);
+    border-radius: var(--border-radius-suave);
+    padding: 8px 12px;
+    cursor: pointer;
+    z-index: 1001;
+    transition: left 0.35s ease-in-out, background-color 0.3s ease, color 0.3s ease;
+}
+
+/* Adjust toggle button position when sidebar is visible */
+body.sidebar-active #sidebar-toggle {
+    left: 300px; /* sidebar width + desired offset */
+}
+
+
+#sidebar .logo-link {
+    display: block;
+    text-align: center;
+    margin-bottom: 30px;
+    padding: 10px 0;
+}
+
+#sidebar .logo-image {
+    max-width: 80%; /* Adjust as needed */
+    height: auto;
+    border-radius: var(--border-radius-suave);
+    margin: 0 auto;
+    border: 3px solid var(--color-secundario-dorado);
+}
+
+#sidebar .nav-links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex; /* Keep flex for easy column layout */
+    flex-direction: column; /* Stack links vertically */
+    align-items: flex-start; /* Align items to the start of the flex container */
+    width: 100%;
+}
+
+#sidebar .nav-links li {
+    width: 100%; /* Make list items take full width */
+    margin-bottom: 8px; /* Space between links */
+}
+
+#sidebar .nav-links a {
+    display: block; /* Make links block-level for full-width click area */
+    padding: 12px 15px;
+    color: var(--color-piedra-clara);
+    font-family: var(--font-titulos);
+    font-size: 1.1em; /* Slightly larger font for sidebar */
+    font-weight: 600;
+    text-decoration: none;
+    border-radius: var(--border-radius-suave);
+    transition: background-color var(--transition-speed-fast) ease, color var(--transition-speed-fast) ease, padding-left var(--transition-speed-fast) ease;
+}
+
+#sidebar .nav-links a:hover,
+#sidebar .nav-links a:focus-visible,
+#sidebar .nav-links a.active-link {
+    background-color: var(--color-acento-amarillo);
+    color: var(--color-primario-purpura);
+    padding-left: 25px; /* Indent on hover/active for visual feedback */
+    outline: none;
+}
+
+#sidebar .nav-links a i {
+    margin-right: 10px; /* Space for icons */
+    font-size: 1.1em;
+}
+
+/* Main content adjustment when sidebar is active */
+body.sidebar-active {
+    margin-left: 280px; /* Should match sidebar width */
+    transition: margin-left 0.35s ease-in-out;
+}
+
+/* Responsive adjustments for toggle button and sidebar interaction */
+@media (max-width: 768px) {
+    /* No changes needed for #sidebar-toggle related to 'body.sidebar-active' as it's handled by JS */
+    /* The main content margin adjustment will still apply, which is good. */
+    /* Ensure the old navbar and nav-toggle are hidden if they still exist or appear */
+    .navbar, .nav-toggle {
+        display: none !important; /* Force hide old navbar elements */
+    }
+}
+
+/* --- Styles from historia/nuestra_historia_nuevo4.html <style> block --- */
+.article-content p {
+    margin-bottom: 1em;
+    line-height: 1.6;
+}
+.article-content h3 {
+    font-family: 'Cinzel', serif;
+    color: var(--color-secundario-dorado);
+    margin-top: 1.5em;
+    margin-bottom: 0.5em;
+}
+.article-content h4 {
+    font-family: 'Lora', serif;
+    font-style: italic;
+    color: var(--color-primario-purpura);
+    margin-top: 1em;
+    margin-bottom: 0.3em;
+}
+.article-content a {
+    color: var(--color-acento-rojo);
+    text-decoration: underline;
+}
+.article-content a:hover {
+    color: var(--color-secundario-dorado);
+}
+/* --- End of styles from historia/nuestra_historia_nuevo4.html <style> block --- */
+/* --- Styles from inline attributes in historia/nuestra_historia_nuevo4.html --- */
+.page-header.hero.hero-nuestra-historia-specific {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/cerezo_vista_aerea.jpg');
+    min-height: 50vh;
+}
+/* --- End of styles from inline attributes in historia/nuestra_historia_nuevo4.html --- */

--- a/css/estilos_condado.css
+++ b/css/estilos_condado.css
@@ -15,7 +15,7 @@
     --color-linterna-centro: rgba(255, 255, 240, 0.55); /* Centro más brillante de la linterna */
 
 
-    --color-primario-purpura-rgb: 74, 13, 103;
+    --color-primario-purpura-rgb: 91, 26, 125;
     --color-negro-contraste-rgb: 10, 10, 10; 
     --color-dorado-rgb: 184, 134, 11;
     --color-acento-amarillo-rgb: 255, 215, 0;
@@ -59,7 +59,7 @@ body {
     font-family: var(--font-principal);
     line-height: 1.8; 
     color: var(--color-texto-principal);
-    background-image: url('/assets/img/alabastro.jpg'); 
+    background-image: linear-gradient(rgba(234, 224, 208, 0.05), rgba(234, 224, 208, 0.05)), url('/assets/img/alabastro.jpg'); 
     background-size: cover; 
     background-repeat: no-repeat; 
     background-attachment: fixed;
@@ -278,7 +278,7 @@ img {
     color: var(--color-texto-hero); 
     padding: clamp(80px, 22vh, 160px) 20px; 
     text-align: center;
-    border-bottom: 15px solid var(--color-secundario-dorado); 
+    border-bottom: 15px solid #AF8F0A; 
     min-height: 95vh; 
     display: flex;
     flex-direction: column;
@@ -574,7 +574,7 @@ img {
     background-color: var(--color-fondo-pagina); 
     border: 2px solid var(--color-piedra-media); 
     border-radius: var(--border-radius-medio); 
-    box-shadow: 8px 8px 0px -2px var(--color-piedra-media), 16px 16px 28px rgba(var(--color-morado-emperador-rgb), 0.18); 
+    box-shadow: 8px 8px 0px -2px var(--color-piedra-media), 16px 16px 28px rgba(91, 26, 125, 0.18); 
     overflow: hidden; 
     transition: transform 0.4s ease, box-shadow 0.4s ease; 
     position: relative; 

--- a/cultura/cultura.html
+++ b/cultura/cultura.html
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
-    <link rel="stylesheet" href="/css/estilos_condado.css">
+    <link rel="stylesheet" href="/assets/css/estilos.css">
 </head>
 <body>
 

--- a/galeria/galeria_colaborativa.html
+++ b/galeria/galeria_colaborativa.html
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
-    <link rel="stylesheet" href="/css/estilos_condado.css">
+    <link rel="stylesheet" href="/assets/css/estilos.css">
 </head>
 <body>
 

--- a/museo/museo.html
+++ b/museo/museo.html
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
-    <link rel="stylesheet" href="/css/estilos_condado.css">
+    <link rel="stylesheet" href="/assets/css/estilos.css">
 </head>
 <body>
 

--- a/secciones_index/historia_tiempo_resumen.html
+++ b/secciones_index/historia_tiempo_resumen.html
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
-    <link rel="stylesheet" href="/css/estilos_condado.css">
+    <link rel="stylesheet" href="/assets/css/estilos.css">
 
 </head>
 <body>

--- a/secciones_index/memoria_hispanidad.html
+++ b/secciones_index/memoria_hispanidad.html
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
-    <link rel="stylesheet" href="/css/estilos_condado.css">
+    <link rel="stylesheet" href="/assets/css/estilos.css">
 
 </head>
 <body>

--- a/visitas/visitas.html
+++ b/visitas/visitas.html
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
-    <link rel="stylesheet" href="/css/estilos_condado.css">
+    <link rel="stylesheet" href="/assets/css/estilos.css">
 </head>
 <body>
 


### PR DESCRIPTION
- I populated `css/estilos_condado.css` by copying from `assets/css/estilos.css`.
- I differentiated `css/estilos_condado.css` with a modified primary purple color (#5B1A7D) and title font ('Georgia') to create a distinct "Condado" theme.
- I ensured that primary "Condado" themed pages (`index.html`, `alfoz/`, `historia/`, `personajes/`, `lugares/`) use `css/estilos_condado.css`.
- I updated general pages (`camino_santiago/`, `contacto/`, `cultura/`, `galeria/`, `museo/`, `visitas/`, some `secciones_index/` files) to use the default `assets/css/estilos.css`.
- This change allows for specific styling for core "Condado" pages while maintaining a general site style for other content.