### PR TITLE
Input:

### DIFF
--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html
@@ -265,20 +265,22 @@
                     <img src="/assets/img/placeholder.jpg" alt="[Retrato o imagen de Alvaro Herramelliz]" class="personaje-imagen-principal" onerror="this.style.display='none'">
                     <h2>Biografía y Relevancia</h2>
                     <p>
-                        Información detallada sobre Alvaro Herramelliz, su vida, sus hazañas y su importancia en la historia del Condado de Castilla y Cerezo de Río Tirón. 
-                        Este es un texto de ejemplo, por favor reemplázalo con el contenido real.
+                        Alvaro Herraméliz fue una figura crucial en la historia temprana de Castilla, ostentando los títulos de Conde de Cerezo y Lantarón, así como Conde de Castilla y Álava. Gobernó desde el estratégico Alcázar de Cerasio, considerado en el documento `nuevo4.md` como un punto central en el origen de Castilla.
                     </p>
                     <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-                        Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
-                        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                        Su esposa fue Doña Sancha, hija de los reyes de Navarra. Tras la muerte de Alvaro Herraméliz, Doña Sancha heredó sus importantes títulos. Posteriormente, Doña Sancha contrajo matrimonio con Fernán González, quien ya era Conde de Lara y Burgos. A través de este matrimonio, Fernán González también asumió los títulos de Conde de Cerezo y Lantarón, y Conde de Castilla y Álava. Esta unión y la consolidación de títulos fueron un evento significativo, marcando un punto de inflexión en la historia de Castilla, que incluyó el traslado de la capitalidad a Burgos por parte de Fernán González.
+                    </p>
+                    <p>
+                        Alvaro Herraméliz es recordado como el último Conde de Cerasio antes de esta transición, subrayando la importancia de Cerezo de Río Tirón y el Alcázar de Cerasio en la narrativa fundacional de Castilla. En los textos, también se le menciona con las variantes de Alvaro de Herramélluri y Alvaro Herrameliz.
                     </p>
                     
                     <h3>Hitos Importantes</h3>
                     <ul>
-                        <li>[Hito importante 1 de Alvaro Herramelliz]</li>
-                        <li>[Hito importante 2 de Alvaro Herramelliz]</li>
-                        <li>[Hito importante 3 de Alvaro Herramelliz]</li>
+                        <li>Conde de Cerezo y Lantarón.</li>
+                        <li>Conde de Castilla y Álava.</li>
+                        <li>Gobernó desde el Alcázar de Cerasio.</li>
+                        <li>Esposo de Doña Sancha, hija de los reyes de Navarra.</li>
+                        <li>Su viuda, Doña Sancha, transmitió sus títulos a Fernán González tras su matrimonio, unificando así importantes señoríos castellanos.</li>
                     </ul>
                     
                     <p style="text-align:center;">


### PR DESCRIPTION
Populate Alvaro Herramelliz page with historical data

Updated the page personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html with information about Alvaro Herramelliz, Conde de Cerezo y Lantarón, Conde de Castilla y Álava.

The information was extracted from nuevo4.md and includes:
- Biographical details focusing on his titles and marriage to Doña Sancha.
- His role in the historical narrative of Cerezo de Río Tirón and the Alcázar de Cerasio as origins of Castile.
- Clarification of how his titles passed to Fernán González.
- A list of key historical milestones.

Output:
I've updated the page personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html with information about Alvaro Herramelliz, Conde de Cerezo y Lantarón, Conde de Castilla y Álava.

The information was extracted from nuevo4.md and includes:
- Biographical details focusing on his titles and marriage to Doña Sancha.
- His role in the historical narrative of Cerezo de Río Tirón and the Alcázar de Cerasio as origins of Castile.
- Clarification of how his titles passed to Fernán González.
- A list of key historical milestones.