### PR TITLE
Feat: Implement PHP backend for collaborative gallery

### DIFF
--- a/api/galeria_list.php
+++ b/api/galeria_list.php
@@ -1,0 +1,67 @@
+<?php
+header('Content-Type: application/json');
+
+$targetDir = "../uploads/museo_piezas/";
+$photosData = [];
+
+if (!is_dir($targetDir)) {
+    // Directory doesn't exist, which might be normal if no uploads yet.
+    // galeria_upload.php is responsible for creating it.
+    echo json_encode($photosData); // Return empty array
+    exit;
+}
+
+$files = scandir($targetDir);
+if ($files === false) {
+    // Failed to scan directory
+    // Optionally log an error or return a specific error response
+    echo json_encode(["error" => "Failed to scan directory."]);
+    exit;
+}
+
+foreach ($files as $file) {
+    if ($file === '.' || $file === '..') {
+        continue;
+    }
+
+    $filePath = $targetDir . $file;
+    $fileExtension = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+    $allowedImageExtensions = ['jpg', 'jpeg', 'png', 'gif'];
+
+    if (in_array($fileExtension, $allowedImageExtensions)) {
+        $metadataFilename = pathinfo($filePath, PATHINFO_FILENAME) . '.json';
+        $metadataFilePath = $targetDir . $metadataFilename;
+
+        if (file_exists($metadataFilePath)) {
+            $metadataJson = file_get_contents($metadataFilePath);
+            if ($metadataJson === false) {
+                // Optionally log error: Failed to read metadata file
+                continue; // Skip this image
+            }
+            $metadata = json_decode($metadataJson, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                // Optionally log error: Invalid JSON in metadata file
+                continue; // Skip this image
+            }
+
+            // Ensure imagenUrl is correct (it should be from the upload script)
+            // Add an 'id' if not present, using the filename without extension
+            if (!isset($metadata['id'])) {
+                $metadata['id'] = pathinfo($file, PATHINFO_FILENAME);
+            }
+
+            // Ensure essential fields are present, provide defaults if necessary
+            $metadata['titulo'] = $metadata['titulo'] ?? 'Sin título';
+            $metadata['descripcion'] = $metadata['descripcion'] ?? 'Sin descripción';
+            $metadata['autor'] = $metadata['autor'] ?? 'Anónimo';
+            $metadata['imagenUrl'] = $metadata['imagenUrl'] ?? '/uploads/museo_piezas/' . $file;
+
+
+            $photosData[] = $metadata;
+        }
+        // If metadata file doesn't exist, we skip this image as per instructions.
+    }
+}
+
+echo json_encode($photosData);
+?>

--- a/api/galeria_upload.php
+++ b/api/galeria_upload.php
@@ -1,0 +1,95 @@
+<?php
+header('Content-Type: application/json');
+
+$targetDir = "../uploads/museo_piezas/";
+$response = ["success" => false, "message" => ""];
+
+// Create target directory if it doesn't exist
+if (!file_exists($targetDir)) {
+    if (!mkdir($targetDir, 0777, true)) {
+        $response["message"] = "Error: No se pudo crear el directorio de subida.";
+        echo json_encode($response);
+        exit;
+    }
+}
+
+if (!is_writable($targetDir)) {
+    $response["message"] = "Error: El directorio de subida no tiene permisos de escritura.";
+    echo json_encode($response);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_FILES['photoFile'])) {
+        $photoFile = $_FILES['photoFile'];
+
+        // Sanitize inputs
+        $photoTitulo = isset($_POST['photoTitulo']) ? htmlspecialchars(strip_tags($_POST['photoTitulo'])) : 'Sin título';
+        $photoDescripcion = isset($_POST['photoDescripcion']) ? htmlspecialchars(strip_tags($_POST['photoDescripcion'])) : 'Sin descripción';
+        $photoAutor = isset($_POST['photoAutor']) ? htmlspecialchars(strip_tags($_POST['photoAutor'])) : 'Anónimo';
+        $originalFilename = $photoFile['name'];
+
+        // File validation
+        if ($photoFile['error'] !== UPLOAD_ERR_OK) {
+            $response["message"] = "Error en la subida del archivo: " . $photoFile['error'];
+            echo json_encode($response);
+            exit;
+        }
+
+        $allowedMimeTypes = ['image/jpeg', 'image/png', 'image/gif'];
+        $fileMimeType = mime_content_type($photoFile['tmp_name']);
+        if (!in_array($fileMimeType, $allowedMimeTypes)) {
+            $response["message"] = "Error: Tipo de archivo no permitido. Solo se permiten JPG, PNG y GIF.";
+            echo json_encode($response);
+            exit;
+        }
+
+        $maxFileSize = 2 * 1024 * 1024; // 2MB
+        if ($photoFile['size'] > $maxFileSize) {
+            $response["message"] = "Error: El archivo excede el tamaño máximo permitido de 2MB.";
+            echo json_encode($response);
+            exit;
+        }
+
+        // Generate unique filename
+        $fileExtension = strtolower(pathinfo($originalFilename, PATHINFO_EXTENSION));
+        $uniqueFilename = uniqid() . '_' . time() . '.' . $fileExtension;
+        $targetFilePath = $targetDir . $uniqueFilename;
+        $webPathToImage = "/uploads/museo_piezas/" . $uniqueFilename; // Relative path from web root
+
+        // Move uploaded file
+        if (move_uploaded_file($photoFile['tmp_name'], $targetFilePath)) {
+            // Create metadata JSON file
+            $metadata = [
+                "titulo" => $photoTitulo,
+                "descripcion" => $photoDescripcion,
+                "autor" => $photoAutor,
+                "imagenUrl" => $webPathToImage,
+                "originalFilename" => $originalFilename
+            ];
+            $metadataFilename = $targetDir . pathinfo($uniqueFilename, PATHINFO_FILENAME) . '.json';
+            if (file_put_contents($metadataFilename, json_encode($metadata, JSON_PRETTY_PRINT))) {
+                $response["success"] = true;
+                $response["message"] = "Fotografía subida con éxito.";
+                $response["filepath"] = $webPathToImage;
+            } else {
+                // If metadata creation fails, it's not ideal, but the image is uploaded.
+                // Optionally, delete the uploaded image if metadata is critical.
+                // For now, report success with a warning or handle as partial success.
+                $response["success"] = true; // Or false, depending on how critical metadata is
+                $response["message"] = "Fotografía subida, pero error al guardar metadatos.";
+                $response["filepath"] = $webPathToImage;
+                 // unlink($targetFilePath); // Optionally delete image
+            }
+        } else {
+            $response["message"] = "Error: No se pudo mover el archivo subido.";
+        }
+    } else {
+        $response["message"] = "Error: No se recibió ningún archivo.";
+    }
+} else {
+    $response["message"] = "Error: Método de solicitud no válido. Se esperaba POST.";
+}
+
+echo json_encode($response);
+?>

--- a/galeria/galeria_colaborativa.html
+++ b/galeria/galeria_colaborativa.html
@@ -30,7 +30,6 @@
                 <h2 class="section-title">Comparte tu Visión <i class="fas fa-camera-retro"></i></h2>
                 <p class="intro-paragraph" style="text-align:center; font-size: clamp(1em, 2.2vw, 1.15em); margin-bottom: 2em;">
                     ¿Has capturado la esencia del Condado de Castilla en una fotografía? ¿Un paisaje, un detalle arquitectónico, una escena cotidiana? ¡Súbela y forma parte de nuestra galería colectiva!
-                    <br><small>(Las subidas son para demostración y no se almacenan permanentemente en esta versión. Para una funcionalidad real, se requiere un backend que guarde las imágenes en `/imagenes/galeria_colaborativa/` o similar).</small>
                 </p>
 
                 <form id="uploadPhotoForm" class="upload-form-container"> <div class="form-group">
@@ -103,49 +102,32 @@
 
             // API_BASE_URL se deja vacía ("") si Nginx hace proxy para /api/galeria
             // O usa la URL completa de tu backend si es necesario para desarrollo.
-            const API_BASE_URL_GALERIA = ""; // Ejemplo: "http://localhost:5000" o ""
-            const UPLOAD_PATH_SIMULATED = "/imagenes/galeria_colaborativa/"; // Para simular dónde se guardarían
+            const API_BASE_URL_GALERIA = "/api/"; // Ejemplo: "http://localhost:5000" o ""
+            // const UPLOAD_PATH_SIMULATED = "/imagenes/galeria_colaborativa/"; // Para simular dónde se guardarían - REMOVED
 
             let galleryPhotos = []; 
 
-            function loadSamplePhotos() {
-                // IMPORTANTE: Reemplaza estas URLs con imágenes reales en tu carpeta /imagenes/galeria_colaborativa/
-                // o crea imágenes placeholder.
-                return [
-                    { id: 'sample_photo1', titulo: "Atardecer en el Alcázar (Ejemplo)", descripcion: "Vista del Alcázar de Cerezo bañado por la luz dorada del atardecer.", autor: "Fotógrafo Local", imagenUrl: "/assets/img/galeria_colaborativa/ejemplo_atardecer_alcazar.jpg", altText: "Atardecer sobre el Alcázar de Cerezo" },
-                    { id: 'sample_photo2', titulo: "Detalle Románico (Ejemplo)", descripcion: "Capitel historiado en la portada de una de las iglesias de la comarca.", autor: "Visitante Anónimo", imagenUrl: "/assets/img/galeria_colaborativa/ejemplo_detalle_romanico.jpg", altText: "Detalle de un capitel románico" },
-                    { id: 'sample_photo3', titulo: "Paisaje desde las Alturas (Ejemplo)", descripcion: "Panorámica de los campos de Castilla desde un mirador cercano a Lantarón.", autor: "Amante del Senderismo", imagenUrl: "/assets/img/galeria_colaborativa/ejemplo_paisaje_lantaron.jpg", altText: "Paisaje castellano desde las alturas" }
-                ];
-            }
-            
             async function fetchPhotos() {
-                // En una implementación real, esto haría fetch a tu endpoint GET /api/galeria/fotos
-                // Por ahora, simulamos o usamos ejemplos locales.
-                console.log("Intentando cargar fotos...");
-                if (API_BASE_URL_GALERIA && API_BASE_URL_GALERIA !== "") { // Si hay un backend configurado
-                    try {
-                        const url = `${API_BASE_URL_GALERIA}/api/galeria/fotos`; // Asume este endpoint
-                        const response = await fetch(url);
-                        if (!response.ok) {
-                            throw new Error(`Error HTTP: ${response.status}`);
-                        }
-                        galleryPhotos = await response.json();
-                        renderPhotoGallery(galleryPhotos);
-                    } catch (error) {
-                        console.error('Error al cargar fotos desde el backend:', error);
-                        galleryPhotos = loadSamplePhotos();
-                        renderPhotoGallery(galleryPhotos);
-                        if(noPhotosMsg) noPhotosMsg.innerHTML = `No se pudieron cargar las fotos del servidor. Mostrando ejemplos. <br><small>${error.message}</small>`;
+                console.log("Intentando cargar fotos desde el backend...");
+                try {
+                    const url = `${API_BASE_URL_GALERIA}galeria_list.php`;
+                    const response = await fetch(url);
+                    if (!response.ok) {
+                        throw new Error(`Error HTTP: ${response.status} - ${response.statusText}`);
                     }
-                } else {
-                    // Si no hay backend configurado, solo cargar ejemplos
-                    galleryPhotos = loadSamplePhotos();
+                    galleryPhotos = await response.json();
                     renderPhotoGallery(galleryPhotos);
-                    if(noPhotosMsg && galleryPhotos.length > 0) noPhotosMsg.textContent = 'Mostrando fotos de ejemplo. ¡Sube la tuya!';
+                } catch (error) {
+                    console.error('Error al cargar la galería:', error);
+                    if(noPhotosMsg) {
+                        noPhotosMsg.innerHTML = `Error al cargar la galería. Inténtalo más tarde. <br><small>${error.message}</small>`;
+                        noPhotosMsg.style.display = 'block'; // Asegurarse que el mensaje sea visible
+                    }
+                    galleryGrid.innerHTML = ''; // Limpiar por si había algo antes
                 }
             }
             
-            fetchPhotos();
+            fetchPhotos(); // Cargar fotos al iniciar
 
             if (photoFileInput) {
                 photoFileInput.addEventListener('change', function(event) {
@@ -195,44 +177,29 @@
                     formData.append('photoAutor', autor);
                     formData.append('photoFile', imagenFile); // Nombre del campo de archivo
 
-                    // SIMULACIÓN DE SUBIDA AL BACKEND
-                    if (API_BASE_URL_GALERIA && API_BASE_URL_GALERIA !== "") {
-                        try {
-                            const url = `${API_BASE_URL_GALERIA}/api/galeria/fotos`; // Asume este endpoint
-                            const response = await fetch(url, {
-                                method: 'POST',
-                                body: formData 
-                            });
+                    try {
+                        const response = await fetch(`${API_BASE_URL_GALERIA}galeria_upload.php`, {
+                            method: 'POST',
+                            body: formData
+                        });
 
-                            if (!response.ok) {
-                                const errorData = await response.json().catch(() => ({ error: `Error del servidor: ${response.status}` }));
-                                throw new Error(errorData.error || `Error del servidor: ${response.status}`);
-                            }
-                            const result = await response.json();
-                            alert(result.mensaje || '¡Fotografía subida con éxito!');
-                            fetchPhotos(); // Recargar la galería desde el backend
-                        } catch (error) {
-                            console.error('Error al subir la fotografía:', error);
-                            alert(`Error al subir la fotografía: ${error.message}.`);
+                        // Intentar parsear JSON incluso si !response.ok, ya que el backend debería enviar JSON de error
+                        const result = await response.json();
+
+                        if (!response.ok) {
+                            // Usar el mensaje del backend si está disponible, sino un error genérico.
+                            throw new Error(result.message || `Error del servidor: ${response.status}`);
                         }
-                    } else {
-                        // Simulación local si no hay backend
-                        const reader = new FileReader();
-                        reader.onloadend = function() {
-                            const nuevaFoto = {
-                                id: 'local_' + Date.now(), 
-                                titulo: titulo,
-                                descripcion: descripcion,
-                                autor: autor,
-                                imagenUrl: reader.result, // Data URL para visualización local
-                                altText: `Fotografía: ${titulo}`
-                            };
-                            galleryPhotos.unshift(nuevaFoto);
-                            renderPhotoGallery(galleryPhotos);
-                            alert('¡Fotografía añadida localmente (simulación)!');
-                        }
-                        reader.readAsDataURL(imagenFile);
+
+                        // Usar result.message del backend (era result.mensaje antes, corregido en PHP a message)
+                        alert(result.message || '¡Fotografía subida con éxito!');
+                        fetchPhotos(); // Recargar la galería desde el backend
+                    } catch (error) {
+                        console.error('Error al subir la fotografía:', error);
+                        // Mostrar el mensaje de error capturado, que puede ser del backend o un error de red/fetch.
+                        alert(`Error al subir la fotografía: ${error.message}.`);
                     }
+
                     uploadForm.reset();
                     if(photoPreview) photoPreview.src = '#';
                     if(photoPreviewContainer) photoPreviewContainer.style.display = 'none';
@@ -243,8 +210,12 @@
                 if (!galleryGrid || !noPhotosMsg) return;
                 galleryGrid.innerHTML = ''; 
                 if (!photosArray || photosArray.length === 0) {
-                    noPhotosMsg.style.display = 'block';
-                    noPhotosMsg.textContent = 'Aún no se han compartido fotografías. ¡Anímate a ser el primero!';
+                    // noPhotosMsg.style.display = 'block'; // El bloque catch de fetchPhotos ya maneja esto
+                    // noPhotosMsg.textContent = 'Aún no se han compartido fotografías. ¡Anímate a ser el primero!'; // Idem
+                    if (noPhotosMsg.style.display !== 'block') { // Si no hay un error ya mostrado
+                        noPhotosMsg.textContent = 'Aún no se han compartido fotografías. ¡Anímate a ser el primero!';
+                        noPhotosMsg.style.display = 'block';
+                    }
                     return;
                 }
                 noPhotosMsg.style.display = 'none';
@@ -256,20 +227,20 @@
                     const img = document.createElement('img');
                     // Si la imagenUrl es una ruta relativa del backend, Nginx la servirá.
                     // Si es una Data URL (subida local), se mostrará directamente.
-                    img.src = photo.imagenUrl; 
-                    img.alt = photo.altText || `Fotografía: ${photo.titulo}`;
+                    img.src = photo.imagenUrl; // Esto ya debería ser la URL correcta desde el backend
+                    img.alt = photo.altText || `Fotografía: ${photo.titulo || 'Sin título'}`;
                     img.onerror = function() { 
                         this.onerror=null; 
                         this.src='https://placehold.co/400x300/D2B48C/2c1d12?text=Foto+no+disponible';
-                        this.alt = `Error al cargar foto: ${photo.titulo}`;
+                        this.alt = `Error al cargar foto: ${photo.titulo || 'Sin título'}`;
                     };
-                    img.addEventListener('click', () => openModal(img.src, `${photo.titulo}${photo.autor !== 'Anónimo' && photo.autor ? ' - por ' + photo.autor : ''}`));
+                    img.addEventListener('click', () => openModal(img.src, `${photo.titulo || 'Sin título'}${photo.autor && photo.autor.toLowerCase() !== 'anónimo' ? ' - por ' + photo.autor : ''}`));
 
                     const captionDiv = document.createElement('div');
                     captionDiv.classList.add('photo-card-caption');
                     
                     const titleH4 = document.createElement('h4');
-                    titleH4.textContent = photo.titulo;
+                    titleH4.textContent = photo.titulo || 'Sin título'; // Backend debería proveer 'Sin título' si está vacío
                     captionDiv.appendChild(titleH4);
 
                     if (photo.descripcion) {


### PR DESCRIPTION
This commit introduces a PHP backend for the collaborative gallery (`galeria/galeria_colaborativa.html`), replacing the previous frontend-only simulation.

Key changes:
- Added `api/galeria_upload.php`: Handles image uploads, including validation (file type, size), unique filename generation, and saving the image to `uploads/museo_piezas/`. It also creates a corresponding JSON file in the same directory to store metadata (title, description, author, image URL).
- Added `api/galeria_list.php`: Scans the `uploads/museo_piezas/` directory for images and their associated JSON metadata files, returning a JSON list for display in the gallery.
- Modified `galeria/galeria_colaborativa.html`:
    - Updated JavaScript to use the new PHP endpoints for fetching and uploading photos.
    - Removed client-side simulation logic (sample photos, local array manipulation for uploads).
    - Removed HTML warnings about the gallery being a demonstration.

The gallery now allows you to upload images that are stored persistently on the server, and these uploaded images are displayed in the gallery.