### PR TITLE
feat: Populate Atapuerca page with detailed content

### DIFF
--- a/historia/atapuerca.html
+++ b/historia/atapuerca.html
@@ -5,19 +5,53 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Atapuerca</title>
     <link rel="stylesheet" href="../assets/css/estilos.css">
+    <link rel="stylesheet" href="/css/estilos_condado.css">  <!-- Added this line -->
 </head>
 <body>
-    <header>
-        <h1>Atapuerca</h1>
+    <header class="page-header hero" style="background-image: linear-gradient(rgba(0,0,0, 0.5), rgba(0,0,0, 0.5)), url('../assets/img/placeholder.jpg');"> <!-- Basic hero style -->
+        <div class="hero-content">
+            <h1>Los Yacimientos de la Sierra de Atapuerca</h1>
+        </div>
     </header>
     <main>
-        <section>
-            <h2>Descubrimientos en Atapuerca</h2>
-            <p>Contenido sobre los descubrimientos arqueológicos en Atapuerca...</p>
+        <section class="section alternate-bg">
+            <div class="container">
+                <h2 class="section-title">Un Tesoro de la Prehistoria</h2>
+                <p class="timeline-intro">
+                    La Sierra de Atapuerca, ubicada al norte de Ibeas de Juarros en la provincia de Burgos, es un enclave montañoso de modesta altitud que alberga un extraordinario conjunto de yacimientos arqueológicos y paleontológicos. Reconocida como Patrimonio de la Humanidad por la UNESCO, Espacio de Interés Natural y Bien de Interés Cultural, Atapuerca ha proporcionado al mundo testimonios fósiles de al menos cinco especies distintas de homínidos, arrojando luz invaluable sobre la evolución humana en Europa.
+                </p>
+
+                <article class="content-article"> <!-- Using a generic class for content styling -->
+                    <h3>Contexto Geográfico y Geológico</h3>
+                    <p>
+                        La sierra forma parte del "corredor de la Bureba", un paso histórico entre el valle del Ebro y la cuenca del Duero. Su formación se basa en calizas del Cretácico Superior (hace entre 80 y 100 millones de años). La acción fluvial y la naturaleza calcárea del terreno han originado un complejo sistema kárstico, con numerosas cuevas que, al colmatarse y sellarse, han preservado los restos durante milenios. La construcción de una línea de ferrocarril en el siglo XIX fue lo que inicialmente sacó a la luz estos importantes yacimientos.
+                    </p>
+
+                    <h3>Principales Yacimientos y Descubrimientos Clave</h3>
+                    <p>Entre la multitud de cuevas y simas, destacan varias por la trascendencia de sus hallazgos:</p>
+                    <ul>
+                        <li><strong>Sima del Elefante:</strong> Aquí se han encontrado restos de <em>Homo sp.</em> (probablemente una forma temprana de <em>Homo erectus</em>), con una antigüedad que ronda los 1.2 millones de años, representando algunos de los homínidos más antiguos de Europa.</li>
+                        <li><strong>Gran Dolina (Estrato TD6):</strong> Este yacimiento es famoso por el descubrimiento de <em>Homo antecessor</em>, una especie datada en al menos 800,000 años. Este hallazgo fue crucial para proponer una nueva especie de homínido, posiblemente ancestro común de neandertales y humanos modernos.</li>
+                        <li><strong>Sima de los Huesos:</strong> Un caso excepcional en el registro fósil mundial, esta sima ha proporcionado miles de fósiles pertenecientes a la especie <em>Homo heidelbergensis</em>. Entre ellos se encuentra el famoso Cráneo número 5, "Miguelón". Estos restos datan de hace unos 430,000 años y han permitido estudiar en detalle una población entera de homínidos.</li>
+                    </ul>
+                    <p>Además de estas especies, en Atapuerca también se ha documentado la presencia de <em>Homo neanderthalensis</em> y de nuestra propia especie, <em>Homo sapiens</em>, lo que demuestra una ocupación continuada del territorio a lo largo de la prehistoria.</p>
+
+                    <h3>Importancia Singular de Atapuerca</h3>
+                    <p>
+                        La Sierra de Atapuerca no es solo un conjunto de cuevas con fósiles; es una ventana directa a la vida de nuestros antepasados. La increíble concentración de restos en buen estado de conservación, abarcando un periodo tan extenso (desde el Pleistoceno Inferior hasta el Holoceno), la convierten en un referente mundial para el estudio de la evolución humana. Los hallazgos han permitido comprender mejor las estrategias de caza, la tecnología lítica, las características físicas e incluso posibles prácticas rituales de las distintas especies de homínidos que habitaron esta sierra.
+                    </p>
+                </article>
+            </div>
         </section>
     </main>
-    <footer>
-        <p>&copy; 2023 Tu Nombre o Nombre de la Organización</p>
+
+    <footer class="footer"> <!-- Copied footer style from historia.html -->
+        <div class="container">
+            <p>© <script>document.write(new Date().getFullYear());</script> CondadoDeCastilla.com - Todos los derechos reservados.</p>
+            <p>Un proyecto para la difusión del patrimonio histórico de Cerezo de Río Tirón y el Alfoz de Cerasio y Lantarón.</p>
+            <!-- Social links can be added if needed, like in historia.html -->
+        </div>
     </footer>
+    <script src="/js/layout.js"></script> <!-- Assuming layout.js might be needed -->
 </body>
 </html>


### PR DESCRIPTION
Updates the `historia/atapuerca.html` page with detailed information about the Sierra de Atapuerca archaeological sites.

The content includes:
- An introduction to the importance of Atapuerca.
- Geographical and geological context.
- Descriptions of key sites: Sima del Elefante, Gran Dolina, and Sima de los Huesos.
- Information on hominid species found (Homo sp., Homo antecessor, Homo heidelbergensis, etc.).
- Discussion of the site's significance for understanding human evolution.

The page structure uses semantic HTML and aims to align with existing site styles. This replaces the previous version of the page that had placeholder content.