### PR TITLE
Fix: Ensure sidebar menu links are visible on mobile

### DIFF
--- a/assets/css/estilos.css
+++ b/assets/css/estilos.css
@@ -1852,12 +1852,25 @@ body.sidebar-active {
         display: none !important; /* Force hide old navbar elements */
     }
 
+    #sidebar .nav-links {
+        max-height: none;
+        overflow: visible;
+        /* Optionally, you can be more explicit if other flex properties from the generic .nav-links rule were problematic:
+        position: static; /* Or relative, depending on desired layout, but not absolute like the old one */
+        /* background-color: transparent; /* If it was inheriting a background */
+        /* box-shadow: none; /* If it was inheriting a shadow */
+        /* padding: 0; /* Reset padding if necessary */
+        /* width: 100%; /* Already set in the base #sidebar .nav-links but good to ensure */
+        /* display: flex; /* Already set */
+        /* flex-direction: column; /* Already set */
+    }
+
     /* Explicit styles for sidebar links on mobile to ensure visibility and clickability */
     #sidebar .nav-links a {
-        color: var(--color-piedra-clara) !important; /* Ensure text color */
-        opacity: 1 !important; /* Ensure not transparent */
-        visibility: visible !important; /* Ensure visible */
-        pointer-events: auto !important; /* Ensure clickable */
+        color: var(--color-piedra-clara); /* Ensure text color */
+        opacity: 1; /* Ensure not transparent */
+        visibility: visible; /* Ensure visible */
+        pointer-events: auto; /* Ensure clickable */
         /* Font size, padding, display:block are already set and should be fine */
     }
 }


### PR DESCRIPTION
The CSS rule for the generic '.nav-links' class, intended for the old top navigation bar, was inadvertently causing the link container ('.nav-links') within the new sidebar menu ('#sidebar') to be hidden on mobile devices (max-height: 0, overflow: hidden).

This commit introduces a specific rule for '#sidebar .nav-links' within the mobile media query (@media (max-width: 768px)) to override these properties, ensuring the link container has 'max-height: none' and 'overflow: visible'.

Additionally, the '!important' directives were removed from the '#sidebar .nav-links a' styles within the same media query as they are no longer necessary once the container is correctly displayed.