### PR TITLE
Fix: Center hero escudo image and correct CSS setup

### DIFF
--- a/assets/css/estilos.css
+++ b/assets/css/estilos.css
@@ -23,6 +23,11 @@
     --color-fondo-pagina-rgb: 253, 250, 246; 
     --color-error: #d9534f; 
     --color-success: #5cb85c;
+    --color-piedra-arena-rgb: 200, 187, 174;
+    --color-morado-emperador-rgb: 74, 13, 103; /* Based on --color-primario-purpura-rgb */
+    --color-piedra-clara-rgb: 234, 224, 208;
+    --color-fondo-pagina-base-rgb: 253, 250, 246; /* Based on --color-fondo-pagina */
+    --color-piedra-media-rgb: 210, 180, 140;
 
 
     --font-principal: 'Lora', serif;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
-    <link rel="stylesheet" href="/css/estilos_condado.css">
+    <link rel="stylesheet" href="/assets/css/estilos.css">
 
 </head>
 <body>
@@ -49,7 +49,7 @@
             <div class="container">
                 <h2>Recuperando la Memoria de la Hispanidad Castellana</h2>
                 <p>Un profundo análisis de nuestras raíces culturales, la importancia de la arqueología y el legado de la Civitate Auca Patricia. Descubre cómo el pasado de Cerezo de Río Tirón es fundamental para entender la Hispanidad.</p>
-                <p style="text-align:center; margin-top: 2.5em;">
+                <p style="margin-top: 2.5em;">
                     <a href="/secciones_index/memoria_hispanidad.html" class="cta-button">Leer Más Sobre Nuestra Memoria</a>
                 </p>
             </div>
@@ -116,7 +116,7 @@
                         </div>
                     </div>
                 </div>
-                 <p style="text-align:center; margin-top: 2.5em;">
+                 <p style="margin-top: 2.5em;">
                     <a href="/personajes/indice_personajes.html" class="cta-button">Personajes</a>
                 </p>
             </div>
@@ -126,7 +126,7 @@
             <div class="container">
                 <h2 class="section-title">Nuestra Historia en el Tiempo</h2>
                 <p class="timeline-intro">Un recorrido conciso por los momentos más determinantes de nuestra región, desde la prehistoria hasta la consolidación del Condado. Cada época ha dejado una huella imborrable.</p>
-                <p style="text-align:center; margin-top: 2.5em;">
+                <p style="margin-top: 2.5em;">
                     <a href="/secciones_index/historia_tiempo_resumen.html" class="cta-button">Explorar Resumen de la Historia</a>
                 </p>
             </div>


### PR DESCRIPTION
The main hero image 'escudo.jpg' on the index page was reported as not being centered.

This was resolved by:
1. Correcting the stylesheet link in `index.html` to point to the correct `assets/css/estilos.css` instead of a non-existent file. This ensured that the global image centering styles (`display: block; margin-left: auto; margin-right: auto;`) were properly applied to the hero image.
2. Adding missing CSS color variable definitions (`--color-piedra-arena-rgb`, `--color-morado-emperador-rgb`) to `:root` in `assets/css/estilos.css` based on their fallback usage, improving CSS integrity.
3. Removing redundant inline `text-align:center;` styles from `<p>` tags in `index.html` as global styles already cover this.

The `hero-escudo` image is now confirmed to be centered due to the global image styles. Other images on the page were checked and are unaffected, rendering as per their specific styles.