### PR TITLE
feat: Add WhatsApp link to footer

### DIFF
--- a/_footer.html
+++ b/_footer.html
@@ -6,6 +6,7 @@
             <a href="https://www.facebook.com/groups/1052427398664069" aria-label="Facebook" title="Síguenos en Facebook"><i class="fab fa-facebook-f"></i></a>
             <a aria-label="Instagram" title="Síguenos en Instagram (Próximamente)"><i class="fab fa-instagram"></i></a>
             <a aria-label="Twitter" title="Síguenos en Twitter (Próximamente)"><i class="fab fa-twitter"></i></a>
+            <a href="https://chat.whatsapp.com/JWJ6mWXPuekIBZ8HJSSsZx" target="_blank" rel="noopener noreferrer" aria-label="WhatsApp" title="Únete a nuestro grupo de WhatsApp"><i class="fab fa-whatsapp"></i></a>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
Added a WhatsApp link to the website footer.
The link points to the WhatsApp group already present in the header menu. This improves accessibility to the community group.