### PR TITLE
feat: Add history for Alfoz towns starting with A

### DIFF
--- a/lugares/alfozcerezolantaron/Alcedo/index.html
+++ b/lugares/alfozcerezolantaron/Alcedo/index.html
@@ -7,9 +7,11 @@
 </head>
 <body>
   <div id="header-placeholder"></div>
-  <div id="header-placeholder"></div>
   <h1>Alcedo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Alcedo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+  <p>Perteneciente al <a href="/alfoz/alfoz.html">Alfoz de Cerasio y Lantarón</a>. Perteneció al reino de Navarra, hasta su apropiación por Alfonso de Castilla en el año 1200. Del castillo del lugar, enclavado en otros tiempos en la proximidad occidental del pueblo, sólo quedan ruinas.</p>
+  <p>Antiguamente tuvo dos torres, una de ellas correspondiente a la defensa del antiguo condado de Lantarón, de las cuales hoy en día sólo constan algunas ruinas.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Ameyugo/index.html
+++ b/lugares/alfozcerezolantaron/Ameyugo/index.html
@@ -9,6 +9,9 @@
   <div id="header-placeholder"></div>
   <h1>Ameyugo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Ameyugo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+  <p>Perteneciente al <a href="/alfoz/alfoz.html">Alfoz de Cerasio y Lantarón</a>. Villa en la Cuadrilla de Quintanilla de San García, una de las siete en que se dividía la Merindad de Bureba perteneciente al partido de Bureba. Jurisdicción de realengo con regidor pedáneo.</p>
+  <p>A la caída del Antiguo Régimen queda constituida en ayuntamiento constitucional del mismo nombre, en el partido de Miranda de Ebro en la región de Castilla la Vieja.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>


### PR DESCRIPTION
I searched for and added historical information to the HTML pages for towns in the Alfoz de Cerasio y Lantarón that start with the letter 'A'.

Specifically, I updated:
- Alcedo: Added historical details from Wikipedia, including its link to the Condado de Lantarón. Corrected a duplicated header placeholder.
- Ameyugo: Added historical details from Wikipedia regarding its place in Bureba and Castilla la Vieja.

Both pages now include the introductory sentence "Perteneciente al Alfoz de Cerasio y Lantarón" and a link to the main Alfoz page (/alfoz/alfoz.html).