### PR TITLE
feat: Add document and gallery sections to 'historia'

### DIFF
--- a/historia/documentos/archivos/.gitkeep
+++ b/historia/documentos/archivos/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It is used to ensure that this directory is tracked by git.

--- a/historia/documentos/index.html
+++ b/historia/documentos/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Documentos Históricos - Condado de Castilla</title>
+    <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+    <!-- Add any other common head elements if observed in other main html files -->
+</head>
+<body>
+
+    <!-- Content of _header.html will be dynamically inserted here by the main layout script -->
+    <div id="header-placeholder"></div>
+
+    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_historia_background.jpg');">
+        <div class="hero-content">
+            <h1>Documentos Históricos</h1>
+            <p>Una colección de documentos, manuscritos y archivos relacionados con la historia del Condado de Castilla y Cerezo de Río Tirón.</p>
+        </div>
+    </header>
+
+    <main>
+        <section class="section alternate-bg">
+            <div class="container">
+                <h2 class="section-title">Archivos y Manuscritos</h2>
+                <p>Esta sección alberga diversos documentos históricos disponibles para consulta. Los archivos pueden incluir PDFs, documentos de texto, e imágenes de manuscritos originales.</p>
+
+                <div class="document-list">
+                    <!-- Example of how a document might be listed. Repeat for each document. -->
+                    <!-- This will be dynamically populated or manually updated later. -->
+                    <div class="document-item">
+                        <h3>Ejemplo de Título de Documento</h3>
+                        <p>Breve descripción del documento. Puede incluir información sobre su origen, fecha, y relevancia histórica. Por ejemplo, podría ser una transcripción de un fuero antiguo, un mapa histórico escaneado, o un estudio detallado sobre un aspecto particular de la historia local.</p>
+                        <a href="/historia/documentos/archivos/ejemplo_documento.pdf" target="_blank" class="read-more">Ver Documento (PDF)</a>
+                    </div>
+
+                    <div class="document-item">
+                        <h3>Otro Documento Histórico (Ejemplo)</h3>
+                        <p>Descripción de este segundo archivo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+                        <a href="/historia/documentos/archivos/ejemplo_otro_documento.txt" target="_blank" class="read-more">Leer Texto (TXT)</a>
+                    </div>
+
+                    <p style="margin-top: 30px;"><em>Actualmente, esta es una lista de ejemplos. Se añadirán más documentos próximamente.</em></p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Content of _footer.html will be dynamically inserted here by the main layout script -->
+    <div id="footer-placeholder"></div>
+
+    <script src="/js/layout.js"></script>
+</body>
+</html>

--- a/historia/galeria_historica/imagenes/.gitkeep
+++ b/historia/galeria_historica/imagenes/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It is used to ensure that this directory is tracked by git.

--- a/historia/galeria_historica/index.html
+++ b/historia/galeria_historica/index.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Galería Histórica - Condado de Castilla</title>
+    <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+    <style>
+        /* Basic gallery styling */
+        .gallery-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 20px; /* Space between items */
+            justify-content: center;
+            padding: 20px;
+        }
+        .gallery-item {
+            background-color: #fff; /* White background for items */
+            border: 1px solid #ddd; /* Light grey border */
+            border-radius: 8px; /* Rounded corners */
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1); /* Subtle shadow */
+            width: calc(33.333% - 40px); /* Adjust for 3 items per row, considering gap */
+            margin-bottom: 20px;
+            overflow: hidden; /* Ensures content fits rounded corners */
+            text-align: center;
+        }
+        .gallery-item img, .gallery-item .file-placeholder {
+            width: 100%;
+            height: 200px; /* Fixed height for image/placeholder area */
+            object-fit: cover; /* Cover ensures image fills space, might crop */
+            border-bottom: 1px solid #ddd;
+        }
+        .gallery-item .file-placeholder {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: #f0f0f0; /* Light background for placeholder */
+            font-size: 3em; /* Larger icon */
+            color: #aaa; /* Grey icon color */
+        }
+        .gallery-item-description {
+            padding: 15px;
+            text-align: left;
+        }
+        .gallery-item-description h3 {
+            margin-top: 0;
+            color: var(--color-primario-purpura);
+        }
+        .gallery-item-description p {
+            font-size: 0.9em;
+            color: #333; /* Darker grey for text */
+            margin-bottom: 10px;
+        }
+        .gallery-item-description a {
+            font-size: 0.9em;
+            color: var(--color-secundario-dorado);
+        }
+
+        /* Responsive adjustments */
+        @media (max-width: 992px) {
+            .gallery-item {
+                width: calc(50% - 30px); /* 2 items per row */
+            }
+        }
+        @media (max-width: 768px) {
+            .gallery-item {
+                width: calc(100% - 20px); /* 1 item per row */
+            }
+        }
+    </style>
+</head>
+<body>
+
+    <div id="header-placeholder"></div>
+
+    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_historia_background.jpg');">
+        <div class="hero-content">
+            <h1>Galería Histórica</h1>
+            <p>Imágenes, documentos y artefactos visuales que narran la rica historia del Condado de Castilla y sus gentes.</p>
+        </div>
+    </header>
+
+    <main>
+        <section class="section">
+            <div class="container">
+                <h2 class="section-title">Tesoros Visuales de Nuestra Historia</h2>
+                <p>Explora nuestra colección de imágenes históricas, fotografías de artefactos, mapas antiguos y representaciones de momentos clave. Cada elemento cuenta con una descripción para contextualizar su importancia.</p>
+
+                <div class="gallery-container">
+                    <!-- Example Gallery Item 1: Image -->
+                    <div class="gallery-item">
+                        <img src="/assets/img/galeria_colaborativa/ejemplo_atardecer_alcazar.jpg" alt="Ejemplo de Imagen Histórica 1">
+                        <div class="gallery-item-description">
+                            <h3>Atardecer en el Alcázar</h3>
+                            <p>Una vista evocadora del Alcázar de Cerasio al atardecer. Esta fortaleza fue crucial en la defensa y consolidación temprana de Castilla.</p>
+                        </div>
+                    </div>
+
+                    <!-- Example Gallery Item 2: PDF Document -->
+                    <div class="gallery-item">
+                        <div class="file-placeholder">
+                            <i class="far fa-file-pdf"></i> <!-- Font Awesome PDF icon -->
+                        </div>
+                        <div class="gallery-item-description">
+                            <h3>Fuero Antiguo (Fragmento)</h3>
+                            <p>Visualización de un fragmento del fuero concedido a Cerezo en la Edad Media, un documento vital para entender la organización social y legal de la época.</p>
+                            <a href="/historia/galeria_historica/imagenes/ejemplo_fuero.pdf" target="_blank">Ver PDF</a>
+                        </div>
+                    </div>
+
+                    <!-- Example Gallery Item 3: TXT Document -->
+                    <div class="gallery-item">
+                        <div class="file-placeholder">
+                            <i class="far fa-file-alt"></i> <!-- Font Awesome Text File icon -->
+                        </div>
+                        <div class="gallery-item-description">
+                            <h3>Crónica Local (Extracto)</h3>
+                            <p>Extracto de una crónica local que narra eventos significativos del siglo X. Los archivos de texto permiten una fácil lectura y búsqueda.</p>
+                            <a href="/historia/galeria_historica/imagenes/ejemplo_cronica.txt" target="_blank">Leer TXT</a>
+                        </div>
+                    </div>
+
+                    <!-- Example Gallery Item 4: DOC Document -->
+                    <div class="gallery-item">
+                        <div class="file-placeholder">
+                           <i class="far fa-file-word"></i> <!-- Font Awesome Word File icon -->
+                        </div>
+                        <div class="gallery-item-description">
+                            <h3>Estudio Histórico sobre Auca</h3>
+                            <p>Un documento de investigación sobre la importancia de Auca Patricia y su relación con el origen de Castilla, basado en las reflexiones de nuevo4.md.</p>
+                            <a href="/historia/galeria_historica/imagenes/estudio_auca.doc" target="_blank">Abrir DOC</a>
+                        </div>
+                    </div>
+                     <div class="gallery-item">
+                        <img src="/assets/img/Llana.jpg" alt="Iglesia de la Llana">
+                        <div class="gallery-item-description">
+                            <h3>Iglesia de la Llana</h3>
+                            <p>Fotografía de la Iglesia de la Llana, un importante hito arquitectónico y espiritual en la región, con posibles orígenes en una mezquita.</p>
+                        </div>
+                    </div>
+                     <div class="gallery-item">
+                        <img src="/assets/img/Muralla.jpg" alt="Restos de Muralla">
+                        <div class="gallery-item-description">
+                            <h3>Restos de Muralla</h3>
+                            <p>Vestigios de las antiguas murallas que protegían asentamientos clave en el Condado de Castilla, testigos de un pasado defensivo.</p>
+                        </div>
+                    </div>
+                </div>
+                <p style="text-align:center; margin-top: 30px;"><em>Esta galería se irá enriqueciendo con más elementos visuales y documentales. Se recomienda usar Font Awesome para los iconos de archivo (PDF, TXT, DOC), por lo que el CSS de la página principal o _header.html debería incluir la biblioteca.</em></p>
+            </div>
+        </section>
+    </main>
+
+    <div id="footer-placeholder"></div>
+
+    <script src="/js/layout.js"></script>
+    <!-- Consider adding a link to Font Awesome if not already included globally, e.g., in _header.html or main CSS -->
+    <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"> -->
+</body>
+</html>

--- a/historia/historia.html
+++ b/historia/historia.html
@@ -106,6 +106,26 @@
                     </li>
                     <li class="timeline-item">
                         <div class="timeline-icon">
+                            <img src="/assets/img/estrellaGordita.png" alt="Hito en la línea de tiempo: Documentos Históricos">
+                        </div>
+                        <div class="timeline-content">
+                            <h3>Documentos Históricos del Condado</h3>
+                            <p>Accede a una colección de documentos, manuscritos y archivos relevantes para la investigación y comprensión de la historia de Cerezo de Río Tirón y el Condado de Castilla. Incluye PDFs, textos y otros formatos.</p>
+                            <a href="/historia/documentos/index.html" class="read-more timeline-read-more">Explorar Documentos</a>
+                        </div>
+                    </li>
+                    <li class="timeline-item">
+                        <div class="timeline-icon">
+                            <img src="/assets/img/estrellaGordita.png" alt="Hito en la línea de tiempo: Galería Histórica">
+                        </div>
+                        <div class="timeline-content">
+                            <h3>Galería Visual de la Historia</h3>
+                            <p>Descubre imágenes, mapas antiguos, fotografías de artefactos y otras representaciones visuales que ilustran la rica herencia histórica de nuestra región. Cada elemento incluye una descripción detallada.</p>
+                            <a href="/historia/galeria_historica/index.html" class="read-more timeline-read-more">Visitar Galería</a>
+                        </div>
+                    </li>
+                    <li class="timeline-item">
+                        <div class="timeline-icon">
                              <img src="/assets/img/estrella.png" alt="Hito en la línea de tiempo: Plena y Baja Edad Media">
                         </div>
                         <div class="timeline-content">


### PR DESCRIPTION
Adds new directory structures and HTML pages for displaying historical documents and a visual gallery within the 'historia' section of the website.

- Created `historia/documentos/` with an `index.html` for listing various file types (PDF, DOC, TXT, images) with descriptions. Includes `historia/documentos/archivos/` for storing these files.
- Created `historia/galeria_historica/` with an `index.html` for displaying images and document thumbnails in a gallery format, each with a description. Includes `historia/galeria_historica/imagenes/` for file storage.
- Both new index pages include standard site header/footer placeholders and are styled with `epic_theme.css`. The gallery page includes basic inline responsive CSS.
- Updated `historia/historia.html` to include links in the timeline to these new 'documentos' and 'galeria_historica' sections.
- The design of these new sections is suitable for hosting content similar to that found in `contexto/nuevo4.md`, as per the issue requirements.