### PR TITLE
feat: Add section to Camino page about visiting Cerezo

### DIFF
--- a/camino_santiago/camino_santiago.html
+++ b/camino_santiago/camino_santiago.html
@@ -64,6 +64,23 @@
                     </div>
                 </div>
 
+                <h2 class="section-title">Visitando Cerezo desde el Camino Francés Actual</h2>
+                <div class="camino-content-block">
+                    <div class="camino-text">
+                        <p>Si bien el trazado principal del Camino de Santiago Francés discurre actualmente más al sur, pasando por localidades emblemáticas como Santo Domingo de la Calzada o Belorado, el legado histórico de Cerezo de Río Tirón sigue siendo un poderoso atractivo para el peregrino interesado en las raíces profundas de la ruta jacobea.</p>
+                        <p>Desde <strong>Belorado</strong>, y también accesible desde <strong>Santo Domingo de la Calzada</strong>, los peregrinos pueden organizar una visita a Cerezo para explorar los vestigios de la calzada romana, conocer la historia del Hospital de San Jorge y sumergirse en un pasado donde nuestra villa fue protagonista del Camino Primitivo. Considera dedicar una jornada o unas horas para descubrir este tesoro histórico, accesible mediante un corto trayecto por carretera.</p>
+                        <p>Esta escapada te permitirá conectar con una perspectiva diferente del Camino, enriqueciendo tu peregrinación con la visita a uno de los enclaves que custodiaron la fe y el paso de los primeros caminantes hacia Santiago.</p>
+                    </div>
+                    <div class="camino-image">
+                        <img src="/assets/img/AlfozCerasioLantaron.jpg" alt="Paisaje en la región de Cerezo de Río Tirón">
+                        <p class="image-caption"><i class="fas fa-route"></i> Descubre Cerezo, un desvío histórico desde el Camino.</p>
+                    </div>
+                </div>
+                <div class="camino-cta-block">
+                    <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-cta">
+                    <p>Planifica tu desvío para conocer la rica historia jacobea de Cerezo de Río Tirón.</p>
+                    <a href="/visitas/visitas.html" class="cta-button">Información para Visitar Cerezo</a>
+                </div>
                 <div class="camino-cta-block">
                     <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-cta">
                     <p>Te invitamos a recorrer los senderos que una vez hollaron los peregrinos y a descubrir los vestigios de esta importante etapa jacobea en Cerezo de Río Tirón.</p>


### PR DESCRIPTION
This commit introduces a new section to the `camino_santiago/camino_santiago.html` page.

The new section aims to inform pilgrims on the modern Camino Francés (specifically those passing through Belorado or Santo Domingo de la Calzada) about the possibility and historical value of visiting Cerezo de Río Tirón as a detour.

The content:
- Acknowledges the current Camino Francés route.
- Suggests Cerezo as a side trip from Belorado and Santo Domingo de la Calzada.
- Highlights the historical significance of Cerezo in the context of the primitive Camino.
- Includes a call to action linking to the existing visits page.
- Follows the existing page structure and styling for consistency.