### PR TITLE
feat: Add further ruins and details from nuevo4.md

### DIFF
--- a/ruinas/edificaciones_civiles_publicas/circo_romano.html
+++ b/ruinas/edificaciones_civiles_publicas/circo_romano.html
@@ -36,6 +36,9 @@
                 <p>Las fuentes antiguas, incluyendo la historia de San Formerio, mencionan un circo romano en la Vega de los Tormentos (posiblemente en la actual Quintanilleja), datado en tiempos del emperador Aureliano (circa 277 d.C.). Este circo habría contado con leones y estaba asociado a un gobernador romano, lo que sugiere la importancia administrativa de Auca Patricia.</p>
                 <p>Las ruinas encontradas en esta área parecen corresponder a las dimensiones de un circo, con una espina central de aproximadamente 160 metros de largo por 8 metros de ancho. Se describe que esta espina pudo haber tenido agua en su interior y un diseño angular para la salida de las cuadrigas desde las <em>carceres</em> (puertas de salida).</p>
                 <p>Este circo también se asocia con eventos martiriales, como la decapitación de San Vitores, que según la tradición ocurrió cerca del circo el 26 de Agosto. Se menciona la existencia de un mausoleo romano con un "circo ritual" en el lugar de la decapitación, comparándolo con el circo de Majencio. Del obelisco que pudo haber adornado la espina del circo, aparentemente solo queda la parte inferior en Quintanilleja.</p>
+
+                <h3>Iglesia de Santi Emiliani y Sacralización del Lugar</h3>
+                <p>En directa relación con el Circo Romano, en el valle de Asur (cerca del Pedroso), se encontraba la Iglesia de Santi Emiliani. Se postula que esta iglesia fue construida para sacralizar el lugar de los tormentos a los mártires cristianos que, según la tradición, ocurrieron en el circo. La presencia de esta iglesia subraya la memoria histórica y la transformación religiosa del sitio a lo largo del tiempo.</p>
                 <!-- Contenido específico sobre el Circo Romano de Auca Patricia se añadirá aquí -->
             </div>
         </section>

--- a/ruinas/estructuras_defensivas/alcazar_cerasio.html
+++ b/ruinas/estructuras_defensivas/alcazar_cerasio.html
@@ -37,6 +37,10 @@
                 <p>Su origen se sitúa en el siglo VIII, construido por el Conde Casio, posiblemente entre los años 720-730 d.C. Se menciona que fue edificado con los escombros y yeso de la ciudad romana de Auca Patricia. Pasó a manos cristianas alrededor del año 840.</p>
                 <p>Se localiza donde hoy está la Iglesia de Villalba, con su pueblo amurallado debajo. Aún se pueden observar elementos como el "gajo de naranja" de su Alcazaba y los fosos del río Vallúm. La fortaleza contaba con múltiples niveles de murallas excavadas en la roca y varios castillos o torres adicionales que lo rodeaban.</p>
                 <p>Desde este alcázar gobernaron los primeros Condes de Castilla y Álava, como Rodrigo I, Diego Rodríguez Porcelos, Fernando Díaz, Gonzalo Téllez y Álvaro Herraméliz.</p>
+
+                <h3>Construcción en Alabastro y Defensas</h3>
+                <p>Un rasgo distintivo del Alcázar de Cerasio es su construcción con "alabastro puro", material que también caracteriza al pueblo de Cerezo, descrito como un "pueblo alba". Las piedras de alabastro, originalmente pulidas, revestían las edificaciones, similar a lo observado en otras ciudades romanas como Bílbilis o Zaragoza. El texto de <em>nuevo4.md</em> lamenta que estas piedras milenarias no hayan sido lavadas o pulidas para mostrar su esplendor original, y sugiere que el alabastro de Cerezo, aunque no de calidad para estatuas, es excelente para embellecer la localidad.</p>
+                <p>El sistema defensivo del Alcázar era complejo, incluyendo el "Paseo de la Carcaba" (término que alude a un foso de campamento o ciudad romana), que formaba parte de su perímetro defensivo. La fortaleza contaba con múltiples fosos, algunos con agua y porcino, y puentes levadizos.</p>
                 <!-- Contenido específico sobre el Alcázar de Cerasio se añadirá aquí -->
             </div>
         </section>

--- a/ruinas/estructuras_defensivas/murallas_auca.html
+++ b/ruinas/estructuras_defensivas/murallas_auca.html
@@ -36,6 +36,9 @@
                 <p>Auca Patricia, la extensa ciudad romana en Cerezo de Río Tirón, estuvo defendida por un imponente sistema de murallas. Se describen con un considerable espesor de 6 metros, construidas en hormigón romano, y que llegaban a circundar un área de hasta 144 hectáreas.</p>
                 <p>Parte de estas defensas estaban incluso talladas directamente en la roca de la montaña, aprovechando la topografía para reforzar su inexpugnabilidad. Se mencionan kilómetros de estas murallas, con vestigios aún visibles, por ejemplo, debajo de la Casa de Mogollón.</p>
                 <p>Las puertas de la ciudad estaban integradas en este sistema defensivo y su tamaño, posición y orientación parecen coincidir con el trazado del "decumanus" (eje principal Este-Oeste) de Auca Patricia.</p>
+
+                <h3>El Paseo de la Carcaba</h3>
+                <p>Un elemento destacado del sistema defensivo y la planificación urbana de Auca Patricia es el "Paseo de la Carcaba". Este término hace referencia al foso que circundaba la ciudad romana. Aunque hoy en día no siempre es visible superficialmente, excavaciones leves podrían revelar su trazado y las murallas de hormigón asociadas. El texto menciona que al final de la ciudad, en el plano de calles, se observa este paseo, así como la "Glera de los Cellox" (puerto fluvial), indicando una planificación integrada.</p>
                 <!-- Contenido específico sobre las Murallas de Auca Patricia se añadirá aquí -->
             </div>
         </section>

--- a/ruinas/estructuras_defensivas/otros_campamentos_romanos.html
+++ b/ruinas/estructuras_defensivas/otros_campamentos_romanos.html
@@ -33,6 +33,9 @@
         <section class="section">
             <div class="container">
                 <p>Información sobre otros campamentos romanos en el área del Condado de Castilla, como los de Oxmilla, Maza, y otros posibles emplazamientos militares.</p>
+
+                <h3>Campamento de Legión en Oxmilla</h3>
+                <p>Además del campamento de La Tejera, <em>nuevo4.md</em> menciona "Oxmilla, opidum romano de Campamento de Legion con tienda de campaña". Este campamento se situaba a unos 800 metros del campamento auxiliar de San Martín (posiblemente relacionado con la Episcopi de San Martín). Se describe como un campamento de legión con tiendas de campaña, típico de las avanzadillas o establecimientos temporales romanos.</p>
                 <!-- Contenido específico sobre estos campamentos se añadirá aquí -->
             </div>
         </section>

--- a/ruinas/estructuras_funerarias_religiosas/iglesia_la_llana_mezquita_yanna.html
+++ b/ruinas/estructuras_funerarias_religiosas/iglesia_la_llana_mezquita_yanna.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Iglesia de la Llana (Antigua Mezquita de Yanna) - Ruinas del Condado de Castilla</title>
+    <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+</head>
+<body>
+    <div id="header-placeholder"></div>
+    <header class="page-header"><div class="container"><h1>Iglesia de la Llana (Antigua Mezquita de Yanna)</h1></div></header>
+    <nav aria-label="breadcrumb" class="container breadcrumb-nav">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Inicio</a></li>
+        <li class="breadcrumb-item"><a href="/ruinas/index.html">Ruinas</a></li>
+        <li class="breadcrumb-item"><a href="/ruinas/estructuras_funerarias_religiosas/index.html">Estructuras Funerarias y Religiosas</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Iglesia de la Llana (Antigua Mezquita de Yanna)</li>
+      </ol>
+    </nav>
+    <main><section class="section"><div class="container">
+        <p>La actual Iglesia de la Llana en Cerezo de Río Tirón tiene un origen singular, vinculada al Alcázar de Cerasio y a la figura del Conde Casio. Según se extrae de 'nuevo4.md', en el Alcázar se encontraba la "Mezquita de Yanna", atribuida al hijo del Conde Casio.</p>
+        <p>Posteriormente, esta estructura evolucionó o fue reemplazada por la actual iglesia. El texto indica: "...la mezquita de Yanna en el alto, hoy la iglesia de la llana." Esto la sitúa en una posición elevada, probablemente dentro del complejo defensivo del alcázar.</p>
+        <p>Se menciona también un "Capitel de la Iglesia de la LLana, Cerezo de Río Tirón" como un elemento de interés fotográfico, sugiriendo la existencia de restos escultóricos o arquitectónicos relevantes de sus fases anteriores.</p>
+    </div></section></main>
+    <div id="footer-placeholder"></div><script src="/js/layout.js"></script>
+</body></html>

--- a/ruinas/estructuras_funerarias_religiosas/index.html
+++ b/ruinas/estructuras_funerarias_religiosas/index.html
@@ -22,6 +22,7 @@
             <li><a href="mausoleo_circo_auca.html">Mausoleo del Circo de Auca Patricia</a></li>
             <li><a href="mausoleo_magno_clemente_maximo.html">Mausoleo Imperial de Magno Clemente Máximo</a></li>
             <li><a href="mausoleo_san_nicolas.html">Mausoleo Imperial de San Nicolás</a></li>
+            <li><a href="iglesia_la_llana_mezquita_yanna.html">Iglesia de la Llana (Antigua Mezquita de Yanna)</a></li>
         </ul>
     </div></section></main>
     <div id="footer-placeholder"></div><script src="/js/layout.js"></script>

--- a/ruinas/hallazgos_representaciones/cuevas_setefenestras.html
+++ b/ruinas/hallazgos_representaciones/cuevas_setefenestras.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cuevas de Setefenestras - Ruinas del Condado de Castilla</title>
+    <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+</head>
+<body>
+    <div id="header-placeholder"></div>
+    <header class="page-header"><div class="container"><h1>Cuevas de Setefenestras (Quintanilleja)</h1></div></header>
+    <nav aria-label="breadcrumb" class="container breadcrumb-nav">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Inicio</a></li>
+        <li class="breadcrumb-item"><a href="/ruinas/index.html">Ruinas</a></li>
+        <li class="breadcrumb-item"><a href="/ruinas/hallazgos_representaciones/index.html">Hallazgos y Representaciones</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Cuevas de Setefenestras</li>
+      </ol>
+    </nav>
+    <main><section class="section"><div class="container">
+        <p>Las "Milenarias y olvidadas cuevas de Setefenestras", situadas en la zona de Quintanilleja o Quintanilla de las Dueñas, son un enclave de gran importancia histórica y cultural. Se las considera una "cuna del idioma castellano" por los posibles escritos o grafitis antiguos que podrían albergar en sus paredes, tapados por "polvo milenario".</p>
+        <p>Una característica distintiva de estas cuevas es el uso de "Lapis Specularis" (yeso selenítico traslúcido) en sus paredes y techos. Este material, más caro que el oro en la antigüedad, habría creado un espectáculo visual impresionante al reflejar la luz solar, especialmente al amanecer, visible desde kilómetros dada su altura.</p>
+        <p>El acceso a estas cuevas es descrito como difícil y peligroso, recomendándose guía local. Se menciona que se "abrió camino" en 2018.</p>
+        <p>Las cuevas de Setefenestras también se relacionan con el Circo Romano de Auca Patricia y la iglesia de San Millán.</p>
+    </div></section></main>
+    <div id="footer-placeholder"></div><script src="/js/layout.js"></script>
+</body></html>

--- a/ruinas/hallazgos_representaciones/fotos_hallazgos.html
+++ b/ruinas/hallazgos_representaciones/fotos_hallazgos.html
@@ -33,6 +33,16 @@
         <section class="section">
             <div class="container">
                 <p>Discusión sobre la importancia de la documentación fotográfica y el registro de hallazgos menores en el estudio arqueológico del Condado de Castilla.</p>
+
+                <h3>Menciones Específicas de Fotografías en Fuentes</h3>
+                <p>El documento <em>nuevo4.md</em> hace referencia a varias imágenes y fotografías que serían de gran valor para ilustrar los vestigios de Cerezo y Auca Patricia. Aunque el documento en sí es textual, estas menciones orientan futuras recopilaciones:</p>
+                <ul>
+                    <li>Fotografías comparativas del circo de Auca Patricia con el de Mérida.</li>
+                    <li>Imagen de una Estela de Cerezo de Río Tirón.</li>
+                    <li>Foto de un Capitel de la Iglesia de la Llana.</li>
+                    <li>Representación del Pendón de Castilla, descrito como una puerta romana sobre fondo morado imperial.</li>
+                    <li>El autor de <em>nuevo4.md</em> también expresa un deseo de recopilar más fotos que denoten el castillo de Cerezo.</li>
+                </ul>
                 <!-- Contenido sobre fotografías, tipos de hallazgos menores, y su contexto se añadirá aquí -->
             </div>
         section>

--- a/ruinas/hallazgos_representaciones/index.html
+++ b/ruinas/hallazgos_representaciones/index.html
@@ -22,6 +22,7 @@
             <li><a href="tallas_inscripciones.html">Tallas, Arte Rupestre e Inscripciones</a></li>
             <li><a href="fotos_hallazgos.html">Fotografías y Hallazgos Menores</a></li>
             <li><a href="monedas_antiguas.html">Monedas Antiguas de Cerezo y Auca</a></li>
+            <li><a href="cuevas_setefenestras.html">Cuevas de Setefenestras</a></li>
         </ul>
     </div></section></main>
     <div id="footer-placeholder"></div><script src="/js/layout.js"></script>

--- a/ruinas/hallazgos_representaciones/tallas_inscripciones.html
+++ b/ruinas/hallazgos_representaciones/tallas_inscripciones.html
@@ -32,7 +32,14 @@
     <main>
         <section class="section">
             <div class="container">
-                <p>Información sobre este vestigio aquí.</p>
+                <p>Esta página se enfoca en las manifestaciones artísticas y epigráficas encontradas en el Condado de Castilla, tales como tallas en piedra, posibles ejemplos de arte rupestre, e inscripciones en diversos soportes.</p>
+
+                <h3>Tallas y Grafitis Destacados</h3>
+                <p>Entre los hallazgos significativos se encuentran:</p>
+                <ul>
+                    <li><strong>Antiquísima talla de San Antón con el Tau en el pecho:</strong> Originalmente en el Hospital de San Jorge y actualmente en la Iglesia de San Nicolás. Es un testimonio importante del arte religioso temprano y la historia hospitalaria de Cerezo.</li>
+                    <li><strong>Escritos o grafitis en las Cuevas de Setefenestras:</strong> Se postula que estas cuevas, consideradas cuna del idioma castellano, contienen inscripciones o grafitis del vulgo de gran antigüedad, cubiertos por polvo milenario. Su estudio podría arrojar luz sobre la evolución temprana del idioma.</li>
+                </ul>
                 <!-- Contenido específico sobre tallas, arte rupestre e inscripciones se añadirá aquí -->
             </div>
         </section>

--- a/ruinas/index.html
+++ b/ruinas/index.html
@@ -71,6 +71,7 @@
                             <li><a href="estructuras_funerarias_religiosas/mausoleo_circo_auca.html">Mausoleo del Circo de Auca Patricia</a></li>
                             <li><a href="estructuras_funerarias_religiosas/mausoleo_magno_clemente_maximo.html">Mausoleo Imperial de Magno Clemente Máximo</a></li>
                             <li><a href="estructuras_funerarias_religiosas/mausoleo_san_nicolas.html">Mausoleo Imperial de San Nicolás</a></li>
+                            <li><a href="estructuras_funerarias_religiosas/iglesia_la_llana_mezquita_yanna.html">Iglesia de la Llana (Antigua Mezquita de Yanna)</a></li>
                         </ul>
                     </div>
 
@@ -79,6 +80,9 @@
                         <ul>
                             <li><a href="infraestructura_general/hitos_miliares.html">Hitos Miliares y Calzadas Romanas</a></li>
                             <li><a href="infraestructura_general/puentes_romanos_cerezo.html">Puentes Romanos en Cerezo de Río Tirón</a></li>
+                            <li><a href="infraestructura_general/hospital_san_jorge.html">Hospital de San Jorge y Talla de San Antón</a></li>
+                            <li><a href="infraestructura_general/mansio_romana_meson.html">Mansio Romana en el Mesón</a></li>
+                            <li><a href="infraestructura_general/tunel_antiguo.html">Túnel Antiguo</a></li>
                         </ul>
                     </div>
 
@@ -89,6 +93,7 @@
                             <li><a href="hallazgos_representaciones/tallas_inscripciones.html">Tallas, Arte Rupestre e Inscripciones</a></li>
                             <li><a href="hallazgos_representaciones/fotos_hallazgos.html">Fotografías y Hallazgos Menores</a></li>
                             <li><a href="hallazgos_representaciones/monedas_antiguas.html">Monedas Antiguas de Cerezo y Auca</a></li>
+                            <li><a href="hallazgos_representaciones/cuevas_setefenestras.html">Cuevas de Setefenestras</a></li>
                         </ul>
                     </div>
                 </div>

--- a/ruinas/infraestructura_general/hospital_san_jorge.html
+++ b/ruinas/infraestructura_general/hospital_san_jorge.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hospital de San Jorge y Talla de San Antón - Ruinas del Condado de Castilla</title>
+    <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+</head>
+<body>
+    <div id="header-placeholder"></div>
+    <header class="page-header"><div class="container"><h1>Hospital de San Jorge (Sanjurjo) y Talla de San Antón</h1></div></header>
+    <nav aria-label="breadcrumb" class="container breadcrumb-nav">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Inicio</a></li>
+        <li class="breadcrumb-item"><a href="/ruinas/index.html">Ruinas</a></li>
+        <li class="breadcrumb-item"><a href="/ruinas/infraestructura_general/index.html">Infraestructura General</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Hospital de San Jorge</li>
+      </ol>
+    </nav>
+    <main><section class="section"><div class="container">
+        <p>El Hospital de San Jorge, también conocido como Sanjurjo, fue una importante institución en Cerasio (Cerezo de Río Tirón), fundado alrededor del año 840-842 d.C. por el rey Ramiro I de Asturias y su esposa Paterna (de origen Banu Casi y local de Cerasio).</p>
+        <p>Este hospital estaba atendido por monjes de la orden de San Antón (Hospitalarios) y se estableció bajo la bandera de Ramiro I, la de San Jorge. Su propósito era cuidar de los enfermos, especialmente aquellos que padecían el "fuego de San Antón" (ergotismo), y atender a los peregrinos del Camino de Santiago, que en sus primeros tiempos pasaba por la calzada romana de Cerezo.</p>
+        <p>El hospital cerró en 1040 cuando el Camino de Santiago desvió su ruta principal. Hoy en día, se conserva la localización del hospital y, de gran valor, una antiquísima talla de San Antón con el Tau en el pecho. Esta talla, originalmente en el hospital, se encuentra ahora en la Iglesia de San Nicolás de Bari, aunque se menciona que ha sufrido una restauración moderna con dorados que no respeta el riguroso negro que vestían los hospitalarios de San Antón.</p>
+        <p>Se destaca que esta podría ser una de las primeras órdenes militares de Europa y el hospital de Cerezo, uno de los primeros de dicha orden.</p>
+    </div></section></main>
+    <div id="footer-placeholder"></div><script src="/js/layout.js"></script>
+</body></html>

--- a/ruinas/infraestructura_general/index.html
+++ b/ruinas/infraestructura_general/index.html
@@ -20,6 +20,9 @@
         <ul>
             <li><a href="hitos_miliares.html">Hitos Miliares y Calzadas Romanas</a></li>
             <li><a href="puentes_romanos_cerezo.html">Puentes Romanos en Cerezo de Río Tirón</a></li>
+            <li><a href="hospital_san_jorge.html">Hospital de San Jorge y Talla de San Antón</a></li>
+            <li><a href="mansio_romana_meson.html">Mansio Romana en el Mesón</a></li>
+            <li><a href="tunel_antiguo.html">Túnel Antiguo</a></li>
         </ul>
     </div></section></main>
     <div id="footer-placeholder"></div><script src="/js/layout.js"></script>

--- a/ruinas/infraestructura_general/mansio_romana_meson.html
+++ b/ruinas/infraestructura_general/mansio_romana_meson.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mansio Romana en el Mesón - Ruinas del Condado de Castilla</title>
+    <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+</head>
+<body>
+    <div id="header-placeholder"></div>
+    <header class="page-header"><div class="container"><h1>Mansio Romana en el Mesón (Auca Patricia)</h1></div></header>
+    <nav aria-label="breadcrumb" class="container breadcrumb-nav">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Inicio</a></li>
+        <li class="breadcrumb-item"><a href="/ruinas/index.html">Ruinas</a></li>
+        <li class="breadcrumb-item"><a href="/ruinas/infraestructura_general/index.html">Infraestructura General</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Mansio Romana en el Mesón</li>
+      </ol>
+    </nav>
+    <main><section class="section"><div class="container">
+        <p>Dentro del complejo urbano y territorial de Auca Patricia (Cerezo de Río Tirón), se menciona la existencia de una "mansio romana en el mesón". Las mansiones eran paradas oficiales en las calzadas romanas, mantenidas por el gobierno central para el uso de oficiales y correos.</p>
+        <p>La creación de esta mansio formó parte del establecimiento de la infraestructura romana en la zona, junto con la ciudad de Oca (Auca) en Los Palacios, el campamento militar en La Tejera, y una "Castella romana".</p>
+        <p>El texto de 'nuevo4.md' indica que el río Vallum (actual San García) se usaba para proteger esta Mansio Romana, que estaba situada al pasar el Puente Romano de San Ciprián. Este puente saltaba el foso de Rudera en la Alcazaba, defendiendo tanto la Mansio como el Mausoleo Imperial de San Nicolás. Solo los comerciantes podían entrar cargados o a caballo, y únicamente hasta el mesón (la mansio).</p>
+    </div></section></main>
+    <div id="footer-placeholder"></div><script src="/js/layout.js"></script>
+</body></html>

--- a/ruinas/infraestructura_general/tunel_antiguo.html
+++ b/ruinas/infraestructura_general/tunel_antiguo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Túnel Antiguo en Cerezo - Ruinas del Condado de Castilla</title>
+    <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+</head>
+<body>
+    <div id="header-placeholder"></div>
+    <header class="page-header"><div class="container"><h1>Túnel Antiguo en Cerezo de Río Tirón</h1></div></header>
+    <nav aria-label="breadcrumb" class="container breadcrumb-nav">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Inicio</a></li>
+        <li class="breadcrumb-item"><a href="/ruinas/index.html">Ruinas</a></li>
+        <li class="breadcrumb-item"><a href="/ruinas/infraestructura_general/index.html">Infraestructura General</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Túnel Antiguo</li>
+      </ol>
+    </nav>
+    <main><section class="section"><div class="container">
+        <p>En Cerezo de Río Tirón se hace referencia a un "Túnel en el Túnel", destacando que ha sido "mal reconstruido con hormigón del siglo XX". Esta mención sugiere la preexistencia de una estructura subterránea o pasaje más antiguo que ha sido alterado en tiempos modernos.</p>
+        <p>La naturaleza exacta, propósito y datación de este túnel original requieren más investigación. Podría haber formado parte de la infraestructura defensiva, de comunicación o de gestión de aguas de la antigua Auca Patricia o del posterior Alcázar de Cerasio.</p>
+        <p>La carretera que va desde la Caseta (cruce entre Tormantos y Belorado) hasta el Túnel mide 1200 metros, correspondiendo al Cardo (eje Norte-Sur) de la ciudad romana de Auca Patricia.</p>
+    </div></section></main>
+    <div id="footer-placeholder"></div><script src="/js/layout.js"></script>
+</body></html>


### PR DESCRIPTION
This commit builds upon the previous 'ruinas' section enhancement by incorporating more findings from a deeper analysis of `nuevo4.md`.

Key additions and updates:

1.  **New Ruin Pages Created:**
    *   Iglesia de la Llana (Antigua Mezquita de Yanna) under 'Estructuras Funerarias y Religiosas'.
    *   Cuevas de Setefenestras under 'Hallazgos y Representaciones', highlighting its Lapis Specularis and connection to early Castilian.
    *   Hospital de San Jorge under 'Infraestructura General', detailing its history and the Talla de San Antón.
    *   Mansio Romana en el Mesón under 'Infraestructura General'.
    *   Túnel Antiguo under 'Infraestructura General'.
    Each new page includes breadcrumbs and basic content.

2.  **Updates to Existing Pages:**
    *   `alcazar_cerasio.html`: Added details on alabastro construction and the Paseo de la Carcaba.
    *   `otros_campamentos_romanos.html`: Added specifics about the Oxmilla camp.
    *   `murallas_auca.html`: Further detailed the Paseo de la Carcaba.
    *   `circo_romano.html`: Included its connection to the Iglesia de Santi Emiliani.
    *   `fotos_hallazgos.html`: Added notes on specific photos mentioned in `nuevo4.md`.
    *   `tallas_inscripciones.html`: Added references to the Talla de San Antón and Setefenestras graffiti.

3.  **Index Updates:**
    *   The newly created pages have been linked from their respective category index pages.
    *   The main `ruinas/index.html` has also been updated to ensure all new pages are accessible.

These changes provide a more comprehensive documentation of the ruins and historical sites mentioned in `nuevo4.md`.