### PR TITLE
Add placeholder history sections to Alfoz town HTML files

### DIFF
--- a/lugares/alfozcerezolantaron/Alcedo/index.html
+++ b/lugares/alfozcerezolantaron/Alcedo/index.html
@@ -10,6 +10,8 @@
   <div id="header-placeholder"></div>
   <h1>Alcedo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Alcedo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Alcedo pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Ameyugo/index.html
+++ b/lugares/alfozcerezolantaron/Ameyugo/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Ameyugo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Ameyugo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Ameyugo pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Carcamo/index.html
+++ b/lugares/alfozcerezolantaron/Carcamo/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Cárcamo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Cárcamo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Cárcamo pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Castellum/index.html
+++ b/lugares/alfozcerezolantaron/Castellum/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Castellum</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Castellum</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Castellum pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Cellorigo/index.html
+++ b/lugares/alfozcerezolantaron/Cellorigo/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Cellorigo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Cellorigo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Cellorigo pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Cerezo_de_Rio_Tiron/index.html
+++ b/lugares/alfozcerezolantaron/Cerezo_de_Rio_Tiron/index.html
@@ -192,6 +192,9 @@
         </section>
     </main>
 
+  <h2>Historia</h2>
+<p>Información sobre la historia de Cerezo de Río Tirón pendiente de añadir.</p>
+
     <div id="imageModal" class="modal">
         <span class="modal-close-button">&times;</span>
         <img class="modal-content" id="modalImage" alt="Imagen ampliada">

--- a/lugares/alfozcerezolantaron/Comunion/index.html
+++ b/lugares/alfozcerezolantaron/Comunion/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Comunión</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Comunión</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Comunión pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Cuzcurrita_de_Rio_Tiron/index.html
+++ b/lugares/alfozcerezolantaron/Cuzcurrita_de_Rio_Tiron/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Cuzcurrita de Río Tirón</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Cuzcurrita de Río Tirón</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Cuzcurrita de Río Tirón pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Espejo/index.html
+++ b/lugares/alfozcerezolantaron/Espejo/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Espejo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Espejo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Espejo pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Fontecha/index.html
+++ b/lugares/alfozcerezolantaron/Fontecha/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Fontecha</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Fontecha</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Fontecha pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Fresno_de_Rio_Tiron/index.html
+++ b/lugares/alfozcerezolantaron/Fresno_de_Rio_Tiron/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Fresno de Río Tirón</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Fresno de Río Tirón</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Fresno de Río Tirón pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Granon/index.html
+++ b/lugares/alfozcerezolantaron/Granon/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Grañón</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Grañón</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Grañón pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Gurendes/index.html
+++ b/lugares/alfozcerezolantaron/Gurendes/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Gurendes</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Gurendes</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Gurendes pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Herramelluri/index.html
+++ b/lugares/alfozcerezolantaron/Herramelluri/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Herramélluri</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Herramélluri</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Herramélluri pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Ibrillos/index.html
+++ b/lugares/alfozcerezolantaron/Ibrillos/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Ibrillos</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Ibrillos</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Ibrillos pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Lecinana_del_Camino/index.html
+++ b/lugares/alfozcerezolantaron/Lecinana_del_Camino/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Leciñana del Camino</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Leciñana del Camino</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Leciñana del Camino pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Molinilla/index.html
+++ b/lugares/alfozcerezolantaron/Molinilla/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Molinilla</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Molinilla</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Molinilla pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Monte/index.html
+++ b/lugares/alfozcerezolantaron/Monte/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Monte</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Monte</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Monte pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Nograro/index.html
+++ b/lugares/alfozcerezolantaron/Nograro/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Nograro</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Nograro</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Nograro pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Ochanduri/index.html
+++ b/lugares/alfozcerezolantaron/Ochanduri/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Ochánduri</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Ochánduri</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Ochánduri pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Pancorbo/index.html
+++ b/lugares/alfozcerezolantaron/Pancorbo/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Pancorbo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Pancorbo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Pancorbo pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Pinedo/index.html
+++ b/lugares/alfozcerezolantaron/Pinedo/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Pinedo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Pinedo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Pinedo pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Posada/index.html
+++ b/lugares/alfozcerezolantaron/Posada/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Posada</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Posada</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Posada pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Poza_de_la_Sal/index.html
+++ b/lugares/alfozcerezolantaron/Poza_de_la_Sal/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Poza de la Sal</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Poza de la Sal</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Poza de la Sal pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Puentelarra/index.html
+++ b/lugares/alfozcerezolantaron/Puentelarra/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Puentelarrá</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Puentelarrá</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Puentelarrá pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Quejo/index.html
+++ b/lugares/alfozcerezolantaron/Quejo/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Quejo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Quejo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Quejo pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Quintanaloranco/index.html
+++ b/lugares/alfozcerezolantaron/Quintanaloranco/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Quintanaloranco</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Quintanaloranco</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Quintanaloranco pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Quintanilla_San_Garcia/index.html
+++ b/lugares/alfozcerezolantaron/Quintanilla_San_Garcia/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Quintanilla San García</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Quintanilla San García</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Quintanilla San García pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Quintanilla_del_Monte/index.html
+++ b/lugares/alfozcerezolantaron/Quintanilla_del_Monte/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Quintanilla del Monte</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Quintanilla del Monte</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Quintanilla del Monte pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Recilla/index.html
+++ b/lugares/alfozcerezolantaron/Recilla/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Recilla</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Recilla</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Recilla pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Redecilla_del_Campo/index.html
+++ b/lugares/alfozcerezolantaron/Redecilla_del_Campo/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Redecilla del Campo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Redecilla del Campo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Redecilla del Campo pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Salcedo/index.html
+++ b/lugares/alfozcerezolantaron/Salcedo/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Salcedo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Salcedo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Salcedo pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/San_Emilianus/index.html
+++ b/lugares/alfozcerezolantaron/San_Emilianus/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>San Emilianus</h1>
   <p>Bienvenido al archivo del pueblo de <strong>San Emilianus</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de San Emilianus pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/San_Millan_de_Yecora/index.html
+++ b/lugares/alfozcerezolantaron/San_Millan_de_Yecora/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>San Millán de Yécora</h1>
   <p>Bienvenido al archivo del pueblo de <strong>San Millán de Yécora</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de San Millán de Yécora pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/San_Zadornil/index.html
+++ b/lugares/alfozcerezolantaron/San_Zadornil/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>San Zadornil</h1>
   <p>Bienvenido al archivo del pueblo de <strong>San Zadornil</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de San Zadornil pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Sobron/index.html
+++ b/lugares/alfozcerezolantaron/Sobron/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Sobrón</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Sobrón</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Sobrón pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Sotillo_de_Rioja/index.html
+++ b/lugares/alfozcerezolantaron/Sotillo_de_Rioja/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Sotillo de Rioja</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Sotillo de Rioja</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Sotillo de Rioja pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Tirgo/index.html
+++ b/lugares/alfozcerezolantaron/Tirgo/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Tirgo</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Tirgo</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Tirgo pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Tormantos/index.html
+++ b/lugares/alfozcerezolantaron/Tormantos/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Tormantos</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Tormantos</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Tormantos pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Trevino/index.html
+++ b/lugares/alfozcerezolantaron/Trevino/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Treviño</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Treviño</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Treviño pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Tuesta/index.html
+++ b/lugares/alfozcerezolantaron/Tuesta/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Tuesta</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Tuesta</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Tuesta pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Turiso/index.html
+++ b/lugares/alfozcerezolantaron/Turiso/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Turiso</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Turiso</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Turiso pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Valluercanes/index.html
+++ b/lugares/alfozcerezolantaron/Valluercanes/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Valluércanes</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Valluércanes</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Valluércanes pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Valpuesta/index.html
+++ b/lugares/alfozcerezolantaron/Valpuesta/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Valpuesta</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Valpuesta</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Valpuesta pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>

--- a/lugares/alfozcerezolantaron/Velasco/index.html
+++ b/lugares/alfozcerezolantaron/Velasco/index.html
@@ -9,6 +9,8 @@
   <div id="header-placeholder"></div>
   <h1>Velasco</h1>
   <p>Bienvenido al archivo del pueblo de <strong>Velasco</strong>, integrante del histórico Alfoz de Cerezo y Lantarón.</p>
+  <h2>Historia</h2>
+<p>Información sobre la historia de Velasco pendiente de añadir.</p>
   <div id="footer-placeholder"></div>
   <script src="/js/layout.js" defer></script>
 </body>


### PR DESCRIPTION
This commit adds a standard 'Historia' section with a placeholder paragraph to the index.html files for towns within 'lugares/alfozcerezolantaron/' that were previously missing this section.

The placeholder text "Información sobre la historia de [Town Name] pendiente de añadir." was used as direct fetching of historical data from the internet was not possible at the time of execution. This ensures structural consistency across the town pages and flags them for future content population. Files that already had a history section were not modified.