### PR TITLE
feat(personajes): Add fourth batch of characters from nuevo4.md

### DIFF
--- a/personajes/Militares_y_Gobernantes/alfonso_ii_el_casto.html
+++ b/personajes/Militares_y_Gobernantes/alfonso_ii_el_casto.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>San Millan De La Cogolla - Condado de Castilla</title>
+    <title>Alfonso II el Casto - Rey de Asturias</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -22,17 +22,17 @@
             --color-texto-principal: #2c1d12;  /* Un marrón oscuro para el texto principal */
             --color-fondo-pagina: #fdfaf6;   /* Un blanco hueso muy sutil para el fondo general */
             --color-negro-contraste: #1A1A1A;
-            --color-primario-purpura-rgb: 74, 13, 103; 
-            --transition-speed: 0.3s; 
+            --color-primario-purpura-rgb: 74, 13, 103;
+            --transition-speed: 0.3s;
         }
 
         /* --- Estilos Generales --- */
         *, *::before, *::after {
-            box-sizing: border-box; 
+            box-sizing: border-box;
         }
 
         html {
-            scroll-behavior: smooth; 
+            scroll-behavior: smooth;
         }
 
         body {
@@ -42,7 +42,7 @@
             background-color: var(--color-fondo-pagina);
             margin: 0;
             padding: 0;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         h1, h2, h3, h4, h5, h6 {
@@ -51,10 +51,10 @@
             margin-top: 1.5em;
             margin-bottom: 0.7em;
             line-height: 1.3;
-            font-weight: 700; 
+            font-weight: 700;
         }
 
-        h1 { font-size: clamp(2.2em, 5vw, 3em); text-align: center; } 
+        h1 { font-size: clamp(2.2em, 5vw, 3em); text-align: center; }
         h2 { font-size: clamp(1.8em, 4vw, 2.5em); }
         h3 { font-size: clamp(1.4em, 3vw, 2em); }
 
@@ -64,7 +64,7 @@
             transition: color var(--transition-speed) ease, outline-color var(--transition-speed) ease;
         }
 
-        a:focus-visible { 
+        a:focus-visible {
             color: var(--color-acento-amarillo);
             text-decoration: underline;
             outline: 2px solid var(--color-acento-amarillo);
@@ -79,52 +79,46 @@
             max-width: 100%;
             height: auto;
             border-radius: 8px;
-            display: block; 
+            display: block;
         }
-        
+
         .container {
-            width: 90%; 
-            max-width: 1200px; 
+            width: 90%;
+            max-width: 1200px;
             margin: 0 auto;
             padding: 20px;
         }
 
-        /* --- Barra de Navegación (simplificada para páginas de personajes) --- */
         .navbar {
             background-color: var(--color-primario-purpura);
-            padding: 0.8em 0; 
+            padding: 0.8em 0;
             box-shadow: 0 4px 10px rgba(0,0,0,0.25);
-            /* position: sticky;  Puede no ser necesario en páginas de detalle */
-            /* top: 0; */
             z-index: 1000;
         }
 
         .navbar .container {
             display: flex;
-            justify-content: space-between; /* Centrar si solo hay logo */
+            justify-content: space-between;
             align-items: center;
         }
-        
+
         .navbar .logo-text {
             font-family: "Cinzel", serif;
-            font-size: clamp(1.5em, 3vw, 1.8em); 
+            font-size: clamp(1.5em, 3vw, 1.8em);
             color: var(--color-piedra-clara);
             text-decoration: none;
-            font-weight: 900; 
+            font-weight: 900;
             transition: transform var(--transition-speed) ease;
         }
         .navbar .logo-text:hover, .navbar .logo-text:focus-visible {
             transform: scale(1.05);
             text-decoration: none;
-            outline: none; 
+            outline: none;
         }
-        /* Se omite .nav-links y .nav-toggle para la plantilla de personaje para simplificar, 
-           se puede añadir si se desea un menú completo en cada página de personaje */
 
-        /* Estilos específicos para la página del personaje y el índice */
         .page-header-personaje, .page-header-indice {
             background-color: var(--color-piedra-media);
-            background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.65), rgba(44, 29, 18, 0.8)), url("/assets/img/hero_background_mezquita_llana.jpg"); /* Placeholder, considera cambiarla */
+            background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.65), rgba(44, 29, 18, 0.8)), url("/assets/img/hero_background_mezquita_llana.jpg");
             background-size: cover;
             background-position: center;
             padding: clamp(40px, 10vh, 80px) 20px;
@@ -136,24 +130,24 @@
             color: #fff;
             text-shadow: 2px 2px 6px var(--color-negro-contraste);
         }
-        .content-section { /* Clase genérica para secciones de contenido */
+        .content-section {
             padding: clamp(30px, 6vh, 50px) 0;
         }
-        .content-wrapper { /* Contenedor para el contenido principal */
+        .content-wrapper {
             max-width: 800px;
             margin: 0 auto;
             background-color: #fff;
-            padding: 30px 40px; /* Más padding lateral */
+            padding: 30px 40px;
             border-radius: 8px;
             box-shadow: 0 5px 15px rgba(0,0,0,0.1);
         }
         .content-wrapper img.personaje-imagen-principal {
-            max-width: 300px; 
+            max-width: 300px;
             margin: 0 auto 1.5em auto;
             border: 4px solid var(--color-piedra-media);
-            border-radius: 50%; /* Imagen redonda para retratos */
+            border-radius: 50%;
             object-fit: cover;
-            height: 300px; /* Asegurar que sea cuadrada para el círculo */
+            height: 300px;
         }
         .content-wrapper h2 {
             text-align:left;
@@ -162,7 +156,7 @@
             margin-bottom: 1em;
             font-size: clamp(1.6em, 3.5vw, 2.2em);
         }
-         .content-wrapper h2::after { display:none; } 
+         .content-wrapper h2::after { display:none; }
 
         .content-wrapper p, .content-wrapper ul {
             text-align: justify;
@@ -176,12 +170,12 @@
         .content-wrapper ul li {
             margin-bottom: 0.5em;
         }
-        .back-to-link, .cta-button-personaje { /* Estilo común para botones/enlaces de acción */
+        .back-to-link, .cta-button-personaje {
             display: inline-block;
             margin-top: 2em;
             padding: 12px 25px;
             background-color: var(--color-secundario-dorado);
-            color: var(--color-primario-purpura) !important; /* Forzar color de texto */
+            color: var(--color-primario-purpura) !important;
             border-radius: 25px;
             font-family: "Cinzel", serif;
             font-weight: bold;
@@ -192,37 +186,34 @@
         }
         .back-to-link:hover, .cta-button-personaje:hover {
             background-color: var(--color-primario-purpura);
-            color: var(--color-acento-amarillo) !important; /* Forzar color de texto */
+            color: var(--color-acento-amarillo) !important;
             text-decoration: none;
             transform: translateY(-2px);
         }
-        
-        /* Estilos para el índice de personajes */
+
         .indice-categorias li {
-            list-style-type: none; /* Quitar viñetas de la lista principal de categorías */
+            list-style-type: none;
             margin-bottom: 1.5em;
         }
-        .indice-categorias h3 { /* Título de categoría en el índice */
+        .indice-categorias h3 {
             font-size: clamp(1.3em, 2.8vw, 1.7em);
             border-left: none;
             padding-left: 0;
             margin-bottom: 0.5em;
         }
-        .indice-personajes-lista { /* Lista de personajes dentro de una categoría */
-            list-style: disc; /* Viñetas para los personajes */
+        .indice-personajes-lista {
+            list-style: disc;
             padding-left: 30px;
         }
         .indice-personajes-lista li a {
             font-size: clamp(1em, 2vw, 1.1em);
         }
 
-
-        /* --- Footer --- */
         .footer {
-            background-color: var(--color-texto-principal); 
+            background-color: var(--color-texto-principal);
             color: var(--color-piedra-clara);
             text-align: center;
-            padding: 40px 20px; 
+            padding: 40px 20px;
             margin-top: 50px;
             border-top: 6px solid var(--color-secundario-dorado);
         }
@@ -234,7 +225,7 @@
             margin: 0.6em 0;
             font-size: clamp(0.9em, 1.8vw, 1em);
         }
-        .footer a { 
+        .footer a {
             color: var(--color-acento-amarillo);
         }
         .footer a:focus-visible {
@@ -255,7 +246,7 @@
 
     <header class="page-header-personaje">
         <div class="container">
-            <h1>San Millán de la Cogolla</h1>
+            <h1>Alfonso II el Casto</h1>
         </div>
     </header>
 
@@ -263,34 +254,29 @@
         <section class="content-section">
             <div class="container">
                 <div class="content-wrapper">
-                    <img src="/assets/img/placeholder.jpg" alt="Retrato o imagen de San Millán de la Cogolla" class="personaje-imagen-principal" onerror="this.style.display='none'">
-                    <h2>Biografía y Relevancia</h2>
+                    <img src="/assets/img/militares_gobernantes/alfonso_ii_el_casto_placeholder.jpg" alt="Representación de Alfonso II el Casto" class="personaje-imagen-principal" onerror="this.onerror=null;this.src='/assets/img/placeholder.jpg';">
+                    <h2>Biografía y Relevancia Histórica</h2>
                     <p>
-                        San Millán de la Cogolla (Berceo, 473 - Monasterio de Suso, 574) fue un ermitaño, anacoreta y luego cenobita visigodo, considerado santo y patrón de Castilla y La Rioja. Su vida transcurrió principalmente en la Sierra de la Demanda.
+                        Alfonso II de Asturias, conocido como 'el Casto', reinó desde 791 hasta 842. Su largo reinado fue fundamental para la consolidación del Reino de Asturias y la afirmación de su identidad cristiana frente a Al-Ándalus. Estableció la capital en Oviedo y fomentó un renacimiento cultural y arquitectónico, con la construcción de iglesias como San Julián de los Prados. Uno de los hechos más trascendentales de su reinado fue el descubrimiento de la tumba del Apóstol Santiago en Compostela (circa 813-830), lo que dio origen al Camino de Santiago, convirtiendo a Alfonso II en el primer peregrino jacobeo.
                     </p>
+
+                    <h3>Conexiones con Auca y Cerezo según "nuevo4.md"</h3>
                     <p>
-                        Su figura es fundamental para entender la espiritualidad altomedieval en la península ibérica y su legado perdura a través de los monasterios de Suso y Yuso, declarados Patrimonio de la Humanidad. Es también conocido por ser el lugar donde se encuentran las Glosas Emilianenses, uno de los primeros testimonios escritos del romance hispánico.
-                    </p>
-                    
-                    <h3>Información Adicional de <code>nuevo4.md</code></h3>
-                    <p>
-                        Según el documento <code>nuevo4.md</code>, San Millán fue bautizado por el Obispo de Oca. También se narra, a través de San Braulio, que fue testigo de la destrucción de Civitate Auca Patricia. El Becerro Galicano de San Millán de la Cogolla es citado como una fuente clave que contendría la primera mención de 'Castilla' vinculada a Auca Patricia. La vida de San Millán, escrita por San Braulio, es referenciada en relación con las acciones del rey Leovigildo en Cantabria (Auca) y la profecía sobre un personaje llamado Abundancio.
+                        El documento <code>nuevo4.md</code> destaca a Alfonso II como el 'creador del Camino de Santiago'. Se afirma que conquistó la zona de Auca. La fundación del Hospital de San Jorge en Cerasio (Cerezo de Río Tirón) por su hijo Ramiro I (a través de su matrimonio con Paterna, descrita como de Cerasio/Castilla) está vinculada a su época. Además, <code>nuevo4.md</code> cita la Crónica Albeldense, la cual menciona que Alfonso II fue exiliado a Cerezo durante un periodo. También se le asocia con el establecimiento del Obispado de Valpuesta en el año 804, que <code>nuevo4.md</code> considera un sucesor del obispado de Auca.
                     </p>
 
                     <h3>Hitos Importantes</h3>
                     <ul>
-                        <li>Considerado Santo, Monje, Ermitaño y Patrón de Castilla y La Rioja.</li>
-                        <li>Vivió como anacoreta en las cuevas de la Sierra de la Demanda.</li>
-                        <li>Fundador del Monasterio de Suso, origen del complejo monástico de San Millán de la Cogolla.</li>
-                        <li>Su vida fue escrita por San Braulio, obispo de Zaragoza.</li>
-                        <li>Los monasterios de Suso y Yuso son Patrimonio de la Humanidad por la UNESCO.</li>
-                        <li>En el Monasterio de Suso se encontraron las Glosas Emilianenses.</li>
-                        <li>Bautizado por el Obispo de Oca (según <code>nuevo4.md</code>).</li>
-                        <li>Testigo de la destrucción de Civitate Auca Patricia (narrado por San Braulio, según <code>nuevo4.md</code>).</li>
-                        <li>El Becerro Galicano de San Millán de la Cogolla es una fuente clave que vincularía 'Castilla' con Auca Patricia (según <code>nuevo4.md</code>).</li>
-                        <li>Su biografía por San Braulio es referencia para eventos relacionados con Leovigildo en Cantabria/Auca (según <code>nuevo4.md</code>).</li>
+                        <li>Rey de Asturias (791-842).</li>
+                        <li>Considerado el 'Creador del Camino de Santiago' tras el descubrimiento de la tumba del Apóstol Santiago.</li>
+                        <li>Primer peregrino a Santiago de Compostela.</li>
+                        <li>Estableció la capital del Reino de Asturias en Oviedo.</li>
+                        <li>Según <code>nuevo4.md</code>, conquistó la zona de Auca.</li>
+                        <li>La Crónica Albeldense, citada en <code>nuevo4.md</code>, indica que fue exiliado a Cerezo.</li>
+                        <li>Asociado en <code>nuevo4.md</code> con el establecimiento del Obispado de Valpuesta (804) como sucesor del de Auca.</li>
+                        <li>Su época, según <code>nuevo4.md</code>, vio la unión de su hijo Ramiro I con Paterna (de Cerasio/Castilla) y la fundación del Hospital de San Jorge en Cerasio.</li>
                     </ul>
-                    
+
                     <p style="text-align:center;">
                         <a href="/personajes/indice_personajes.html" class="back-to-link">Volver al Índice de Personajes</a>
                     </p>
@@ -301,7 +287,7 @@
 
     <footer class="footer">
         <div class="container">
-            <p>&copy; 2025 CondadoDeCastilla.com - Todos los derechos reservados.</p>
+            <p>&copy; <script>document.write(new Date().getFullYear());</script> CondadoDeCastilla.com - Todos los derechos reservados.</p>
             <p>Un proyecto para la difusión del patrimonio histórico de Cerezo de Río Tirón y el Alfoz de Cerasio y Lantarón.</p>
         </div>
     </footer>

--- a/personajes/Militares_y_Gobernantes/corocotta.html
+++ b/personajes/Militares_y_Gobernantes/corocotta.html
@@ -257,7 +257,7 @@
                     <img src="/assets/img/militares_gobernantes/corocotta_placeholder.jpg" alt="Ilustración del caudillo cántabro Corocotta" class="personaje-imagen-principal" onerror="this.onerror=null;this.src='/assets/img/placeholder.jpg';">
                     <h2>Biografía y Relevancia</h2>
                     <p>
-                        Corocotta fue un famoso caudillo cántabro del siglo I a.C., conocido por su resistencia contra la conquista romana durante las Guerras Cántabras (29-19 a.C.). Aunque es una figura envuelta en la leyenda, es mencionado por el historiador romano Dión Casio, quien relata un episodio singular: Corocotta, por cuya cabeza el emperador Augusto había ofrecido una gran recompensa, se presentó voluntariamente ante él. Augusto, impresionado por su audacia, no solo le perdonó la vida sino que también le entregó la recompensa. Este acto lo ha convertido en un símbolo de la astucia y el valor de los pueblos cántabros.
+                        Corocotta fue un famoso caudillo cántabro del siglo I a.C., conocido por su resistencia contra la conquista romana durante las Guerras Cántabras (29-19 a.C.). Aunque es una figura envuelta en la leyenda, es mencionado por el historiador romano Dión Casio, quien relata un episodio singular: Corocotta, por cuya cabeza el emperador Augusto había ofrecido una gran recompensa, se presentó voluntariamente ante él. Augusto, impresionado por su audacia, no solo le perdonó la vida sino que también le entregó la recompensa. Este acto lo ha convertido en un símbolo de la astucia y el valor de los pueblos cántabros frente al poder de Roma.
                     </p>
 
                     <h3>Corocotta en "nuevo4.md"</h3>
@@ -271,7 +271,7 @@
                         <li>Según <code>nuevo4.md</code>, fue rey de Segisamam (capital cántabra, asociada por el texto con Cerezo de Río Tirón).</li>
                         <li>Descrito en <code>nuevo4.md</code> como un guerrero valiente, astuto, que unió a las tribus cántabras y era querido por su pueblo.</li>
                         <li>El documento <code>nuevo4.md</code> incluye una detallada narración de su conflicto con César Augusto y Agripa, mencionando a su esposa Alba y sus hijos Turok, Nerea y Amaia.</li>
-                        <li>Famoso por el episodio (relatado por Dión Casio y mencionado en <code>nuevo4.md</code>) en el que se presentó ante César Augusto para reclamar la recompensa ofrecida por su propia captura.</li>
+                        <li>Famoso por el episodio (relatado por Dión Casio y mencionado en <code>nuevo4.md</code>) en el que se presentó ante César Augusto para reclamar la recompensa ofrecida por su propia captura, quien se la concedió admirado por su osadía.</li>
                     </ul>
                     
                     <p style="text-align:center;">

--- a/personajes/Militares_y_Gobernantes/leovigildo.html
+++ b/personajes/Militares_y_Gobernantes/leovigildo.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>San Millan De La Cogolla - Condado de Castilla</title>
+    <title>Leovigildo - Rey Visigodo</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -22,17 +22,17 @@
             --color-texto-principal: #2c1d12;  /* Un marrón oscuro para el texto principal */
             --color-fondo-pagina: #fdfaf6;   /* Un blanco hueso muy sutil para el fondo general */
             --color-negro-contraste: #1A1A1A;
-            --color-primario-purpura-rgb: 74, 13, 103; 
-            --transition-speed: 0.3s; 
+            --color-primario-purpura-rgb: 74, 13, 103;
+            --transition-speed: 0.3s;
         }
 
         /* --- Estilos Generales --- */
         *, *::before, *::after {
-            box-sizing: border-box; 
+            box-sizing: border-box;
         }
 
         html {
-            scroll-behavior: smooth; 
+            scroll-behavior: smooth;
         }
 
         body {
@@ -42,7 +42,7 @@
             background-color: var(--color-fondo-pagina);
             margin: 0;
             padding: 0;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         h1, h2, h3, h4, h5, h6 {
@@ -51,10 +51,10 @@
             margin-top: 1.5em;
             margin-bottom: 0.7em;
             line-height: 1.3;
-            font-weight: 700; 
+            font-weight: 700;
         }
 
-        h1 { font-size: clamp(2.2em, 5vw, 3em); text-align: center; } 
+        h1 { font-size: clamp(2.2em, 5vw, 3em); text-align: center; }
         h2 { font-size: clamp(1.8em, 4vw, 2.5em); }
         h3 { font-size: clamp(1.4em, 3vw, 2em); }
 
@@ -64,7 +64,7 @@
             transition: color var(--transition-speed) ease, outline-color var(--transition-speed) ease;
         }
 
-        a:focus-visible { 
+        a:focus-visible {
             color: var(--color-acento-amarillo);
             text-decoration: underline;
             outline: 2px solid var(--color-acento-amarillo);
@@ -79,52 +79,46 @@
             max-width: 100%;
             height: auto;
             border-radius: 8px;
-            display: block; 
+            display: block;
         }
-        
+
         .container {
-            width: 90%; 
-            max-width: 1200px; 
+            width: 90%;
+            max-width: 1200px;
             margin: 0 auto;
             padding: 20px;
         }
 
-        /* --- Barra de Navegación (simplificada para páginas de personajes) --- */
         .navbar {
             background-color: var(--color-primario-purpura);
-            padding: 0.8em 0; 
+            padding: 0.8em 0;
             box-shadow: 0 4px 10px rgba(0,0,0,0.25);
-            /* position: sticky;  Puede no ser necesario en páginas de detalle */
-            /* top: 0; */
             z-index: 1000;
         }
 
         .navbar .container {
             display: flex;
-            justify-content: space-between; /* Centrar si solo hay logo */
+            justify-content: space-between;
             align-items: center;
         }
-        
+
         .navbar .logo-text {
             font-family: "Cinzel", serif;
-            font-size: clamp(1.5em, 3vw, 1.8em); 
+            font-size: clamp(1.5em, 3vw, 1.8em);
             color: var(--color-piedra-clara);
             text-decoration: none;
-            font-weight: 900; 
+            font-weight: 900;
             transition: transform var(--transition-speed) ease;
         }
         .navbar .logo-text:hover, .navbar .logo-text:focus-visible {
             transform: scale(1.05);
             text-decoration: none;
-            outline: none; 
+            outline: none;
         }
-        /* Se omite .nav-links y .nav-toggle para la plantilla de personaje para simplificar, 
-           se puede añadir si se desea un menú completo en cada página de personaje */
 
-        /* Estilos específicos para la página del personaje y el índice */
         .page-header-personaje, .page-header-indice {
             background-color: var(--color-piedra-media);
-            background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.65), rgba(44, 29, 18, 0.8)), url("/assets/img/hero_background_mezquita_llana.jpg"); /* Placeholder, considera cambiarla */
+            background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.65), rgba(44, 29, 18, 0.8)), url("/assets/img/hero_background_mezquita_llana.jpg");
             background-size: cover;
             background-position: center;
             padding: clamp(40px, 10vh, 80px) 20px;
@@ -136,24 +130,24 @@
             color: #fff;
             text-shadow: 2px 2px 6px var(--color-negro-contraste);
         }
-        .content-section { /* Clase genérica para secciones de contenido */
+        .content-section {
             padding: clamp(30px, 6vh, 50px) 0;
         }
-        .content-wrapper { /* Contenedor para el contenido principal */
+        .content-wrapper {
             max-width: 800px;
             margin: 0 auto;
             background-color: #fff;
-            padding: 30px 40px; /* Más padding lateral */
+            padding: 30px 40px;
             border-radius: 8px;
             box-shadow: 0 5px 15px rgba(0,0,0,0.1);
         }
         .content-wrapper img.personaje-imagen-principal {
-            max-width: 300px; 
+            max-width: 300px;
             margin: 0 auto 1.5em auto;
             border: 4px solid var(--color-piedra-media);
-            border-radius: 50%; /* Imagen redonda para retratos */
+            border-radius: 50%;
             object-fit: cover;
-            height: 300px; /* Asegurar que sea cuadrada para el círculo */
+            height: 300px;
         }
         .content-wrapper h2 {
             text-align:left;
@@ -162,7 +156,7 @@
             margin-bottom: 1em;
             font-size: clamp(1.6em, 3.5vw, 2.2em);
         }
-         .content-wrapper h2::after { display:none; } 
+         .content-wrapper h2::after { display:none; }
 
         .content-wrapper p, .content-wrapper ul {
             text-align: justify;
@@ -176,12 +170,12 @@
         .content-wrapper ul li {
             margin-bottom: 0.5em;
         }
-        .back-to-link, .cta-button-personaje { /* Estilo común para botones/enlaces de acción */
+        .back-to-link, .cta-button-personaje {
             display: inline-block;
             margin-top: 2em;
             padding: 12px 25px;
             background-color: var(--color-secundario-dorado);
-            color: var(--color-primario-purpura) !important; /* Forzar color de texto */
+            color: var(--color-primario-purpura) !important;
             border-radius: 25px;
             font-family: "Cinzel", serif;
             font-weight: bold;
@@ -192,37 +186,34 @@
         }
         .back-to-link:hover, .cta-button-personaje:hover {
             background-color: var(--color-primario-purpura);
-            color: var(--color-acento-amarillo) !important; /* Forzar color de texto */
+            color: var(--color-acento-amarillo) !important;
             text-decoration: none;
             transform: translateY(-2px);
         }
-        
-        /* Estilos para el índice de personajes */
+
         .indice-categorias li {
-            list-style-type: none; /* Quitar viñetas de la lista principal de categorías */
+            list-style-type: none;
             margin-bottom: 1.5em;
         }
-        .indice-categorias h3 { /* Título de categoría en el índice */
+        .indice-categorias h3 {
             font-size: clamp(1.3em, 2.8vw, 1.7em);
             border-left: none;
             padding-left: 0;
             margin-bottom: 0.5em;
         }
-        .indice-personajes-lista { /* Lista de personajes dentro de una categoría */
-            list-style: disc; /* Viñetas para los personajes */
+        .indice-personajes-lista {
+            list-style: disc;
             padding-left: 30px;
         }
         .indice-personajes-lista li a {
             font-size: clamp(1em, 2vw, 1.1em);
         }
 
-
-        /* --- Footer --- */
         .footer {
-            background-color: var(--color-texto-principal); 
+            background-color: var(--color-texto-principal);
             color: var(--color-piedra-clara);
             text-align: center;
-            padding: 40px 20px; 
+            padding: 40px 20px;
             margin-top: 50px;
             border-top: 6px solid var(--color-secundario-dorado);
         }
@@ -234,7 +225,7 @@
             margin: 0.6em 0;
             font-size: clamp(0.9em, 1.8vw, 1em);
         }
-        .footer a { 
+        .footer a {
             color: var(--color-acento-amarillo);
         }
         .footer a:focus-visible {
@@ -255,7 +246,7 @@
 
     <header class="page-header-personaje">
         <div class="container">
-            <h1>San Millán de la Cogolla</h1>
+            <h1>Leovigildo</h1>
         </div>
     </header>
 
@@ -263,34 +254,27 @@
         <section class="content-section">
             <div class="container">
                 <div class="content-wrapper">
-                    <img src="/assets/img/placeholder.jpg" alt="Retrato o imagen de San Millán de la Cogolla" class="personaje-imagen-principal" onerror="this.style.display='none'">
-                    <h2>Biografía y Relevancia</h2>
+                    <img src="/assets/img/placeholder.jpg" alt="Retrato o imagen de Leovigildo" class="personaje-imagen-principal">
+                    <h2>Biografía y Relevancia Histórica</h2>
                     <p>
-                        San Millán de la Cogolla (Berceo, 473 - Monasterio de Suso, 574) fue un ermitaño, anacoreta y luego cenobita visigodo, considerado santo y patrón de Castilla y La Rioja. Su vida transcurrió principalmente en la Sierra de la Demanda.
+                        Leovigildo fue un rey visigodo de Hispania que reinó desde el 568 o 569 hasta su muerte en el 586. Es considerado uno de los monarcas visigodos más importantes, conocido por sus campañas militares que expandieron significativamente el control territorial del reino sobre la península ibérica, incluyendo la conquista del reino suevo. También impulsó reformas legislativas y buscó la unificación religiosa bajo el arrianismo, aunque esta política generó conflictos, incluyendo la rebelión de su propio hijo Hermenegildo, convertido al catolicismo.
                     </p>
+
+                    <h3>Interpretaciones de "nuevo4.md"</h3>
                     <p>
-                        Su figura es fundamental para entender la espiritualidad altomedieval en la península ibérica y su legado perdura a través de los monasterios de Suso y Yuso, declarados Patrimonio de la Humanidad. Es también conocido por ser el lugar donde se encuentran las Glosas Emilianenses, uno de los primeros testimonios escritos del romance hispánico.
-                    </p>
-                    
-                    <h3>Información Adicional de <code>nuevo4.md</code></h3>
-                    <p>
-                        Según el documento <code>nuevo4.md</code>, San Millán fue bautizado por el Obispo de Oca. También se narra, a través de San Braulio, que fue testigo de la destrucción de Civitate Auca Patricia. El Becerro Galicano de San Millán de la Cogolla es citado como una fuente clave que contendría la primera mención de 'Castilla' vinculada a Auca Patricia. La vida de San Millán, escrita por San Braulio, es referenciada en relación con las acciones del rey Leovigildo en Cantabria (Auca) y la profecía sobre un personaje llamado Abundancio.
+                        El documento <code>nuevo4.md</code> destaca el papel de Leovigildo en la historia de Auca Patricia (identificada como la capital de Cantabria y asociada con Cerezo de Río Tirón). Citando a San Braulio, el texto afirma que Leovigildo conquistó Auca Patricia en el año 574, destruyendo sus murallas y torres, pero dejando tres de ellas en pie, un detalle que <code>nuevo4.md</code> vincula con la iconografía del Pendón de Castilla. Además, se le menciona por haber ejecutado a un personaje llamado Abundancio, quien había dudado de una profecía de San Millán sobre la destrucción de Cantabria (Auca).
                     </p>
 
                     <h3>Hitos Importantes</h3>
                     <ul>
-                        <li>Considerado Santo, Monje, Ermitaño y Patrón de Castilla y La Rioja.</li>
-                        <li>Vivió como anacoreta en las cuevas de la Sierra de la Demanda.</li>
-                        <li>Fundador del Monasterio de Suso, origen del complejo monástico de San Millán de la Cogolla.</li>
-                        <li>Su vida fue escrita por San Braulio, obispo de Zaragoza.</li>
-                        <li>Los monasterios de Suso y Yuso son Patrimonio de la Humanidad por la UNESCO.</li>
-                        <li>En el Monasterio de Suso se encontraron las Glosas Emilianenses.</li>
-                        <li>Bautizado por el Obispo de Oca (según <code>nuevo4.md</code>).</li>
-                        <li>Testigo de la destrucción de Civitate Auca Patricia (narrado por San Braulio, según <code>nuevo4.md</code>).</li>
-                        <li>El Becerro Galicano de San Millán de la Cogolla es una fuente clave que vincularía 'Castilla' con Auca Patricia (según <code>nuevo4.md</code>).</li>
-                        <li>Su biografía por San Braulio es referencia para eventos relacionados con Leovigildo en Cantabria/Auca (según <code>nuevo4.md</code>).</li>
+                        <li>Rey visigodo de Hispania (reinado: 568/569 – 586).</li>
+                        <li>Conquistador del reino suevo y unificador de gran parte de la península ibérica bajo dominio visigodo.</li>
+                        <li>Impulsor de reformas legislativas (revisión del Código de Eurico, base del posterior Liber Iudiciorum) y de la unificación religiosa (arrianismo).</li>
+                        <li>Según <code>nuevo4.md</code> (citando a San Braulio), conquistó Auca Patricia (capital de Cantabria, asociada con Cerezo) en el año 574.</li>
+                        <li>Conforme a <code>nuevo4.md</code>, destruyó las murallas de Auca Patricia, dejando tres torres en pie (vinculadas por el texto al Pendón de Castilla).</li>
+                        <li>Mencionado en <code>nuevo4.md</code> por ejecutar a Abundancio tras la profecía de San Millán sobre la destrucción de Cantabria.</li>
                     </ul>
-                    
+
                     <p style="text-align:center;">
                         <a href="/personajes/indice_personajes.html" class="back-to-link">Volver al Índice de Personajes</a>
                     </p>
@@ -301,7 +285,7 @@
 
     <footer class="footer">
         <div class="container">
-            <p>&copy; 2025 CondadoDeCastilla.com - Todos los derechos reservados.</p>
+            <p>&copy; <script>document.write(new Date().getFullYear());</script> CondadoDeCastilla.com - Todos los derechos reservados.</p>
             <p>Un proyecto para la difusión del patrimonio histórico de Cerezo de Río Tirón y el Alfoz de Cerasio y Lantarón.</p>
         </div>
     </footer>

--- a/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
+++ b/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>San Millan De La Cogolla - Condado de Castilla</title>
+    <title>Fray Prudencio de Sandoval - Cronistas e Historiadores</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -22,17 +22,17 @@
             --color-texto-principal: #2c1d12;  /* Un marrón oscuro para el texto principal */
             --color-fondo-pagina: #fdfaf6;   /* Un blanco hueso muy sutil para el fondo general */
             --color-negro-contraste: #1A1A1A;
-            --color-primario-purpura-rgb: 74, 13, 103; 
-            --transition-speed: 0.3s; 
+            --color-primario-purpura-rgb: 74, 13, 103;
+            --transition-speed: 0.3s;
         }
 
         /* --- Estilos Generales --- */
         *, *::before, *::after {
-            box-sizing: border-box; 
+            box-sizing: border-box;
         }
 
         html {
-            scroll-behavior: smooth; 
+            scroll-behavior: smooth;
         }
 
         body {
@@ -42,7 +42,7 @@
             background-color: var(--color-fondo-pagina);
             margin: 0;
             padding: 0;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         h1, h2, h3, h4, h5, h6 {
@@ -51,10 +51,10 @@
             margin-top: 1.5em;
             margin-bottom: 0.7em;
             line-height: 1.3;
-            font-weight: 700; 
+            font-weight: 700;
         }
 
-        h1 { font-size: clamp(2.2em, 5vw, 3em); text-align: center; } 
+        h1 { font-size: clamp(2.2em, 5vw, 3em); text-align: center; }
         h2 { font-size: clamp(1.8em, 4vw, 2.5em); }
         h3 { font-size: clamp(1.4em, 3vw, 2em); }
 
@@ -64,7 +64,7 @@
             transition: color var(--transition-speed) ease, outline-color var(--transition-speed) ease;
         }
 
-        a:focus-visible { 
+        a:focus-visible {
             color: var(--color-acento-amarillo);
             text-decoration: underline;
             outline: 2px solid var(--color-acento-amarillo);
@@ -79,52 +79,46 @@
             max-width: 100%;
             height: auto;
             border-radius: 8px;
-            display: block; 
+            display: block;
         }
-        
+
         .container {
-            width: 90%; 
-            max-width: 1200px; 
+            width: 90%;
+            max-width: 1200px;
             margin: 0 auto;
             padding: 20px;
         }
 
-        /* --- Barra de Navegación (simplificada para páginas de personajes) --- */
         .navbar {
             background-color: var(--color-primario-purpura);
-            padding: 0.8em 0; 
+            padding: 0.8em 0;
             box-shadow: 0 4px 10px rgba(0,0,0,0.25);
-            /* position: sticky;  Puede no ser necesario en páginas de detalle */
-            /* top: 0; */
             z-index: 1000;
         }
 
         .navbar .container {
             display: flex;
-            justify-content: space-between; /* Centrar si solo hay logo */
+            justify-content: space-between;
             align-items: center;
         }
-        
+
         .navbar .logo-text {
             font-family: "Cinzel", serif;
-            font-size: clamp(1.5em, 3vw, 1.8em); 
+            font-size: clamp(1.5em, 3vw, 1.8em);
             color: var(--color-piedra-clara);
             text-decoration: none;
-            font-weight: 900; 
+            font-weight: 900;
             transition: transform var(--transition-speed) ease;
         }
         .navbar .logo-text:hover, .navbar .logo-text:focus-visible {
             transform: scale(1.05);
             text-decoration: none;
-            outline: none; 
+            outline: none;
         }
-        /* Se omite .nav-links y .nav-toggle para la plantilla de personaje para simplificar, 
-           se puede añadir si se desea un menú completo en cada página de personaje */
 
-        /* Estilos específicos para la página del personaje y el índice */
         .page-header-personaje, .page-header-indice {
             background-color: var(--color-piedra-media);
-            background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.65), rgba(44, 29, 18, 0.8)), url("/assets/img/hero_background_mezquita_llana.jpg"); /* Placeholder, considera cambiarla */
+            background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.65), rgba(44, 29, 18, 0.8)), url("/assets/img/hero_background_mezquita_llana.jpg");
             background-size: cover;
             background-position: center;
             padding: clamp(40px, 10vh, 80px) 20px;
@@ -136,24 +130,24 @@
             color: #fff;
             text-shadow: 2px 2px 6px var(--color-negro-contraste);
         }
-        .content-section { /* Clase genérica para secciones de contenido */
+        .content-section {
             padding: clamp(30px, 6vh, 50px) 0;
         }
-        .content-wrapper { /* Contenedor para el contenido principal */
+        .content-wrapper {
             max-width: 800px;
             margin: 0 auto;
             background-color: #fff;
-            padding: 30px 40px; /* Más padding lateral */
+            padding: 30px 40px;
             border-radius: 8px;
             box-shadow: 0 5px 15px rgba(0,0,0,0.1);
         }
         .content-wrapper img.personaje-imagen-principal {
-            max-width: 300px; 
+            max-width: 300px;
             margin: 0 auto 1.5em auto;
             border: 4px solid var(--color-piedra-media);
-            border-radius: 50%; /* Imagen redonda para retratos */
+            border-radius: 50%;
             object-fit: cover;
-            height: 300px; /* Asegurar que sea cuadrada para el círculo */
+            height: 300px;
         }
         .content-wrapper h2 {
             text-align:left;
@@ -162,7 +156,7 @@
             margin-bottom: 1em;
             font-size: clamp(1.6em, 3.5vw, 2.2em);
         }
-         .content-wrapper h2::after { display:none; } 
+         .content-wrapper h2::after { display:none; }
 
         .content-wrapper p, .content-wrapper ul {
             text-align: justify;
@@ -176,12 +170,12 @@
         .content-wrapper ul li {
             margin-bottom: 0.5em;
         }
-        .back-to-link, .cta-button-personaje { /* Estilo común para botones/enlaces de acción */
+        .back-to-link, .cta-button-personaje {
             display: inline-block;
             margin-top: 2em;
             padding: 12px 25px;
             background-color: var(--color-secundario-dorado);
-            color: var(--color-primario-purpura) !important; /* Forzar color de texto */
+            color: var(--color-primario-purpura) !important;
             border-radius: 25px;
             font-family: "Cinzel", serif;
             font-weight: bold;
@@ -192,37 +186,34 @@
         }
         .back-to-link:hover, .cta-button-personaje:hover {
             background-color: var(--color-primario-purpura);
-            color: var(--color-acento-amarillo) !important; /* Forzar color de texto */
+            color: var(--color-acento-amarillo) !important;
             text-decoration: none;
             transform: translateY(-2px);
         }
-        
-        /* Estilos para el índice de personajes */
+
         .indice-categorias li {
-            list-style-type: none; /* Quitar viñetas de la lista principal de categorías */
+            list-style-type: none;
             margin-bottom: 1.5em;
         }
-        .indice-categorias h3 { /* Título de categoría en el índice */
+        .indice-categorias h3 {
             font-size: clamp(1.3em, 2.8vw, 1.7em);
             border-left: none;
             padding-left: 0;
             margin-bottom: 0.5em;
         }
-        .indice-personajes-lista { /* Lista de personajes dentro de una categoría */
-            list-style: disc; /* Viñetas para los personajes */
+        .indice-personajes-lista {
+            list-style: disc;
             padding-left: 30px;
         }
         .indice-personajes-lista li a {
             font-size: clamp(1em, 2vw, 1.1em);
         }
 
-
-        /* --- Footer --- */
         .footer {
-            background-color: var(--color-texto-principal); 
+            background-color: var(--color-texto-principal);
             color: var(--color-piedra-clara);
             text-align: center;
-            padding: 40px 20px; 
+            padding: 40px 20px;
             margin-top: 50px;
             border-top: 6px solid var(--color-secundario-dorado);
         }
@@ -234,7 +225,7 @@
             margin: 0.6em 0;
             font-size: clamp(0.9em, 1.8vw, 1em);
         }
-        .footer a { 
+        .footer a {
             color: var(--color-acento-amarillo);
         }
         .footer a:focus-visible {
@@ -255,7 +246,7 @@
 
     <header class="page-header-personaje">
         <div class="container">
-            <h1>San Millán de la Cogolla</h1>
+            <h1>Fray Prudencio de Sandoval</h1>
         </div>
     </header>
 
@@ -263,34 +254,25 @@
         <section class="content-section">
             <div class="container">
                 <div class="content-wrapper">
-                    <img src="/assets/img/placeholder.jpg" alt="Retrato o imagen de San Millán de la Cogolla" class="personaje-imagen-principal" onerror="this.style.display='none'">
+                    <img src="/assets/img/placeholder.jpg" alt="Retrato o imagen de Fray Prudencio de Sandoval" class="personaje-imagen-principal">
                     <h2>Biografía y Relevancia</h2>
                     <p>
-                        San Millán de la Cogolla (Berceo, 473 - Monasterio de Suso, 574) fue un ermitaño, anacoreta y luego cenobita visigodo, considerado santo y patrón de Castilla y La Rioja. Su vida transcurrió principalmente en la Sierra de la Demanda.
+                        Fray Prudencio de Sandoval, una destacada figura del Siglo de Oro español (siglos XVI-XVII), fue un monje benedictino, historiador y Obispo de Tuy y posteriormente de Pamplona. Es conocido por sus extensas crónicas sobre la historia de España y de la Iglesia.
                     </p>
                     <p>
-                        Su figura es fundamental para entender la espiritualidad altomedieval en la península ibérica y su legado perdura a través de los monasterios de Suso y Yuso, declarados Patrimonio de la Humanidad. Es también conocido por ser el lugar donde se encuentran las Glosas Emilianenses, uno de los primeros testimonios escritos del romance hispánico.
-                    </p>
-                    
-                    <h3>Información Adicional de <code>nuevo4.md</code></h3>
-                    <p>
-                        Según el documento <code>nuevo4.md</code>, San Millán fue bautizado por el Obispo de Oca. También se narra, a través de San Braulio, que fue testigo de la destrucción de Civitate Auca Patricia. El Becerro Galicano de San Millán de la Cogolla es citado como una fuente clave que contendría la primera mención de 'Castilla' vinculada a Auca Patricia. La vida de San Millán, escrita por San Braulio, es referenciada en relación con las acciones del rey Leovigildo en Cantabria (Auca) y la profecía sobre un personaje llamado Abundancio.
+                        El documento <code>nuevo4.md</code> lo cita con frecuencia debido a sus interpretaciones del Becerro Galicano de San Millán de la Cogolla, particularmente en lo referente a Auca Patricia (asociada con Cerezo de Río Tirón) como origen de Castilla. Según <code>nuevo4.md</code>, Sandoval defendió la fundación de Auca por César Augusto y su estatus como sede episcopal, interpretando 'Auca Patricia' donde otros leían 'Area Paterniani' en el Becerro. Su obra 'Historia de los Cinco Obispos' (Pamplona, 1615), cuyo título original es más extenso como 'Historias de Idacio obispo...', es una referencia clave en estas discusiones presentadas en <code>nuevo4.md</code>.
                     </p>
 
                     <h3>Hitos Importantes</h3>
                     <ul>
-                        <li>Considerado Santo, Monje, Ermitaño y Patrón de Castilla y La Rioja.</li>
-                        <li>Vivió como anacoreta en las cuevas de la Sierra de la Demanda.</li>
-                        <li>Fundador del Monasterio de Suso, origen del complejo monástico de San Millán de la Cogolla.</li>
-                        <li>Su vida fue escrita por San Braulio, obispo de Zaragoza.</li>
-                        <li>Los monasterios de Suso y Yuso son Patrimonio de la Humanidad por la UNESCO.</li>
-                        <li>En el Monasterio de Suso se encontraron las Glosas Emilianenses.</li>
-                        <li>Bautizado por el Obispo de Oca (según <code>nuevo4.md</code>).</li>
-                        <li>Testigo de la destrucción de Civitate Auca Patricia (narrado por San Braulio, según <code>nuevo4.md</code>).</li>
-                        <li>El Becerro Galicano de San Millán de la Cogolla es una fuente clave que vincularía 'Castilla' con Auca Patricia (según <code>nuevo4.md</code>).</li>
-                        <li>Su biografía por San Braulio es referencia para eventos relacionados con Leovigildo en Cantabria/Auca (según <code>nuevo4.md</code>).</li>
+                        <li>Cronista e historiador español de la Época Moderna (siglos XVI-XVII).</li>
+                        <li>Monje benedictino, Obispo de Tuy y de Pamplona.</li>
+                        <li>Autor de 'Historias de Idacio obispo que escrivio poco antes que España se perdiese. De Isidoro obispo de Badajoz,...De Sebastiano obispo de Salamanca,...De Sampiro obispo de Astorga,...De pelagio obispo de Ouiedo,...Nunca hasta agora impressas, con otras notas tocantes e estas historias, y reyes dellas' (Pamplona, 1615), referida en `nuevo4.md` también como 'Historia de cinco obispos'.</li>
+                        <li>Según <code>nuevo4.md</code>, figura clave por sus interpretaciones del Becerro Galicano de San Millán.</li>
+                        <li>Defensor, según <code>nuevo4.md</code>, de la tesis de Auca Patricia (Cerezo de Río Tirón) como origen de Castilla y su fundación por Augusto.</li>
+                        <li>Citado en <code>nuevo4.md` por leer 'Auca Patricia' en el Becerro Galicano donde otros interpretaban 'Area Paterniani'.</li>
                     </ul>
-                    
+
                     <p style="text-align:center;">
                         <a href="/personajes/indice_personajes.html" class="back-to-link">Volver al Índice de Personajes</a>
                     </p>
@@ -301,7 +283,7 @@
 
     <footer class="footer">
         <div class="container">
-            <p>&copy; 2025 CondadoDeCastilla.com - Todos los derechos reservados.</p>
+            <p>&copy; <script>document.write(new Date().getFullYear());</script> CondadoDeCastilla.com - Todos los derechos reservados.</p>
             <p>Un proyecto para la difusión del patrimonio histórico de Cerezo de Río Tirón y el Alfoz de Cerasio y Lantarón.</p>
         </div>
     </footer>

--- a/personajes/Santos_y_Martires/san_braulio.html
+++ b/personajes/Santos_y_Martires/san_braulio.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>San Millan De La Cogolla - Condado de Castilla</title>
+    <title>San Braulio de Zaragoza - Obispos y Escritores</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -22,17 +22,17 @@
             --color-texto-principal: #2c1d12;  /* Un marrón oscuro para el texto principal */
             --color-fondo-pagina: #fdfaf6;   /* Un blanco hueso muy sutil para el fondo general */
             --color-negro-contraste: #1A1A1A;
-            --color-primario-purpura-rgb: 74, 13, 103; 
-            --transition-speed: 0.3s; 
+            --color-primario-purpura-rgb: 74, 13, 103;
+            --transition-speed: 0.3s;
         }
 
         /* --- Estilos Generales --- */
         *, *::before, *::after {
-            box-sizing: border-box; 
+            box-sizing: border-box;
         }
 
         html {
-            scroll-behavior: smooth; 
+            scroll-behavior: smooth;
         }
 
         body {
@@ -42,7 +42,7 @@
             background-color: var(--color-fondo-pagina);
             margin: 0;
             padding: 0;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         h1, h2, h3, h4, h5, h6 {
@@ -51,10 +51,10 @@
             margin-top: 1.5em;
             margin-bottom: 0.7em;
             line-height: 1.3;
-            font-weight: 700; 
+            font-weight: 700;
         }
 
-        h1 { font-size: clamp(2.2em, 5vw, 3em); text-align: center; } 
+        h1 { font-size: clamp(2.2em, 5vw, 3em); text-align: center; }
         h2 { font-size: clamp(1.8em, 4vw, 2.5em); }
         h3 { font-size: clamp(1.4em, 3vw, 2em); }
 
@@ -64,7 +64,7 @@
             transition: color var(--transition-speed) ease, outline-color var(--transition-speed) ease;
         }
 
-        a:focus-visible { 
+        a:focus-visible {
             color: var(--color-acento-amarillo);
             text-decoration: underline;
             outline: 2px solid var(--color-acento-amarillo);
@@ -79,52 +79,46 @@
             max-width: 100%;
             height: auto;
             border-radius: 8px;
-            display: block; 
+            display: block;
         }
-        
+
         .container {
-            width: 90%; 
-            max-width: 1200px; 
+            width: 90%;
+            max-width: 1200px;
             margin: 0 auto;
             padding: 20px;
         }
 
-        /* --- Barra de Navegación (simplificada para páginas de personajes) --- */
         .navbar {
             background-color: var(--color-primario-purpura);
-            padding: 0.8em 0; 
+            padding: 0.8em 0;
             box-shadow: 0 4px 10px rgba(0,0,0,0.25);
-            /* position: sticky;  Puede no ser necesario en páginas de detalle */
-            /* top: 0; */
             z-index: 1000;
         }
 
         .navbar .container {
             display: flex;
-            justify-content: space-between; /* Centrar si solo hay logo */
+            justify-content: space-between;
             align-items: center;
         }
-        
+
         .navbar .logo-text {
             font-family: "Cinzel", serif;
-            font-size: clamp(1.5em, 3vw, 1.8em); 
+            font-size: clamp(1.5em, 3vw, 1.8em);
             color: var(--color-piedra-clara);
             text-decoration: none;
-            font-weight: 900; 
+            font-weight: 900;
             transition: transform var(--transition-speed) ease;
         }
         .navbar .logo-text:hover, .navbar .logo-text:focus-visible {
             transform: scale(1.05);
             text-decoration: none;
-            outline: none; 
+            outline: none;
         }
-        /* Se omite .nav-links y .nav-toggle para la plantilla de personaje para simplificar, 
-           se puede añadir si se desea un menú completo en cada página de personaje */
 
-        /* Estilos específicos para la página del personaje y el índice */
         .page-header-personaje, .page-header-indice {
             background-color: var(--color-piedra-media);
-            background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.65), rgba(44, 29, 18, 0.8)), url("/assets/img/hero_background_mezquita_llana.jpg"); /* Placeholder, considera cambiarla */
+            background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.65), rgba(44, 29, 18, 0.8)), url("/assets/img/hero_background_mezquita_llana.jpg");
             background-size: cover;
             background-position: center;
             padding: clamp(40px, 10vh, 80px) 20px;
@@ -136,24 +130,24 @@
             color: #fff;
             text-shadow: 2px 2px 6px var(--color-negro-contraste);
         }
-        .content-section { /* Clase genérica para secciones de contenido */
+        .content-section {
             padding: clamp(30px, 6vh, 50px) 0;
         }
-        .content-wrapper { /* Contenedor para el contenido principal */
+        .content-wrapper {
             max-width: 800px;
             margin: 0 auto;
             background-color: #fff;
-            padding: 30px 40px; /* Más padding lateral */
+            padding: 30px 40px;
             border-radius: 8px;
             box-shadow: 0 5px 15px rgba(0,0,0,0.1);
         }
         .content-wrapper img.personaje-imagen-principal {
-            max-width: 300px; 
+            max-width: 300px;
             margin: 0 auto 1.5em auto;
             border: 4px solid var(--color-piedra-media);
-            border-radius: 50%; /* Imagen redonda para retratos */
+            border-radius: 50%;
             object-fit: cover;
-            height: 300px; /* Asegurar que sea cuadrada para el círculo */
+            height: 300px;
         }
         .content-wrapper h2 {
             text-align:left;
@@ -162,7 +156,7 @@
             margin-bottom: 1em;
             font-size: clamp(1.6em, 3.5vw, 2.2em);
         }
-         .content-wrapper h2::after { display:none; } 
+         .content-wrapper h2::after { display:none; }
 
         .content-wrapper p, .content-wrapper ul {
             text-align: justify;
@@ -176,12 +170,12 @@
         .content-wrapper ul li {
             margin-bottom: 0.5em;
         }
-        .back-to-link, .cta-button-personaje { /* Estilo común para botones/enlaces de acción */
+        .back-to-link, .cta-button-personaje {
             display: inline-block;
             margin-top: 2em;
             padding: 12px 25px;
             background-color: var(--color-secundario-dorado);
-            color: var(--color-primario-purpura) !important; /* Forzar color de texto */
+            color: var(--color-primario-purpura) !important;
             border-radius: 25px;
             font-family: "Cinzel", serif;
             font-weight: bold;
@@ -192,37 +186,34 @@
         }
         .back-to-link:hover, .cta-button-personaje:hover {
             background-color: var(--color-primario-purpura);
-            color: var(--color-acento-amarillo) !important; /* Forzar color de texto */
+            color: var(--color-acento-amarillo) !important;
             text-decoration: none;
             transform: translateY(-2px);
         }
-        
-        /* Estilos para el índice de personajes */
+
         .indice-categorias li {
-            list-style-type: none; /* Quitar viñetas de la lista principal de categorías */
+            list-style-type: none;
             margin-bottom: 1.5em;
         }
-        .indice-categorias h3 { /* Título de categoría en el índice */
+        .indice-categorias h3 {
             font-size: clamp(1.3em, 2.8vw, 1.7em);
             border-left: none;
             padding-left: 0;
             margin-bottom: 0.5em;
         }
-        .indice-personajes-lista { /* Lista de personajes dentro de una categoría */
-            list-style: disc; /* Viñetas para los personajes */
+        .indice-personajes-lista {
+            list-style: disc;
             padding-left: 30px;
         }
         .indice-personajes-lista li a {
             font-size: clamp(1em, 2vw, 1.1em);
         }
 
-
-        /* --- Footer --- */
         .footer {
-            background-color: var(--color-texto-principal); 
+            background-color: var(--color-texto-principal);
             color: var(--color-piedra-clara);
             text-align: center;
-            padding: 40px 20px; 
+            padding: 40px 20px;
             margin-top: 50px;
             border-top: 6px solid var(--color-secundario-dorado);
         }
@@ -234,7 +225,7 @@
             margin: 0.6em 0;
             font-size: clamp(0.9em, 1.8vw, 1em);
         }
-        .footer a { 
+        .footer a {
             color: var(--color-acento-amarillo);
         }
         .footer a:focus-visible {
@@ -255,7 +246,7 @@
 
     <header class="page-header-personaje">
         <div class="container">
-            <h1>San Millán de la Cogolla</h1>
+            <h1>San Braulio de Zaragoza</h1>
         </div>
     </header>
 
@@ -263,34 +254,27 @@
         <section class="content-section">
             <div class="container">
                 <div class="content-wrapper">
-                    <img src="/assets/img/placeholder.jpg" alt="Retrato o imagen de San Millán de la Cogolla" class="personaje-imagen-principal" onerror="this.style.display='none'">
-                    <h2>Biografía y Relevancia</h2>
+                    <img src="/assets/img/placeholder.jpg" alt="Retrato o imagen de San Braulio" class="personaje-imagen-principal">
+                    <h2>Biografía y Relevancia Histórica</h2>
                     <p>
-                        San Millán de la Cogolla (Berceo, 473 - Monasterio de Suso, 574) fue un ermitaño, anacoreta y luego cenobita visigodo, considerado santo y patrón de Castilla y La Rioja. Su vida transcurrió principalmente en la Sierra de la Demanda.
+                        San Braulio (c. 590 – c. 651) fue una figura eclesiástica e intelectual prominente en la Hispania visigoda. Obispo de Zaragoza desde aproximadamente el 631 hasta su muerte, fue un prolífico escritor, consejero de reyes visigodos y una figura central en la cultura de su tiempo. Mantuvo correspondencia con importantes personalidades y participó activamente en los Concilios de Toledo. Su obra más conocida es la 'Vida de San Millán de la Cogolla', un texto hagiográfico fundamental para la historia del cristianismo primitivo en la península.
                     </p>
+
+                    <h3>Menciones en "nuevo4.md"</h3>
                     <p>
-                        Su figura es fundamental para entender la espiritualidad altomedieval en la península ibérica y su legado perdura a través de los monasterios de Suso y Yuso, declarados Patrimonio de la Humanidad. Es también conocido por ser el lugar donde se encuentran las Glosas Emilianenses, uno de los primeros testimonios escritos del romance hispánico.
-                    </p>
-                    
-                    <h3>Información Adicional de <code>nuevo4.md</code></h3>
-                    <p>
-                        Según el documento <code>nuevo4.md</code>, San Millán fue bautizado por el Obispo de Oca. También se narra, a través de San Braulio, que fue testigo de la destrucción de Civitate Auca Patricia. El Becerro Galicano de San Millán de la Cogolla es citado como una fuente clave que contendría la primera mención de 'Castilla' vinculada a Auca Patricia. La vida de San Millán, escrita por San Braulio, es referenciada en relación con las acciones del rey Leovigildo en Cantabria (Auca) y la profecía sobre un personaje llamado Abundancio.
+                        El documento <code>nuevo4.md</code> recurre a la 'Vida de San Millán de la Cogolla', escrita por San Braulio, como una fuente histórica clave. Específicamente, se cita su obra para relatar la destrucción de Auca Patricia (identificada como la capital de Cantabria y asociada con Cerezo de Río Tirón) por el rey visigodo Leovigildo. Según <code>nuevo4.md</code>, San Braulio detalló que Leovigildo dejó solo tres torres en pie en Auca, un hecho que el documento vincula con el diseño del Pendón de Castilla. También se hace referencia a San Braulio al narrar la historia de Abundancio, quien dudó de una profecía de San Millán sobre esta destrucción y fue posteriormente ejecutado por Leovigildo.
                     </p>
 
                     <h3>Hitos Importantes</h3>
                     <ul>
-                        <li>Considerado Santo, Monje, Ermitaño y Patrón de Castilla y La Rioja.</li>
-                        <li>Vivió como anacoreta en las cuevas de la Sierra de la Demanda.</li>
-                        <li>Fundador del Monasterio de Suso, origen del complejo monástico de San Millán de la Cogolla.</li>
-                        <li>Su vida fue escrita por San Braulio, obispo de Zaragoza.</li>
-                        <li>Los monasterios de Suso y Yuso son Patrimonio de la Humanidad por la UNESCO.</li>
-                        <li>En el Monasterio de Suso se encontraron las Glosas Emilianenses.</li>
-                        <li>Bautizado por el Obispo de Oca (según <code>nuevo4.md</code>).</li>
-                        <li>Testigo de la destrucción de Civitate Auca Patricia (narrado por San Braulio, según <code>nuevo4.md</code>).</li>
-                        <li>El Becerro Galicano de San Millán de la Cogolla es una fuente clave que vincularía 'Castilla' con Auca Patricia (según <code>nuevo4.md</code>).</li>
-                        <li>Su biografía por San Braulio es referencia para eventos relacionados con Leovigildo en Cantabria/Auca (según <code>nuevo4.md</code>).</li>
+                        <li>Obispo de Zaragoza en el siglo VII (c. 631-651).</li>
+                        <li>Destacado intelectual y escritor de la Hispania visigoda.</li>
+                        <li>Autor de la 'Vida de San Millán de la Cogolla'.</li>
+                        <li>Según <code>nuevo4.md</code>, su obra es fuente para la conquista y destrucción de Auca Patricia/Cantabria por Leovigildo.</li>
+                        <li>Citado en <code>nuevo4.md</code> por el detalle de las tres torres que quedaron en Auca tras la destrucción por Leovigildo (vinculadas al Pendón de Castilla).</li>
+                        <li>Referenciado en <code>nuevo4.md</code> al contar la historia de Abundancio, su escepticismo ante la profecía de San Millán y su posterior muerte a manos de Leovigildo.</li>
                     </ul>
-                    
+
                     <p style="text-align:center;">
                         <a href="/personajes/indice_personajes.html" class="back-to-link">Volver al Índice de Personajes</a>
                     </p>
@@ -301,7 +285,7 @@
 
     <footer class="footer">
         <div class="container">
-            <p>&copy; 2025 CondadoDeCastilla.com - Todos los derechos reservados.</p>
+            <p>&copy; <script>document.write(new Date().getFullYear());</script> CondadoDeCastilla.com - Todos los derechos reservados.</p>
             <p>Un proyecto para la difusión del patrimonio histórico de Cerezo de Río Tirón y el Alfoz de Cerasio y Lantarón.</p>
         </div>
     </footer>

--- a/personajes/indice_personajes.html
+++ b/personajes/indice_personajes.html
@@ -60,13 +60,14 @@
                     <li>
                         <h3><i class="fas fa-cross"></i> Santos y Mártires</h3>
                         <ul class="indice-personajes-lista" id="santos-lista">
-                            <li><a href="/personajes/Santos_y_Martires/san_formerio.html">San Formerio</a></li>
-                            <li><a href="/personajes/Santos_y_Martires/san_vitores.html">San Vitores</a></li>
-                            <li><a href="/personajes/Santos_y_Martires/san_millan_de_la_cogolla.html">San Millán de la Cogolla</a></li>
-                            <li><a href="/personajes/Santos_y_Martires/obispo_indalecio.html">Obispo Indalecio</a></li>
-                            <li><a href="/personajes/Santos_y_Martires/obispo_sancho.html">Obispo Sancho</a></li>
                             <li><a href="/personajes/Santos_y_Martires/abades_sonna_donnino_damian.html">Abades Sonna, Donnino y Damián</a></li>
                             <li><a href="/personajes/Santos_y_Martires/obispos_gudesteos_frunimio.html">Obispos Gudesteos y Frunimio</a></li>
+                            <li><a href="/personajes/Santos_y_Martires/obispo_indalecio.html">Obispo Indalecio</a></li>
+                            <li><a href="/personajes/Santos_y_Martires/obispo_sancho.html">Obispo Sancho</a></li>
+                            <li><a href="/personajes/Santos_y_Martires/san_braulio.html">San Braulio</a></li>
+                            <li><a href="/personajes/Santos_y_Martires/san_formerio.html">San Formerio</a></li>
+                            <li><a href="/personajes/Santos_y_Martires/san_millan_de_la_cogolla.html">San Millán de la Cogolla</a></li>
+                            <li><a href="/personajes/Santos_y_Martires/san_vitores.html">San Vitores</a></li>
                         </ul>
                     </li>
                     <li>
@@ -85,6 +86,19 @@
                         <ul class="indice-personajes-lista" id="ordenes-lista">
                             <li><a href="/personajes/Ordenes_y_Legados/monjes_hospitalarios_san_jorge_y_san_anton.html">Monjes Hospitalarios de San Jorge y San Antón</a></li>
                             <li><a href="/personajes/Ordenes_y_Legados/paterna_banucasi.html">Paterna (Banucasi)</a></li>
+                        </ul>
+                    </li>
+                    <li>
+                        <h3><i class="fas fa-crown"></i> Reyes y Reinas</h3>
+                        <ul class="indice-personajes-lista" id="reyes-lista">
+                            <li><a href="/personajes/Reyes_y_Reinas/alfonso_ii_el_casto.html">Alfonso II el Casto</a></li>
+                            <li><a href="/personajes/Reyes_y_Reinas/leovigildo.html">Leovigildo</a></li>
+                        </ul>
+                    </li>
+                    <li>
+                        <h3><i class="fas fa-pen-nib"></i> Escritores y Cronistas</h3>
+                        <ul class="indice-personajes-lista" id="escritores-lista">
+                            <li><a href="/personajes/Escritores_y_Cronistas/fray_prudencio_de_sandoval.html">Fray Prudencio de Sandoval</a></li>
                         </ul>
                     </li>
                     <li>

--- a/personajes_nuevo4_batch4.json
+++ b/personajes_nuevo4_batch4.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "San Millán de la Cogolla",
+    "era": "Visigothic / Early Medieval",
+    "status": "Santo, Monje, Ermitaño, Patrón de Castilla y La Rioja",
+    "description": "Baptized by the Bishop of Oca, according to `nuevo4.md`. Witnessed the destruction of Civitate Auca Patricia, as narrated by San Braulio. The Becerro Galicano de San Millán de la Cogolla is a key source repeatedly cited, said to contain the first mention of 'Castilla' linked to Auca Patricia. His life, written by San Braulio, is referenced for Leovigildo's actions in Cantabria (Auca) and the prophecy about Abundancio."
+  },
+  {
+    "name": "Fray Prudencio de Sandoval",
+    "era": "Early Modern (16th-17th Century)",
+    "status": "Cronista, Obispo de Pamplona, Monje de San Millán",
+    "description": "Author of 'Historias de Idacio obispo...' (original title) / 'Historia de cinco obispos' (Pamplona, 1615). Frequently cited in `nuevo4.md` for his interpretations of the Becerro Galicano, especially regarding Auca Patricia as the origin of Castilla, its founding by Augustus, and its episcopal status. `nuevo4.md` often aligns with his views, such as reading 'Auca Patricia' instead of 'Area Paterniani' in the Becerro."
+  },
+  {
+    "name": "Leovigildo",
+    "era": "Visigothic (6th Century)",
+    "status": "Rey Godo",
+    "description": "According to `nuevo4.md` (citing San Braulio), he conquered Auca Patricia (capital of Cantabria) in 574, destroying its walls and towers but leaving three standing (linked to the Pendón de Castilla). Also mentioned for executing Abundancio after the prophecy of San Millán about Cantabria's destruction."
+  },
+  {
+    "name": "San Braulio",
+    "era": "Visigothic (7th Century)",
+    "status": "Obispo de Zaragoza, Escritor",
+    "description": "Author of 'Vida de San Millán de la Cogolla'. His work is cited in `nuevo4.md` as a source for Leovigildo's destruction of Auca Patricia/Cantabria, the detail about three towers remaining, and the story of Abundancio's disbelief and subsequent death at Leovigildo's hand."
+  },
+  {
+    "name": "Alfonso II el Casto",
+    "era": "Astur (c. 791-842)",
+    "status": "Rey, Creador del Camino de Santiago",
+    "description": "Referred to in `nuevo4.md` as the 'creador del Camino de Santiago'. The text states he conquered the Auca area. His son Ramiro I's marriage to Paterna (from Cerasio/Castilla) and their founding of the Hospital de San Jorge in Cerasio are linked to his era. The Crónica Albeldense is cited stating Alfonso II was exiled to Cerezo. Also associated with establishing the Bishopric of Valpuesta (804) as a successor to Auca."
+  }
+]


### PR DESCRIPTION
This commit introduces a fourth batch of character pages and updates based on analysis of the `contexto/nuevo4.md` document.

Key changes:
- Created 4 new character HTML pages:
    - `personajes/Escritores_y_Cronistas/fray_prudencio_de_sandoval.html`
    - `personajes/Reyes_y_Reinas/leovigildo.html`
    - `personajes/Santos_y_Martires/san_braulio.html`
    - `personajes/Reyes_y_Reinas/alfonso_ii_el_casto.html`
- Updated 1 existing character page:
    - `personajes/Santos_y_Martires/san_millan_de_la_cogolla.html` The updates involve appending information from `nuevo4.md` (via `personajes_nuevo4_batch4.json`) to their biography and milestones sections.
- Updated `personajes/indice_personajes.html`:
    - Added links to the new character pages.
    - Introduced new categories "Reyes y Reinas" and "Escritores y Cronistas" to better organize the index.

This work further populates the character section of the site with details derived from the extensive research in `contexto/nuevo4.md`.