### PR TITLE
feat: Convertir Atapuerca a PHP e introducir demo de Resumen Inteligente

### DIFF
--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -1,0 +1,90 @@
+<?php
+if (session_status() == PHP_SESSION_NONE) {
+    // Usar session_start() solo si no hay una sesión activa.
+    // Es preferible no usar @ para suprimir errores aquí.
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+         session_start();
+    }
+}
+// Asumimos que db_connect.php establece $pdo
+require_once __DIR__ . '/../dashboard/db_connect.php';
+// text_manager.php incluye auth.php, así que $is_admin estará disponible indirectamente.
+require_once __DIR__ . '/../includes/text_manager.php';
+require_once __DIR__ . '/../includes/ai_utils.php';
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Atapuerca</title>
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+</head>
+<body>
+<?php require_once __DIR__ . '/../_header.html'; ?>
+    <header class="page-header hero" style="background-image: linear-gradient(rgba(0,0,0, 0.5), rgba(0,0,0, 0.5)), url('../assets/img/placeholder.jpg');"> <!-- Basic hero style -->
+        <div class="hero-content">
+            <h1><?php editableText('atapuerca_titulo_hero', $pdo, 'Los Yacimientos de la Sierra de Atapuerca'); ?></h1>
+        </div>
+    </header>
+    <main>
+        <section class="section alternate-bg">
+            <div class="container">
+                <h2 class="section-title"><?php editableText('atapuerca_titulo_seccion', $pdo, 'Un Tesoro de la Prehistoria'); ?></h2>
+                <p class="timeline-intro"><?php editableText('atapuerca_intro_p1', $pdo, 'La Sierra de Atapuerca, ubicada al norte de Ibeas de Juarros en la provincia de Burgos, es un enclave montañoso de modesta altitud que alberga un extraordinario conjunto de yacimientos arqueológicos y paleontológicos. Reconocida como Patrimonio de la Humanidad por la UNESCO, Espacio de Interés Natural y Bien de Interés Cultural, Atapuerca ha proporcionado al mundo testimonios fósiles de al menos cinco especies distintas de homínidos, arrojando luz invaluable sobre la evolución humana en Europa.'); ?></p>
+
+                <article class="content-article"> <!-- Using a generic class for content styling -->
+                    <div id="textoPrincipalAtapuerca">
+                        <h3><?php editableText('atapuerca_ctx_geo_titulo', $pdo, 'Contexto Geográfico y Geológico'); ?></h3>
+                        <p><?php editableText('atapuerca_ctx_geo_p1', $pdo, 'La sierra forma parte del "corredor de la Bureba", un paso histórico entre el valle del Ebro y la cuenca del Duero. Su formación se basa en calizas del Cretácico Superior (hace entre 80 y 100 millones de años). La acción fluvial y la naturaleza calcárea del terreno han originado un complejo sistema kárstico, con numerosas cuevas que, al colmatarse y sellarse, han preservado los restos durante milenios. La construcción de una línea de ferrocarril en el siglo XIX fue lo que inicialmente sacó a la luz estos importantes yacimientos.'); ?></p>
+
+                        <h3><?php editableText('atapuerca_yacimientos_titulo', $pdo, 'Principales Yacimientos y Descubrimientos Clave'); ?></h3>
+                    <p><?php editableText('atapuerca_yacimientos_p1', $pdo, 'Entre la multitud de cuevas y simas, destacan varias por la trascendencia de sus hallazgos:'); ?></p>
+                    <ul>
+                        <li><strong>Sima del Elefante:</strong><?php editableText('atapuerca_yac_sima_elefante', $pdo, 'Aquí se han encontrado restos de Homo sp. (probablemente una forma temprana de Homo erectus), con una antigüedad que ronda los 1.2 millones de años, representando algunos de los homínidos más antiguos de Europa.'); ?></li>
+                        <li><strong>Gran Dolina (Estrato TD6):</strong><?php editableText('atapuerca_yac_gran_dolina', $pdo, 'Este yacimiento es famoso por el descubrimiento de Homo antecessor, una especie datada en al menos 800,000 años. Este hallazgo fue crucial para proponer una nueva especie de homínido, posiblemente ancestro común de neandertales y humanos modernos.'); ?></li>
+                        <li><strong>Sima de los Huesos:</strong><?php editableText('atapuerca_yac_sima_huesos', $pdo, 'Un caso excepcional en el registro fósil mundial, esta sima ha proporcionado miles de fósiles pertenecientes a la especie Homo heidelbergensis. Entre ellos se encuentra el famoso Cráneo número 5, "Miguelón". Estos restos datan de hace unos 430,000 años y han permitido estudiar en detalle una población entera de homínidos.'); ?></li>
+                    </ul>
+                    <p><?php editableText('atapuerca_yacimientos_p2', $pdo, 'Además de estas especies, en Atapuerca también se ha documentado la presencia de Homo neanderthalensis y de nuestra propia especie, Homo sapiens, lo que demuestra una ocupación continuada del territorio a lo largo de la prehistoria.'); ?></p>
+
+                        <h3><?php editableText('atapuerca_importancia_titulo', $pdo, 'Importancia Singular de Atapuerca'); ?></h3>
+                        <p><?php editableText('atapuerca_importancia_p1', $pdo, 'La Sierra de Atapuerca no es solo un conjunto de cuevas con fósiles; es una ventana directa a la vida de nuestros antepasados. La increíble concentración de restos en buen estado de conservación, abarcando un periodo tan extenso (desde el Pleistoceno Inferior hasta el Holoceno), la convierten en un referente mundial para el estudio de la evolución humana. Los hallazgos han permitido comprender mejor las estrategias de caza, la tecnología lítica, las características físicas e incluso posibles prácticas rituales de las distintas especies de homínidos que habitaron esta sierra.'); ?></p>
+                    </div>
+                </article>
+                <div style="text-align: center; margin-top: 30px; margin-bottom: 30px;"> <!-- Contenedor para centrar el botón -->
+                    <button id="btnResumenIA" class="cta-button" style="padding: 12px 25px; font-size: 1.1em;">Ver Resumen Inteligente</button>
+                </div>
+                <div id="resumenIAContenedor" style="display:none; margin-top:20px; padding:20px; border:1px solid #ddd; border-radius: 5px; background-color: #f9f9f9; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                    <!-- El resumen generado por IA se insertará aquí -->
+                </div>
+            </div>
+        </section>
+    </main>
+<?php require_once __DIR__ . '/../_footer.html'; ?>
+    <script src="/js/layout.js"></script>
+        <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const btnResumen = document.getElementById('btnResumenIA');
+            const resumenContenedor = document.getElementById('resumenIAContenedor');
+
+            if (btnResumen && resumenContenedor) {
+                btnResumen.addEventListener('click', function() {
+                    // Para esta demostración, obtenemos un resumen de placeholder generado por PHP.
+                    // En una implementación real, aquí podría haber una llamada AJAX
+                    // o se podría haber extraído el texto de 'textoPrincipalAtapuerca'
+                    // y enviado a una función de resumen.
+
+                    // Generamos el resumen placeholder directamente con PHP e imprimimos como string JS.
+                    // Usamos una clave genérica ya que no estamos pasando el texto completo aquí.
+                    const resumenHtml = <?php echo json_encode(get_smart_summary_placeholder('Contenido de Atapuerca')); ?>;
+
+                    resumenContenedor.innerHTML = resumenHtml;
+                    resumenContenedor.style.display = 'block';
+                    // Opcional: Desplazar la vista al resumen
+                    // resumenContenedor.scrollIntoView({ behavior: 'smooth' });
+                });
+            }
+        });
+        </script>
+</body>
+</html>

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -1,0 +1,33 @@
+<?php
+// includes/ai_utils.php
+
+if (!defined('AI_UTILS_LOADED')) {
+    define('AI_UTILS_LOADED', true);
+}
+
+/**
+ * Placeholder para una función que generaría un resumen inteligente.
+ * En una implementación real, esto podría llamar a una API de IA,
+ * procesar el texto localmente con un modelo, etc.
+ *
+ * @param string $content_key Un identificador para el contenido a resumir,
+ *                            o potencialmente el texto completo si es corto.
+ * @param string $full_text (Opcional) El texto completo a resumir.
+ * @return string El resumen generado (o un placeholder).
+ */
+function get_smart_summary_placeholder(string $content_key, string $full_text = ''): string {
+    // Simulación de procesamiento
+    $summary = "Resumen inteligente para '" . htmlspecialchars($content_key) . "': ";
+
+    if (!empty($full_text)) {
+        // Tomar las primeras ~250 caracteres como un resumen muy básico si se proporciona el texto completo.
+        // strip_tags para evitar problemas si el contenido tiene HTML.
+        $summary .= substr(strip_tags($full_text), 0, 250) . "...";
+    } else {
+        $summary .= "Este es un resumen de demostración generado por IA. En el futuro, aquí aparecería un extracto conciso y relevante del contenido principal, procesado por un modelo de lenguaje avanzado para destacar los puntos clave de la sección sobre " . htmlspecialchars($content_key) . ".";
+    }
+
+    return "<p><strong>" . $summary . "</strong></p><p><em>(Funcionalidad de resumen real con IA pendiente de implementación completa).</em></p>";
+}
+
+?>


### PR DESCRIPTION
Este commit implementa dos mejoras principales:

1.  Conversión de `historia/atapuerca.html` a `historia/atapuerca.php`:
    *   La página ahora utiliza inclusiones PHP (`require_once`) para la cabecera (`_header.html`) y el pie de página (`_footer.html`), alineándose con la refactorización previamente realizada en otras secciones del sitio.
    *   El contenido textual principal de la página de Atapuerca se ha hecho editable a través del sistema `text_manager.php` (función `editableText`), permitiendo su gestión desde el panel de administración.
    *   Se ha mantenido la carga de `layout.js` para la funcionalidad de la barra lateral y otros efectos.

2.  Introducción de la funcionalidad "Resumen Inteligente" (Placeholder) en `atapuerca.php`:
    *   Se ha añadido un botón "Ver Resumen Inteligente" y un contenedor para mostrar el resumen.
    *   Se ha creado un nuevo archivo `includes/ai_utils.php` que contiene una función placeholder `get_smart_summary_placeholder()`. Esta función simula la generación de un resumen.
    *   Un script JavaScript en `atapuerca.php` maneja el clic del botón y muestra el resumen de demostración generado por la función placeholder.
    *   Esto sienta las bases para una futura integración de un sistema de IA real para la generación de resúmenes.

Todas las funcionalidades implementadas han sido probadas, incluyendo la correcta carga de la página, la visibilidad de los elementos de resumen, y la funcionalidad de edición de textos (simulada como admin). No se identificaron problemas de assets rotos.