### PR TITLE
feat: Introducir demo de Etiquetas Sugeridas por IA en Atapuerca

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -677,6 +677,43 @@ body.sidebar-active {
     outline: none;
 }
 
+/* --- Estilos para Etiquetas Sugeridas por IA --- */
+.tags-sugeridos-ia {
+    /* El contenedor tiene estilos inline para margen y borde superior.
+       El text-align:center se aplica a sus hijos a través de #listaTagsIA y el h4. */
+}
+
+.lista-tags-ia {
+    /* El text-align:center ya está aplicado inline. */
+    /* Se añade flexbox para mejor espaciado y envoltura de etiquetas. */
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px; /* Espacio horizontal y vertical entre etiquetas */
+    margin-top: 10px; /* Espacio después del título h4 de la sección */
+}
+
+.tag-ia {
+    display: inline-block; /* Comportamiento natural para spans, pero explícito */
+    background-color: var(--epic-alabaster-medium);
+    color: var(--epic-purple-emperor);
+    padding: 6px 12px;
+    border-radius: 15px; /* Estilo píldora */
+    font-size: 0.9em;
+    font-family: var(--font-primary);
+    border: 1px solid var(--epic-gold-secondary);
+    transition: background-color 0.3s ease, color 0.3s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    text-decoration: none; /* En caso de que se conviertan en enlaces */
+    margin-bottom: 4px; /* Para el caso de wrap, asegurar un pequeño espacio vertical extra si gap no es suficiente */
+}
+
+.tag-ia:hover {
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+    transform: translateY(-1px); /* Ligero efecto de elevación */
+    box-shadow: 0 2px 5px rgba(var(--epic-text-color-rgb), 0.15);
+}
+
 /* --- View Switcher Buttons --- */
 .view-switch-controls {
     /* Using .container class for width management if needed, or text-align: center; directly */

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -57,6 +57,26 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                 <div id="resumenIAContenedor" style="display:none; margin-top:20px; padding:20px; border:1px solid #ddd; border-radius: 5px; background-color: #f9f9f9; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
                     <!-- El resumen generado por IA se insertará aquí -->
                 </div>
+                <div id="tagsSugeridosIA" class="tags-sugeridos-ia" style="margin-top: 30px; padding-top: 20px; border-top: 1px dashed #ccc;">
+                    <h4 style="font-family: 'Cinzel', serif; color: var(--epic-purple-emperor); margin-bottom: 15px; text-align:center;">Etiquetas Sugeridas por IA:</h4>
+                    <div id="listaTagsIA" class="lista-tags-ia" style="text-align:center;">
+                        <?php
+                        if (function_exists('get_suggested_tags_placeholder')) {
+                            $suggested_tags = get_suggested_tags_placeholder('atapuerca');
+                            if (!empty($suggested_tags)) {
+                                foreach ($suggested_tags as $tag) {
+                                    echo '<span class="tag-ia">' . htmlspecialchars($tag) . '</span> ';
+                                }
+                            } else {
+                                echo '<p>No hay sugerencias de etiquetas por el momento.</p>';
+                            }
+                        } else {
+                            // Esto no debería ocurrir si ai_utils.php se incluyó correctamente.
+                            echo '<p>Error: La función de sugerencia de etiquetas no está disponible.</p>';
+                        }
+                        ?>
+                    </div>
+                </div>
             </div>
         </section>
     </main>

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -30,4 +30,20 @@ function get_smart_summary_placeholder(string $content_key, string $full_text = 
     return "<p><strong>" . $summary . "</strong></p><p><em>(Funcionalidad de resumen real con IA pendiente de implementación completa).</em></p>";
 }
 
+/**
+ * Placeholder para una función que generaría etiquetas sugeridas por IA.
+ *
+ * @param string $content_key Un identificador para el contenido a etiquetar.
+ * @return array Un array de strings con las etiquetas sugeridas.
+ */
+function get_suggested_tags_placeholder(string $content_key): array {
+    // Simulación basada en content_key
+    if ($content_key === 'atapuerca' || $content_key === 'Contenido de Atapuerca') {
+        return ['Prehistoria', 'Evolución Humana', 'Arqueología', 'Yacimientos UNESCO', 'Homo Antecessor', 'Burgos', 'Paleontología'];
+    }
+
+    // Etiquetas por defecto para otros contenidos no especificados
+    return ['General', 'Contenido Interesante', 'Historia', 'Web'];
+}
+
 ?>


### PR DESCRIPTION
Este commit añade una funcionalidad de demostración para "Etiquetas Sugeridas por IA" en la página `historia/atapuerca.php`.

Cambios Principales:

1.  Interfaz en `atapuerca.php`:
    *   He añadido una nueva sección titulada "Etiquetas Sugeridas por IA:" debajo de la funcionalidad de resumen inteligente.
    *   Esta sección está diseñada para mostrar etiquetas de contenido generadas (en esta fase, simuladas).

2.  Lógica de Placeholder en `ai_utils.php`:
    *   He añadido una nueva función `get_suggested_tags_placeholder(string $content_key): array` al archivo `includes/ai_utils.php`.
    *   Esta función devuelve un conjunto predefinido de etiquetas de demostración para el contenido de "Atapuerca" y etiquetas genéricas para otros casos.

3.  Integración en `atapuerca.php`:
    *   La página ahora llama a `get_suggested_tags_placeholder()` y muestra dinámicamente las etiquetas devueltas.
    *   Cada etiqueta se presenta dentro de un `<span>` con la clase `tag-ia`.

4.  Estilos CSS para Etiquetas:
    *   He añadido nuevas reglas a `assets/css/epic_theme.css` para estilizar las etiquetas sugeridas (`.tag-ia`) y su contenedor (`.lista-tags-ia`). Esto incluye una apariencia de "píldora", espaciado y efectos hover básicos.

Esta funcionalidad sirve como un prototipo conceptual, sentando las bases para una futura integración con un sistema de IA real capaz de analizar el contenido de la página y generar etiquetas relevantes automáticamente.

Todas las pruebas que realicé en `historia/atapuerca.php` han sido exitosas, confirmando que la nueva sección se muestra correctamente sin afectar las funcionalidades existentes.