### PR TITLE
feat: Introducir demo de Traducción Inteligente en Atapuerca

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -677,6 +677,54 @@ body.sidebar-active {
     outline: none;
 }
 
+/* --- Estilos para Selector de Idioma (Demostración) --- */
+#languageSelectorContainer {
+    /* El contenedor ya tiene estilos inline para margen, padding-bottom y border-bottom.
+       El text-align:center también está inline. */
+}
+
+#languageSelectorContainer h4 {
+    /* El h4 ya tiene estilos inline y usa variables del tema. */
+}
+
+.lang-btn {
+    background-color: var(--epic-alabaster-medium);
+    color: var(--epic-purple-emperor);
+    border: 1px solid var(--epic-gold-secondary);
+    padding: 8px 15px;
+    margin: 0 5px 5px 5px; /* Añadido margen inferior para posible envoltura */
+    border-radius: 20px;
+    cursor: pointer;
+    font-family: var(--font-primary);
+    font-size: 0.9em;
+    font-weight: 600; /* Un poco más de peso */
+    transition: background-color 0.3s ease, color 0.3s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    text-decoration: none;
+}
+
+.lang-btn:hover {
+    background-color: var(--epic-gold-secondary);
+    color: var(--epic-alabaster-bg);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(var(--epic-text-color-rgb), 0.1);
+}
+
+.lang-btn.active {
+    background-color: var(--epic-purple-emperor);
+    color: var(--epic-gold-main);
+    font-weight: bold; /* Más destacado */
+    border-color: var(--epic-gold-main);
+    box-shadow: inset 0 2px 4px rgba(0,0,0,0.25); /* Sombra interior para efecto presionado */
+    transform: none;
+}
+
+.lang-btn.active:hover {
+    background-color: var(--epic-purple-emperor);
+    color: var(--epic-gold-main);
+    /* Mantener el efecto de sombra interior, pero se podría añadir un sutil brillo exterior si se desea */
+    box-shadow: inset 0 2px 4px rgba(0,0,0,0.25), 0 0 8px rgba(var(--epic-gold-main-rgb), 0.4);
+}
+
 /* --- Estilos para Etiquetas Sugeridas por IA --- */
 .tags-sugeridos-ia {
     /* El contenedor tiene estilos inline para margen y borde superior.

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -33,6 +33,12 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                 <h2 class="section-title"><?php editableText('atapuerca_titulo_seccion', $pdo, 'Un Tesoro de la Prehistoria'); ?></h2>
                 <p class="timeline-intro"><?php editableText('atapuerca_intro_p1', $pdo, 'La Sierra de Atapuerca, ubicada al norte de Ibeas de Juarros en la provincia de Burgos, es un enclave montañoso de modesta altitud que alberga un extraordinario conjunto de yacimientos arqueológicos y paleontológicos. Reconocida como Patrimonio de la Humanidad por la UNESCO, Espacio de Interés Natural y Bien de Interés Cultural, Atapuerca ha proporcionado al mundo testimonios fósiles de al menos cinco especies distintas de homínidos, arrojando luz invaluable sobre la evolución humana en Europa.'); ?></p>
 
+                <div id="languageSelectorContainer" style="margin-bottom: 25px; padding-bottom: 20px; border-bottom: 1px dashed #ccc; text-align: center;">
+                    <h4 style="font-family: 'Cinzel', serif; color: var(--epic-purple-emperor); margin-bottom: 10px;">Seleccionar Idioma (Demostración):</h4>
+                    <button class="lang-btn active" data-lang="es" title="Ver contenido en Español (original)">Español (Original)</button>
+                    <button class="lang-btn" data-lang="en-ai" title="Simular traducción al Inglés por IA">Inglés (Traducción IA)</button>
+                    <button class="lang-btn" data-lang="fr-ai" title="Simular traducción al Francés por IA">Francés (Traducción IA)</button>
+                </div>
                 <article class="content-article"> <!-- Using a generic class for content styling -->
                     <div id="textoPrincipalAtapuerca">
                         <h3><?php editableText('atapuerca_ctx_geo_titulo', $pdo, 'Contexto Geográfico y Geológico'); ?></h3>
@@ -106,5 +112,49 @@ require_once __DIR__ . '/../includes/ai_utils.php';
             }
         });
         </script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const langButtons = document.querySelectorAll('.lang-btn');
+        const contentContainer = document.getElementById('textoPrincipalAtapuerca');
+        const originalContentHTML = contentContainer ? contentContainer.innerHTML : ''; // Guardar el contenido HTML original
+
+        // Preparar los textos de placeholder para cada idioma usando PHP
+        // Esto se hace una vez al cargar la página para tenerlos listos en JS
+        <?php
+            // Asegurarse de que la función existe antes de llamarla
+            $translation_placeholders = [];
+            if (function_exists('get_simulated_translation_placeholder')) {
+                // Para la demostración, no necesitamos pasar el texto original completo aquí,
+                // la función get_simulated_translation_placeholder ya tiene una lógica de snippet.
+                // Usaremos un content_id genérico para Atapuerca.
+                $original_text_snippet_for_demo = "Contenido original de la página de Atapuerca..."; // Un snippet muy corto o incluso vacío
+                $translation_placeholders['en-ai'] = get_simulated_translation_placeholder('atapuerca_main_content', 'en-ai', $original_text_snippet_for_demo);
+                $translation_placeholders['fr-ai'] = get_simulated_translation_placeholder('atapuerca_main_content', 'fr-ai', $original_text_snippet_for_demo);
+            }
+        ?>
+        const translations = <?php echo json_encode($translation_placeholders); ?>;
+
+        if (contentContainer && langButtons.length > 0) {
+            langButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    // Gestionar clase activa
+                    langButtons.forEach(btn => btn.classList.remove('active'));
+                    this.classList.add('active');
+
+                    const targetLang = this.getAttribute('data-lang');
+
+                    if (targetLang === 'es') {
+                        contentContainer.innerHTML = originalContentHTML;
+                    } else if (translations[targetLang]) {
+                        contentContainer.innerHTML = translations[targetLang];
+                    } else {
+                        // Fallback si algo va mal (ej. idioma no definido en placeholders)
+                        contentContainer.innerHTML = "<p>Traducción de demostración no disponible para este idioma.</p>";
+                    }
+                });
+            });
+        }
+    });
+    </script>
 </body>
 </html>

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -46,4 +46,41 @@ function get_suggested_tags_placeholder(string $content_key): array {
     return ['General', 'Contenido Interesante', 'Historia', 'Web'];
 }
 
+/**
+ * Placeholder para una función que simularía una traducción inteligente.
+ *
+ * @param string $content_id Identificador del contenido (ej. 'atapuerca_main_text').
+ * @param string $target_language Código del idioma objetivo (ej. 'en-ai', 'fr-ai').
+ * @param string $original_sample_text Un extracto del texto original para incluir en la demo. O el texto completo si se desea devolverlo para 'es'.
+ * @return string El texto "traducido" de demostración o el texto original si target_language es 'es'.
+ */
+function get_simulated_translation_placeholder(string $content_id, string $target_language, string $original_sample_text = ''): string {
+    if ($target_language === 'es') {
+        // Si el objetivo es español, se asume que se quiere restaurar el original.
+        // El JavaScript debería tener el contenido original completo.
+        // Esta función, si es llamada con 'es', simplemente devuelve el sample/original que se le pasó.
+        return $original_sample_text;
+    }
+
+    $original_snippet = !empty($original_sample_text) ? htmlspecialchars(substr(strip_tags($original_sample_text), 0, 70)) . "..." : "el contenido original";
+
+    $outputText = "<div style='padding:15px; background-color:#e3f2fd; border:1px solid #bbdefb; border-radius:4px; margin-top:10px;'>";
+    $outputText .= "<p style='font-size:0.9em; color:#0d47a1;'><em>Traducción IA (Demostración) para: " . htmlspecialchars($content_id) . "</em></p>";
+
+    switch ($target_language) {
+        case 'en-ai':
+            $outputText .= "<p><strong>Simulated English Translation:</strong> This demonstrates where AI-generated English text would appear. The original Spanish content started with: '<em>" . $original_snippet . "</em>'.</p>";
+            $outputText .= "<p>In a production system, the full text would be processed by an advanced neural machine translation model to provide an accurate and nuanced English version.</p>";
+            break;
+        case 'fr-ai':
+            $outputText .= "<p><strong>Traduction Française Simulée :</strong> Ceci montre où le texte français généré par l'IA apparaîtrait. Le contenu original en espagnol commençait par : '<em>" . $original_snippet . "</em>'.</p>";
+            $outputText .= "<p>Dans un système de production, le texte intégral serait traité par un modèle avancé de traduction automatique neuronale pour fournir une version française précise et nuancée.</p>";
+            break;
+        // No hay caso 'default' o 'es' aquí porque ya se manejó al inicio de la función.
+    }
+    $outputText .= "<p style='font-size:0.8em; color:#1976d2; margin-top:10px;'><em>(Esta es una simulación. La funcionalidad de traducción real con IA está pendiente de implementación).</em></p>";
+    $outputText .= "</div>";
+    return $outputText;
+}
+
 ?>


### PR DESCRIPTION
Este commit añade una funcionalidad de demostración para "Traducción Inteligente" en la página `historia/atapuerca.php`.

Cambios Principales:

1.  Interfaz de Selección de Idioma en `atapuerca.php`:
    *   He añadido una sección con botones que te permiten seleccionar un idioma de visualización (Español, Inglés IA, Francés IA) para el contenido principal de la página.
    *   Esta interfaz se encuentra antes del artículo principal.

2.  Lógica de Placeholder para Traducción Simulada en `ai_utils.php`:
    *   He añadido una nueva función `get_simulated_translation_placeholder()` al archivo `includes/ai_utils.php`.
    *   Esta función genera textos de demostración que simulan ser traducciones a inglés y francés, incluyendo un pequeño snippet del contenido original para contextualizar.

3.  Integración en `atapuerca.php`:
    *   Un script JavaScript maneja la selección de idioma.
    *   Al cargar la página, se guarda el contenido original en español del artículo.
    *   Los textos de traducción simulada para inglés y francés se preparan usando PHP y se almacenan en una variable JavaScript.
    *   Al hacer clic en un botón de idioma, el script actualiza el contenido del artículo para mostrar la "traducción" simulada correspondiente o restaura el contenido original en español.

4.  Estilos CSS para el Selector de Idioma:
    *   He añadido nuevas reglas a `assets/css/epic_theme.css` para estilizar los botones de selección de idioma (`.lang-btn`) y su estado activo (`.active`), dándoles una apariencia de grupo de selección.

Esta funcionalidad sirve como un prototipo conceptual para mostrar cómo se podría integrar un sistema de traducción asistida por IA. Las funcionalidades previas de resumen inteligente y etiquetas sugeridas en la misma página permanecen intactas.

Todas las pruebas que realicé en `historia/atapuerca.php` han sido exitosas.