### PR TITLE
Standardize text alignment in main content area

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -2552,3 +2552,24 @@ ul li, ol li { text-align: center; } // Broader rule from estilos.css
     text-decoration: none;
     outline: none;
 }
+
+/* ============================================= */
+/* == ESTANDARIZACIÓN DE ALINEACIÓN DE TEXTO == */
+/* ============================================= */
+/*
+ * Regla para centrar titulares (h1-h6) y justificar párrafos (p)
+ * dentro del contenedor principal (<main>) de cada página.
+ * Esto unifica el diseño en todo el sitio.
+*/
+main h1,
+main h2,
+main h3,
+main h4,
+main h5,
+main h6 {
+    text-align: center;
+}
+
+main p {
+    text-align: justify;
+}


### PR DESCRIPTION
This commit updates the active stylesheet `assets/css/epic_theme.css` to provide a consistent text alignment strategy within the `<main>` HTML element across the site.

The following changes were implemented:
- Headings (h1-h6) within `<main>` are now centered by default (`text-align: center;`).
- Paragraphs (`p`) within `<main>` are now justified by default (`text-align: justify;`).

This change addresses the issue of previously inconsistent text alignments (some centered, some left-aligned) and aims for a more unified, orderly, and symmetrical visual presentation, incorporating your feedback to use justified text for paragraphs.

The global `body { text-align: left; }` remains, and these new rules provide more specific styling for the main content regions. Existing more specific CSS rules (e.g., for components, helper classes with `!important`, or specific article layouts) will continue to override these new default `<main>` styles as intended.