### PR TITLE
Secure DB password via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Deployment Notes
+
+This project contains a small PHP dashboard under `dashboard/` which connects to a PostgreSQL database. For security, the database password is loaded from an environment variable.
+
+## Configuration
+
+Set the `CONDADO_DB_PASSWORD` environment variable on the server before running the dashboard. The `dashboard/db_connect.php` file reads this variable to obtain the database password.
+
+The development configuration enables PHP error display. For production deployments these settings are commented out in `db_connect.php` and should remain disabled.

--- a/dashboard/README.html
+++ b/dashboard/README.html
@@ -66,7 +66,8 @@
     $db_user = "YOUR_DB_USER";</code></li>
 <li><code>$db_pass</code>: The password for the database user.
     <code>php
-    $db_pass = "YOUR_DB_PASSWORD";</code></li>
+    $db_pass = getenv('CONDADO_DB_PASSWORD');</code> <!-- Set this environment variable on the server -->
+</li>
 <li><code>$db_port</code>: The port number your Progress database is listening on. This is often specific to your Progress setup (e.g., 2050, 5555).
     <code>php
     $db_port = "YOUR_DB_PORT"; // e.g., 2050</code></li>

--- a/dashboard/db_connect.php
+++ b/dashboard/db_connect.php
@@ -5,16 +5,16 @@
 // --- IMPORTANTE PARA PRODUCCIÓN ---
 // Las siguientes líneas habilitan la visualización de errores para desarrollo.
 // DEBEN SER COMENTADAS O ELIMINADAS en un entorno de producción para no exponer información sensible.
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
+// ini_set('display_errors', 1);
+// ini_set('display_startup_errors', 1);
+// error_reporting(E_ALL);
 // --- FIN DE SECCIÓN IMPORTANTE PARA PRODUCCIÓN ---
 
 // Configuración de la base de datos PostgreSQL
 $db_host = "localhost";         // Host de la base de datos (PostgreSQL está en el mismo servidor)
 $db_name = "condado_castilla_db"; // Nombre de tu base de datos PostgreSQL
 $db_user = "condado_user";        // Usuario de tu base de datos PostgreSQL
-$db_pass = "tu_contraseña_muy_segura"; // ¡¡¡CRÍTICO: REEMPLAZA ESTO INMEDIATAMENTE CON UNA CONTRASEÑA REAL, ÚNICA Y SEGURA!!!
+$db_pass = getenv('CONDADO_DB_PASSWORD'); // Se obtiene la contraseña de una variable de entorno segura
 $db_port = "5432";                // Puerto estándar de PostgreSQL
 
 // Cadena de conexión (DSN) para PostgreSQL usando PDO


### PR DESCRIPTION
## Summary
- comment out error display lines in `db_connect.php`
- use `CONDADO_DB_PASSWORD` environment variable for the DB password
- document password environment variable in dashboard README
- add a short top-level README with deployment notes

## Testing
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f418fd14832994c3f9f94787b37c