### PR TITLE
Add global API config file

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,2 @@
+const API_BASE_URL = '';
+window.API_BASE_URL = API_BASE_URL;

--- a/js/museo-2d-gallery.js
+++ b/js/museo-2d-gallery.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const show2DGalleryBtn = document.getElementById('show-2d-gallery-btn');
     const show3DMuseumBtn = document.getElementById('show-3d-museum-btn');
 
-    const API_BASE_URL = ""; // API is at the root, e.g., /api/museo/piezas
+    const API_BASE_URL = window.API_BASE_URL || '';
 
     let localMuseumPieces = []; // Cache for fetched pieces
 

--- a/js/museum-3d/utils.js
+++ b/js/museum-3d/utils.js
@@ -20,7 +20,7 @@ MUSEUM_3D.Utils = (function() {
         doorFrame: new THREE.Color("#5c4d3f")
     };
 
-    const API_BASE_URL = ""; // Assuming API is at root, e.g., /api/museo/piezas
+    const API_BASE_URL = window.API_BASE_URL || '';
     const PIEZAS_API_URL = `${API_BASE_URL}/api/museo/piezas`;
 
     const DEBUG_MODE = false; // Set to true for debugging features like Box3Helpers

--- a/museo/museo.html
+++ b/museo/museo.html
@@ -149,6 +149,7 @@
         </div>
     </footer>
 
+    <script src="/js/config.js"></script>
     <script src="/js/layout.js"></script>
     <script src="/js/museo-2d-gallery.js"></script>
     <!-- Museo 3D Modules -->


### PR DESCRIPTION
## Summary
- add `js/config.js` with global `API_BASE_URL`
- include new config script in `museo/museo.html`
- read `API_BASE_URL` from the global config in 2D and 3D museum scripts

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842f44ed8548329b48fa710c1f9e632