### PR TITLE
Implement real Gemini API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Condado de Castilla
+
+Este proyecto utiliza funciones de inteligencia artificial que se comunican con la API de Gemini. Para que dichas funciones funcionen correctamente es necesario definir las siguientes variables de entorno en el entorno de ejecución:
+
+- `GEMINI_API_KEY`: clave de autenticación de la API.
+- `GEMINI_API_ENDPOINT`: URL del punto de acceso de la API.
+
+Asegúrate de que estas variables estén disponibles antes de ejecutar cualquier script que llame a las utilidades de `includes/ai_utils.php`.


### PR DESCRIPTION
## Summary
- read Gemini API credentials from environment variables
- implement `call_gemini_api` helper
- use the API in `get_smart_summary_placeholder` and `get_simulated_translation_placeholder`
- document required environment variables in a new README

## Testing
- `php -l includes/ai_utils.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f45c22108329a257f55ccd2d8d0e