### PR TITLE
Remove obsolete Certbot test file

### DIFF
--- a/.well-known/acme-challenge/test-file.txt
+++ b/.well-known/acme-challenge/test-file.txt
@@ -1,1 +1,0 @@
-Test de validacion OCI y Certbot cxsv2


### PR DESCRIPTION
## Summary
- remove `.well-known/acme-challenge/test-file.txt`

The file was an early test for ACME validation and is not referenced anywhere in the repo. Certbot generates challenge files dynamically during renewal, so keeping this static file isn't necessary.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f46862b8832996785e1e841d1a55