### PR TITLE
Add Gemini API example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,16 @@ Esto iniciará el servidor en `http://localhost:8000`.
 
 La API del museo está disponible en la ruta `/api/museo/piezas`, gestionada por el script `api_museo.php`. Desde ahí es posible obtener o crear registros de piezas del museo.
 
+
+## Ejemplo de uso de la API de Gemini
+
+Para realizar una prueba con la API de Gemini puedes utilizar el script `scripts/gemini_request.sh`. Este script envía una solicitud al modelo *gemini-2.0-flash* y muestra la respuesta.
+
+Antes de ejecutarlo, define la variable de entorno `GEMINI_API_KEY` con tu clave de API de Google:
+
+```bash
+export GEMINI_API_KEY="tu_clave"
+./scripts/gemini_request.sh
+```
+
+El script realizará una petición sencilla que pregunta *"Explain how AI works in a few words"*.

--- a/scripts/gemini_request.sh
+++ b/scripts/gemini_request.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Usage: GEMINI_API_KEY=your_api_key ./gemini_request.sh
+
+API_URL="https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
+
+if [ -z "$GEMINI_API_KEY" ]; then
+  echo "GEMINI_API_KEY environment variable not set" >&2
+  exit 1
+fi
+
+curl "${API_URL}?key=${GEMINI_API_KEY}" \
+  -H 'Content-Type: application/json' \
+  -X POST \
+  -d '{
+    "contents": [
+      {
+        "parts": [
+          {
+            "text": "Explain how AI works in a few words"
+          }
+        ]
+      }
+    ]
+  }'


### PR DESCRIPTION
## Summary
- include a script to hit the Gemini API using an environment variable
- document example usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842f8f2079083299aedf848566d7696