### PR TITLE
Add auto-update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,37 @@ Esto iniciará el servidor en `http://localhost:8000`.
 
 La API del museo está disponible en la ruta `/api/museo/piezas`, gestionada por el script `api_museo.php`. Desde ahí es posible obtener o crear registros de piezas del museo.
 
+
+## Scripts de mantenimiento
+
+Este repositorio incluye utilidades en Python dentro del directorio `scripts/`. El script `auto_update.py` ejecuta tres tareas clave:
+
+1. Procesar las fichas de personajes y generar el archivo `characters_enriched.json`.
+2. Crear `sitemap.xml` con todas las páginas del sitio.
+3. Analizar el grafo de conocimiento para verificar su consistencia.
+
+### Instalación de dependencias
+
+Se recomienda usar un entorno virtual de Python. Desde la raíz del proyecto:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Ejecución manual
+
+```bash
+python scripts/auto_update.py
+```
+
+### Programar con cron
+
+Para ejecutar el script automáticamente cada día puedes añadir una entrada al `crontab` del usuario:
+
+```bash
+0 3 * * * /ruta/al/proyecto/venv/bin/python /ruta/al/proyecto/scripts/auto_update.py >> /ruta/al/proyecto/auto_update.log 2>&1
+```
+
+Esto lanzará la actualización a las 3:00 AM y registrará la salida en `auto_update.log`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+requests

--- a/scripts/auto_update.py
+++ b/scripts/auto_update.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+# Ensure script and project root are in the Python path
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(SCRIPT_DIR)
+if SCRIPT_DIR not in sys.path:
+    sys.path.append(SCRIPT_DIR)
+if ROOT_DIR not in sys.path:
+    sys.path.append(ROOT_DIR)
+
+from process_characters import main as process_characters_main
+from generate_sitemap import main as generate_sitemap_main
+
+try:
+    from consistency_analyzer import ConsistencyAnalyzer
+    from graph_db_interface import GraphDBInterface
+except ImportError as e:
+    raise ImportError(f"Could not import dependencies: {e}")
+
+
+def main() -> None:
+    """Runs maintenance tasks for the site."""
+    process_characters_main()
+    generate_sitemap_main()
+
+    db = GraphDBInterface()
+    analyzer = ConsistencyAnalyzer(db)
+    analyzer.analyze_graph_consistency()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add automatic maintenance script with characters, sitemap and consistency check
- list Python dependencies in requirements.txt
- document how to run and schedule the new script

## Testing
- `python -m py_compile scripts/auto_update.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f9fa4b54832995338253be47c7e0