### PR TITLE
Add env variable check in db_connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ $db_port = "5432";                // Puerto de PostgreSQL
 
 Ajusta esos valores según tu entorno para que la aplicación pueda acceder a la base de datos.
 
+El script obtiene la contraseña real desde la variable de entorno `CONDADO_DB_PASSWORD`.
+Si dicha variable no está definida, `dashboard/db_connect.php` lanzará una
+`RuntimeException` indicando el problema.
+
 ## Servidor de desarrollo
 
 Para probar el sitio de forma local puedes usar el servidor embebido de PHP. Sitúate en la raíz del repositorio y ejecuta:

--- a/dashboard/db_connect.php
+++ b/dashboard/db_connect.php
@@ -17,7 +17,8 @@ $db_name = "condado_castilla_db"; // Nombre de tu base de datos PostgreSQL
 $db_user = "condado_user";        // Usuario de tu base de datos PostgreSQL
 $db_pass = getenv('CONDADO_DB_PASSWORD'); // Definido vía variable de entorno
 if ($db_pass === false) {
-    $db_pass = ""; // Valor por defecto si no se ha configurado la variable
+    // Generar un error claro si la variable de entorno no existe
+    throw new RuntimeException('CONDADO_DB_PASSWORD is not defined');
 }
 $db_port = "5432";                // Puerto estándar de PostgreSQL
 


### PR DESCRIPTION
## Summary
- raise an error if `CONDADO_DB_PASSWORD` is missing in dashboard/db_connect.php
- document the environment variable requirement in README

## Testing
- `php -l dashboard/db_connect.php`

------
https://chatgpt.com/codex/tasks/task_e_6842fa8429008329a60c91063e9854d7