### PR TITLE
Remove production error display

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ php -S localhost:8000
 
 Esto iniciará el servidor en `http://localhost:8000`.
 
+## Consideraciones de produccion
+
+La muestra de errores PHP se mantiene deshabilitada en `dashboard/db_connect.php` e `dashboard/index.php` para no exponer detalles sensibles en produccion.
 ## API
 
 La API del museo está disponible en la ruta `/api/museo/piezas`, gestionada por el script `api_museo.php`. Desde ahí es posible obtener o crear registros de piezas del museo.

--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -1,7 +1,8 @@
 <?php
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
+// Configuración de errores solo para desarrollo
+//ini_set('display_errors', 1);
+//ini_set('display_startup_errors', 1);
+//error_reporting(E_ALL);
 // ... resto de tu código PHP ...
 ?>
 


### PR DESCRIPTION
## Summary
- disable development error reporting in `dashboard/index.php`
- note in README that error display is disabled in `db_connect.php` and `index.php`

## Testing
- `php -l dashboard/index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842fa86825c83298b937258212719cc