### PR TITLE
Improve Gemini API error detection

### DIFF
--- a/scripts/test_gemini_error.php
+++ b/scripts/test_gemini_error.php
@@ -1,0 +1,18 @@
+<?php
+// Simple script to demonstrate _call_gemini_api error reporting
+
+define('GEMINI_API_KEY', 'dummy');
+define('GEMINI_API_ENDPOINT', 'https://httpstat.us/404');
+
+require_once __DIR__ . '/../includes/ai_utils.php';
+
+$payload = ['test' => 'value'];
+$error = null;
+$result = _call_gemini_api($payload, $error);
+
+if ($result === null) {
+    echo "Error captured: $error\n";
+} else {
+    echo "Success:\n";
+    var_dump($result);
+}


### PR DESCRIPTION
## Summary
- add HTTP status parsing in `_call_gemini_api` with fallback to `file_get_contents`
- surface detailed error message in `get_real_ai_summary`
- add `scripts/test_gemini_error.php` to demonstrate error reporting

## Testing
- `php scripts/test_gemini_error.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843001f52588329aaa5d23639882a3f