### PR TITLE
Add collaborative blog with AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ La muestra de errores PHP se mantiene deshabilitada en `dashboard/db_connect.php
 
 La API del museo está disponible en la ruta `/api/museo/piezas`, gestionada por el script `api_museo.php`. Desde ahí es posible obtener o crear registros de piezas del museo.
 
+## Blog colaborativo
+
+El directorio `blog/` ofrece una plataforma básica para publicar artículos y comentarios.
+Las imágenes asociadas se almacenan en `uploads_storage/blog_photos/` y se sirven con `serve_blog_image.php`.
+Cada entrada permite obtener un resumen, una corrección y traducciones de demostración gracias a las funciones de `includes/ai_utils.php`.
+
 
 ## Ejemplo de uso de la API de Gemini
 

--- a/ajax_actions/get_correction.php
+++ b/ajax_actions/get_correction.php
@@ -1,0 +1,27 @@
+<?php
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Método no permitido']);
+    exit;
+}
+require_once __DIR__ . '/../includes/ai_utils.php';
+header('Content-Type: application/json; charset=utf-8');
+$input = json_decode(file_get_contents('php://input'), true);
+$text = trim($input['text_to_correct'] ?? ($_POST['text_to_correct'] ?? ''));
+if ($text === '') {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'No se proporcionó texto']);
+    exit;
+}
+if (function_exists('get_ai_correction')) {
+    $corr = get_ai_correction($text);
+    if (stripos($corr, 'Error:') === 0) {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => $corr]);
+    } else {
+        echo json_encode(['success' => true, 'correction' => $corr]);
+    }
+} else {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Función de corrección no disponible']);
+}

--- a/ajax_actions/get_translation.php
+++ b/ajax_actions/get_translation.php
@@ -1,0 +1,23 @@
+<?php
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Método no permitido']);
+    exit;
+}
+require_once __DIR__ . '/../includes/ai_utils.php';
+header('Content-Type: application/json; charset=utf-8');
+$input = json_decode(file_get_contents('php://input'), true);
+$text = trim($input['text'] ?? ($_POST['text'] ?? ''));
+$target = trim($input['target_lang'] ?? ($_POST['target_lang'] ?? 'en-ai'));
+if ($text === '') {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'No se proporcionó texto']);
+    exit;
+}
+if (function_exists('translate_with_gemini')) {
+    $trans = translate_with_gemini('blog_post', $target, substr($text,0,100));
+    echo json_encode(['success' => true, 'translation' => $trans]);
+} else {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Función de traducción no disponible']);
+}

--- a/blog/add_comment.php
+++ b/blog/add_comment.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__ . '/../dashboard/db_connect.php';
+require_once __DIR__ . '/../includes/csrf.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: index.php');
+    exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    die('CSRF token inválido');
+}
+
+$post_id = intval($_POST['post_id'] ?? 0);
+$author = trim($_POST['author'] ?? 'Anónimo');
+$comment = trim($_POST['comment'] ?? '');
+
+if ($post_id <= 0 || $comment === '') {
+    die('Datos de comentario inválidos');
+}
+
+try {
+    $stmt = $pdo->prepare("INSERT INTO blog_comments (post_id, author, comment) VALUES (:post_id, :author, :comment)");
+    $stmt->bindParam(':post_id', $post_id, PDO::PARAM_INT);
+    $stmt->bindParam(':author', $author);
+    $stmt->bindParam(':comment', $comment);
+    $stmt->execute();
+    header('Location: post.php?id=' . urlencode($post_id));
+} catch (PDOException $e) {
+    error_log('Error adding comment: ' . $e->getMessage());
+    die('Error al guardar el comentario');
+}

--- a/blog/create_post.php
+++ b/blog/create_post.php
@@ -1,0 +1,54 @@
+<?php
+require_once __DIR__ . '/../dashboard/db_connect.php';
+require_once __DIR__ . '/../includes/csrf.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: index.php');
+    exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    die('CSRF token inválido');
+}
+
+$title = trim($_POST['title'] ?? '');
+$content = trim($_POST['content'] ?? '');
+$image_filename = null;
+
+if ($title === '' || $content === '') {
+    die('Título y contenido son obligatorios.');
+}
+
+$upload_dir = dirname(__DIR__) . '/uploads_storage/blog_photos/';
+if (!is_dir($upload_dir)) {
+    mkdir($upload_dir, 0775, true);
+}
+
+if (!empty($_FILES['image']['tmp_name'])) {
+    $file = $_FILES['image'];
+    if ($file['error'] === UPLOAD_ERR_OK) {
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        $type = finfo_file($finfo, $file['tmp_name']);
+        finfo_close($finfo);
+        $allowed = ['image/jpeg','image/png','image/gif'];
+        if (in_array($type, $allowed) && $file['size'] <= 2*1024*1024) {
+            $ext = pathinfo($file['name'], PATHINFO_EXTENSION);
+            $safe_name = time() . '_' . preg_replace('/[^a-zA-Z0-9_.-]/','_', pathinfo($file['name'], PATHINFO_FILENAME)) . '.' . $ext;
+            move_uploaded_file($file['tmp_name'], $upload_dir . $safe_name);
+            $image_filename = $safe_name;
+        }
+    }
+}
+
+try {
+    $stmt = $pdo->prepare("INSERT INTO blog_posts (title, content, image_filename) VALUES (:title, :content, :image)");
+    $stmt->bindParam(':title', $title);
+    $stmt->bindParam(':content', $content);
+    $stmt->bindParam(':image', $image_filename);
+    $stmt->execute();
+    $post_id = $pdo->lastInsertId();
+    header('Location: post.php?id=' . urlencode($post_id));
+} catch (PDOException $e) {
+    error_log('Error creating post: ' . $e->getMessage());
+    die('Error al guardar el artículo');
+}

--- a/blog/index.php
+++ b/blog/index.php
@@ -1,0 +1,41 @@
+<?php
+require_once __DIR__ . '/../dashboard/db_connect.php';
+require_once __DIR__ . '/../includes/csrf.php';
+
+try {
+    $stmt = $pdo->query("SELECT id, title, content, image_filename, created_at FROM blog_posts ORDER BY created_at DESC");
+    $posts = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $posts = [];
+    error_log('Error fetching blog posts: ' . $e->getMessage());
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Blog</title>
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Blog de la Comunidad</h1>
+        <p><a href="new_post.php">Escribir nuevo artículo</a></p>
+        <?php if (empty($posts)): ?>
+            <p>No hay artículos aún.</p>
+        <?php else: ?>
+            <?php foreach ($posts as $post): ?>
+                <article style="margin-bottom:20px; border-bottom:1px solid #ccc; padding-bottom:15px;">
+                    <h2><a href="post.php?id=<?php echo urlencode($post['id']); ?>"><?php echo htmlspecialchars($post['title']); ?></a></h2>
+                    <small>Publicado el <?php echo htmlspecialchars(date('d/m/Y', strtotime($post['created_at']))); ?></small>
+                    <?php if (!empty($post['image_filename'])): ?>
+                        <div><img src="/serve_blog_image.php?file=<?php echo urlencode($post['image_filename']); ?>" alt="Imagen del artículo" style="max-width:200px;"></div>
+                    <?php endif; ?>
+                    <p><?php echo htmlspecialchars(mb_substr(strip_tags($post['content']),0,200)); ?>...</p>
+                    <p><a href="post.php?id=<?php echo urlencode($post['id']); ?>">Leer más</a></p>
+                </article>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </div>
+</body>
+</html>

--- a/blog/js/post.js
+++ b/blog/js/post.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const summaryBtn = document.getElementById('btn-summary');
+    const correctBtn = document.getElementById('btn-correct');
+    const langBtns = document.querySelectorAll('.lang-btn');
+    const content = document.getElementById('post-content');
+    const aiResult = document.getElementById('ai-result');
+    const originalHTML = content ? content.innerHTML : '';
+
+    async function postData(url = '', data = {}) {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        });
+        return response.json();
+    }
+
+    if (summaryBtn) {
+        summaryBtn.addEventListener('click', async () => {
+            aiResult.textContent = 'Generando resumen...';
+            const res = await postData('/ajax_actions/get_summary.php', {text_to_summarize: content.textContent});
+            aiResult.innerHTML = res.success ? res.summary : res.error;
+        });
+    }
+
+    if (correctBtn) {
+        correctBtn.addEventListener('click', async () => {
+            aiResult.textContent = 'Corrigiendo...';
+            const res = await postData('/ajax_actions/get_correction.php', {text_to_correct: content.textContent});
+            aiResult.innerHTML = res.success ? res.correction : res.error;
+        });
+    }
+
+    langBtns.forEach(btn => {
+        btn.addEventListener('click', async () => {
+            const lang = btn.getAttribute('data-lang');
+            aiResult.textContent = 'Traduciendo...';
+            const res = await postData('/ajax_actions/get_translation.php', {text: content.textContent, target_lang: lang});
+            aiResult.innerHTML = res.success ? res.translation : res.error;
+        });
+    });
+});

--- a/blog/new_post.php
+++ b/blog/new_post.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/../includes/csrf.php';
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Nuevo Artículo</title>
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Crear nuevo artículo</h1>
+        <form action="create_post.php" method="POST" enctype="multipart/form-data">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(get_csrf_token()); ?>">
+            <div>
+                <label for="title">Título:</label><br>
+                <input type="text" id="title" name="title" required>
+            </div>
+            <div>
+                <label for="content">Contenido:</label><br>
+                <textarea id="content" name="content" rows="10" required></textarea>
+            </div>
+            <div>
+                <label for="image">Imagen (opcional):</label><br>
+                <input type="file" id="image" name="image" accept="image/jpeg,image/png,image/gif">
+            </div>
+            <button type="submit">Publicar</button>
+        </form>
+        <p><a href="index.php">Volver al blog</a></p>
+    </div>
+</body>
+</html>

--- a/blog/post.php
+++ b/blog/post.php
@@ -1,0 +1,79 @@
+<?php
+require_once __DIR__ . '/../dashboard/db_connect.php';
+require_once __DIR__ . '/../includes/csrf.php';
+require_once __DIR__ . '/../includes/ai_utils.php';
+
+$post_id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+if ($post_id <= 0) {
+    die('Artículo no válido');
+}
+
+try {
+    $stmt = $pdo->prepare("SELECT id, title, content, image_filename, created_at FROM blog_posts WHERE id = :id");
+    $stmt->bindParam(':id', $post_id, PDO::PARAM_INT);
+    $stmt->execute();
+    $post = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$post) {
+        die('Artículo no encontrado');
+    }
+
+    $stmtC = $pdo->prepare("SELECT author, comment, created_at FROM blog_comments WHERE post_id = :id ORDER BY created_at ASC");
+    $stmtC->bindParam(':id', $post_id, PDO::PARAM_INT);
+    $stmtC->execute();
+    $comments = $stmtC->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    error_log('Error fetching post: ' . $e->getMessage());
+    die('Error al cargar el artículo');
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title><?php echo htmlspecialchars($post['title']); ?></title>
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+    <script src="js/post.js" defer></script>
+</head>
+<body>
+    <div class="container">
+        <h1><?php echo htmlspecialchars($post['title']); ?></h1>
+        <small>Publicado el <?php echo htmlspecialchars(date('d/m/Y', strtotime($post['created_at']))); ?></small>
+        <?php if ($post['image_filename']): ?>
+            <div><img src="/serve_blog_image.php?file=<?php echo urlencode($post['image_filename']); ?>" alt="Imagen del artículo" style="max-width:400px;"></div>
+        <?php endif; ?>
+        <div id="post-content"><?php echo nl2br(htmlspecialchars($post['content'])); ?></div>
+        <button id="btn-summary">Resumen IA</button>
+        <button id="btn-correct">Corrección IA</button>
+        <button class="lang-btn" data-lang="en-ai">Traducir a inglés</button>
+        <button class="lang-btn" data-lang="fr-ai">Traducir a francés</button>
+        <div id="ai-result" style="margin-top:15px;"></div>
+
+        <h2>Comentarios</h2>
+        <?php if (empty($comments)): ?>
+            <p>No hay comentarios.</p>
+        <?php else: ?>
+            <?php foreach ($comments as $c): ?>
+                <div style="border-bottom:1px solid #ccc; margin-bottom:10px;">
+                    <strong><?php echo htmlspecialchars($c['author']); ?></strong> - <?php echo htmlspecialchars(date('d/m/Y', strtotime($c['created_at']))); ?>
+                    <p><?php echo nl2br(htmlspecialchars($c['comment'])); ?></p>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        <h3>Nuevo comentario</h3>
+        <form action="add_comment.php" method="POST">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(get_csrf_token()); ?>">
+            <input type="hidden" name="post_id" value="<?php echo $post_id; ?>">
+            <div>
+                <label for="author">Nombre:</label><br>
+                <input type="text" id="author" name="author">
+            </div>
+            <div>
+                <label for="comment">Comentario:</label><br>
+                <textarea id="comment" name="comment" rows="4" required></textarea>
+            </div>
+            <button type="submit">Enviar</button>
+        </form>
+        <p><a href="index.php">Volver al blog</a></p>
+    </div>
+</body>
+</html>

--- a/database_setup/03_create_blog_tables.sql
+++ b/database_setup/03_create_blog_tables.sql
@@ -1,0 +1,15 @@
+CREATE TABLE blog_posts (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    image_filename VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE blog_comments (
+    id SERIAL PRIMARY KEY,
+    post_id INTEGER NOT NULL REFERENCES blog_posts(id) ON DELETE CASCADE,
+    author VARCHAR(255) DEFAULT 'Anónimo',
+    comment TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -241,4 +241,34 @@ function translate_with_gemini(string $content_id, string $target_language, stri
     return $outputText;
 }
 
+/**
+ * Devuelve un texto corregido simulando una corrección gramatical por IA.
+ *
+ * @param string $text Texto a corregir.
+ * @return string Texto corregido o mensaje de error.
+ */
+function get_ai_correction(string $text): string {
+    if (empty(trim($text))) {
+        return "Error: No se proporcionó texto para corregir.";
+    }
+
+    $prompt = "Corrige gramaticalmente el siguiente texto manteniendo su significado:";
+    $payload = [
+        'contents' => [
+            [ 'parts' => [ ['text' => $prompt . "\n\n" . $text ] ] ]
+        ]
+    ];
+
+    $response = _call_gemini_api($payload);
+    if ($response === null) {
+        return "Error: La llamada a la API de IA para la corrección falló.";
+    }
+
+    if (isset($response['candidates'][0]['content']['parts'][0]['text'])) {
+        $corr = trim($response['candidates'][0]['content']['parts'][0]['text']);
+        return !empty($corr) ? nl2br(htmlspecialchars($corr)) : "Error: La IA no devolvió texto corregido.";
+    }
+    return "Error: Respuesta inesperada del servicio de corrección de IA.";
+}
+
 ?>

--- a/serve_blog_image.php
+++ b/serve_blog_image.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/dashboard/db_connect.php';
+
+$filename = basename($_GET['file'] ?? '');
+$path = __DIR__ . '/uploads_storage/blog_photos/' . $filename;
+if (!preg_match('/^[A-Za-z0-9_.-]+$/', $filename) || !is_file($path)) {
+    http_response_code(404);
+    exit('Imagen no encontrada');
+}
+$finfo = finfo_open(FILEINFO_MIME_TYPE);
+$type = finfo_file($finfo, $path);
+finfo_close($finfo);
+header('Content-Type: ' . $type);
+readfile($path);


### PR DESCRIPTION
## Summary
- add a basic blog platform allowing article submissions with optional images
- enable comments on blog posts
- provide AI-powered summary, correction and translation actions
- include sample JS handlers and AJAX endpoints
- extend README with blog information
- create database schema for blog tables

## Testing
- `php -l blog/index.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842ffea6f3c8329ba171ce5de69e283