### PR TITLE
Add basic tienda section with admin tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Ajusta esos valores según tu entorno para que la aplicación pueda acceder a la
 El script obtiene la contraseña real desde la variable de entorno `CONDADO_DB_PASSWORD`.
 Si dicha variable no está definida, `dashboard/db_connect.php` lanzará una
 `RuntimeException` indicando el problema.
+Para preparar la base de datos ejecuta en orden los scripts de `database_setup`: `01_create_tables.sql`, `02_create_museo_piezas_table.sql` y `03_create_tienda_productos.sql`.
 
 ## Servidor de desarrollo
 
@@ -69,3 +70,4 @@ es necesario definir dos variables de entorno:
 
 Puedes revisar el script opcional `scripts/gemini_request.sh` para ver un ejemplo
 básico de invocación que hace uso de `GEMINI_API_KEY`.
+Encuentra la tienda en [tienda/index.php](tienda/index.php).

--- a/_header.html
+++ b/_header.html
@@ -19,6 +19,7 @@
         <li><a href="/camino_santiago/camino_santiago.html">Camino de Santiago</a></li>
         <li><a href="/museo/museo.html">Museo Colaborativo</a></li>
         <li><a href="/galeria/galeria_colaborativa.php">Galería Colaborativa</a></li>
+        <li><a href="/tienda/index.php">Tienda</a></li>
         <li><a href="/visitas/visitas.html">Planifica Tu Visita</a></li>
         <li><a href="/cultura/cultura.html">Cultura y Legado</a></li>
         <li><a href="/personajes/indice_personajes.html">Personajes</a></li>

--- a/api_tienda.php
+++ b/api_tienda.php
@@ -1,0 +1,105 @@
+<?php
+require_once 'dashboard/db_connect.php';
+require_once 'includes/auth.php';
+require_once 'includes/csrf.php';
+
+if (session_status() == PHP_SESSION_NONE) {
+    session_start();
+}
+
+header('Content-Type: application/json');
+
+global $pdo;
+
+function json_response($data, $status = 200) {
+    http_response_code($status);
+    echo json_encode($data);
+    exit;
+}
+
+define('UPLOAD_DIR_BASE', dirname(__DIR__) . '/uploads_storage/tienda_productos/');
+
+if (!is_dir(UPLOAD_DIR_BASE)) {
+    @mkdir(UPLOAD_DIR_BASE, 0775, true);
+}
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+switch ($method) {
+    case 'GET':
+        try {
+            $stmt = $pdo->query("SELECT id, nombre, descripcion, precio, imagen_nombre, stock, created_at FROM tienda_productos ORDER BY id DESC");
+            $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            json_response($items);
+        } catch (PDOException $e) {
+            json_response(['error' => 'DB error', 'details' => $e->getMessage()], 500);
+        }
+        break;
+    case 'POST':
+        if (!is_admin_logged_in()) {
+            json_response(['error' => 'Admin authentication required'], 403);
+        }
+        if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+            json_response(['error' => 'Invalid CSRF token'], 400);
+        }
+        $nombre = trim($_POST['nombre'] ?? '');
+        $descripcion = trim($_POST['descripcion'] ?? '');
+        $precio = floatval($_POST['precio'] ?? 0);
+        $stock = intval($_POST['stock'] ?? 0);
+        if ($nombre === '' || empty($_FILES['imagen']['name'])) {
+            json_response(['error' => 'Nombre e imagen requeridos'], 400);
+        }
+        $file = $_FILES['imagen'];
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        $mime = finfo_file($finfo, $file['tmp_name']);
+        finfo_close($finfo);
+        $allowed = ['image/jpeg','image/png','image/gif'];
+        if ($file['error'] !== UPLOAD_ERR_OK || !in_array($mime, $allowed)) {
+            json_response(['error' => 'Tipo de imagen no válido'], 400);
+        }
+        $ext = pathinfo($file['name'], PATHINFO_EXTENSION);
+        $safe = preg_replace('/[^a-zA-Z0-9_.-]/','_', pathinfo($file['name'], PATHINFO_FILENAME));
+        $filename = time().'_'.$safe.'.'.$ext;
+        if (!move_uploaded_file($file['tmp_name'], UPLOAD_DIR_BASE.$filename)) {
+            json_response(['error' => 'No se pudo guardar la imagen'], 500);
+        }
+        try {
+            $stmt = $pdo->prepare("INSERT INTO tienda_productos (nombre, descripcion, precio, imagen_nombre, stock) VALUES (:n,:d,:p,:i,:s)");
+            $stmt->execute([':n'=>$nombre, ':d'=>$descripcion, ':p'=>$precio, ':i'=>$filename, ':s'=>$stock]);
+            $id = $pdo->lastInsertId();
+            json_response(['message' => 'Producto creado', 'id' => $id, 'imagen_nombre' => $filename], 201);
+        } catch (PDOException $e) {
+            @unlink(UPLOAD_DIR_BASE.$filename);
+            json_response(['error' => 'DB error', 'details' => $e->getMessage()], 500);
+        }
+        break;
+    case 'DELETE':
+        if (!is_admin_logged_in()) {
+            json_response(['error' => 'Admin authentication required'], 403);
+        }
+        $id = intval($_GET['id'] ?? 0);
+        if ($id <= 0) {
+            json_response(['error' => 'ID requerido'], 400);
+        }
+        try {
+            $stmt = $pdo->prepare("SELECT imagen_nombre FROM tienda_productos WHERE id=:id");
+            $stmt->execute([':id'=>$id]);
+            $img = $stmt->fetchColumn();
+            $stmt = $pdo->prepare("DELETE FROM tienda_productos WHERE id=:id");
+            $stmt->execute([':id'=>$id]);
+            if ($stmt->rowCount()) {
+                if ($img && file_exists(UPLOAD_DIR_BASE.$img)) {
+                    @unlink(UPLOAD_DIR_BASE.$img);
+                }
+                json_response(['message' => 'Producto eliminado']);
+            } else {
+                json_response(['error' => 'Producto no encontrado'], 404);
+            }
+        } catch (PDOException $e) {
+            json_response(['error' => 'DB error', 'details' => $e->getMessage()], 500);
+        }
+        break;
+    default:
+        json_response(['error' => 'Método no permitido'], 405);
+}
+?>

--- a/dashboard/tienda_admin.php
+++ b/dashboard/tienda_admin.php
@@ -1,0 +1,175 @@
+<?php
+if (session_status() == PHP_SESSION_NONE) {
+    @session_start();
+}
+require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/db_connect.php';
+require_once __DIR__ . '/../includes/csrf.php';
+
+require_admin_login();
+
+$feedback_message = '';
+$feedback_type = '';
+
+// Directory for product images (outside web root)
+$upload_dir = dirname(__DIR__) . '/uploads_storage/tienda_productos/';
+if (!is_dir($upload_dir)) {
+    @mkdir($upload_dir, 0775, true);
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+        $feedback_message = 'CSRF token inválido.';
+        $feedback_type = 'error';
+    } else {
+        $action = $_POST['action'] ?? '';
+        if ($action === 'add') {
+            $nombre = trim($_POST['nombre'] ?? '');
+            $descripcion = trim($_POST['descripcion'] ?? '');
+            $precio = floatval($_POST['precio'] ?? 0);
+            $stock = intval($_POST['stock'] ?? 0);
+            if ($nombre === '' || empty($_FILES['imagen']['name'])) {
+                $feedback_message = 'Nombre e imagen son obligatorios.';
+                $feedback_type = 'error';
+            } else {
+                $file = $_FILES['imagen'];
+                $finfo = finfo_open(FILEINFO_MIME_TYPE);
+                $mime = finfo_file($finfo, $file['tmp_name']);
+                finfo_close($finfo);
+                $allowed = ['image/jpeg','image/png','image/gif'];
+                if ($file['error'] !== UPLOAD_ERR_OK || !in_array($mime, $allowed)) {
+                    $feedback_message = 'Error o tipo de imagen no válido.';
+                    $feedback_type = 'error';
+                } else {
+                    $ext = pathinfo($file['name'], PATHINFO_EXTENSION);
+                    $safe = preg_replace('/[^a-zA-Z0-9_.-]/','_', pathinfo($file['name'], PATHINFO_FILENAME));
+                    $filename = time().'_'.$safe.'.'.$ext;
+                    if (move_uploaded_file($file['tmp_name'], $upload_dir.$filename)) {
+                        try {
+                            $stmt = $pdo->prepare("INSERT INTO tienda_productos (nombre, descripcion, precio, imagen_nombre, stock) VALUES (:n,:d,:p,:i,:s)");
+                            $stmt->execute([':n'=>$nombre, ':d'=>$descripcion, ':p'=>$precio, ':i'=>$filename, ':s'=>$stock]);
+                            $feedback_message = 'Producto añadido correctamente.';
+                            $feedback_type = 'success';
+                        } catch (PDOException $e) {
+                            @unlink($upload_dir.$filename);
+                            $feedback_message = 'Error al guardar en la base de datos.';
+                            $feedback_type = 'error';
+                        }
+                    } else {
+                        $feedback_message = 'No se pudo guardar la imagen.';
+                        $feedback_type = 'error';
+                    }
+                }
+            }
+        } elseif ($action === 'delete') {
+            $id = intval($_POST['id'] ?? 0);
+            if ($id > 0) {
+                try {
+                    $stmt = $pdo->prepare("SELECT imagen_nombre FROM tienda_productos WHERE id=:id");
+                    $stmt->execute([':id'=>$id]);
+                    $img = $stmt->fetchColumn();
+                    $stmt = $pdo->prepare("DELETE FROM tienda_productos WHERE id=:id");
+                    $stmt->execute([':id'=>$id]);
+                    if ($stmt->rowCount()) {
+                        if ($img && file_exists($upload_dir.$img)) {
+                            @unlink($upload_dir.$img);
+                        }
+                        $feedback_message = 'Producto eliminado.';
+                        $feedback_type = 'success';
+                    }
+                } catch (PDOException $e) {
+                    $feedback_message = 'Error al eliminar el producto.';
+                    $feedback_type = 'error';
+                }
+            }
+        }
+    }
+}
+
+$productos = [];
+try {
+    $stmt = $pdo->query("SELECT id, nombre, descripcion, precio, imagen_nombre, stock, created_at FROM tienda_productos ORDER BY id DESC");
+    $productos = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $feedback_message = 'Error al cargar productos: ' . $e->getMessage();
+    $feedback_type = 'error';
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Administrar Tienda</title>
+    <link rel="stylesheet" href="../assets/css/epic_theme.css">
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .container { max-width: 900px; margin: auto; }
+        table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+        .feedback.success { background:#d4edda; padding:10px; margin-bottom:10px; }
+        .feedback.error { background:#f8d7da; padding:10px; margin-bottom:10px; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <nav>
+        <a href="../index.php">Inicio</a>
+        <a href="logout.php">Cerrar sesión</a>
+    </nav>
+    <h1>Administrar Productos</h1>
+    <?php if ($feedback_message): ?>
+        <div class="feedback <?php echo htmlspecialchars($feedback_type); ?>">
+            <?php echo htmlspecialchars($feedback_message); ?>
+        </div>
+    <?php endif; ?>
+    <h2>Añadir Producto</h2>
+    <form action="" method="POST" enctype="multipart/form-data">
+        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(get_csrf_token()); ?>">
+        <input type="hidden" name="action" value="add">
+        <div>
+            <label>Nombre:</label><br>
+            <input type="text" name="nombre" required>
+        </div>
+        <div>
+            <label>Descripción:</label><br>
+            <textarea name="descripcion"></textarea>
+        </div>
+        <div>
+            <label>Precio:</label><br>
+            <input type="number" name="precio" step="0.01" required>
+        </div>
+        <div>
+            <label>Stock:</label><br>
+            <input type="number" name="stock" value="0" required>
+        </div>
+        <div>
+            <label>Imagen:</label><br>
+            <input type="file" name="imagen" accept="image/*" required>
+        </div>
+        <button type="submit">Agregar</button>
+    </form>
+    <h2>Productos Existentes</h2>
+    <table>
+        <tr><th>ID</th><th>Nombre</th><th>Precio</th><th>Stock</th><th>Acciones</th></tr>
+        <?php foreach ($productos as $p): ?>
+            <tr>
+                <td><?php echo $p['id']; ?></td>
+                <td><?php echo htmlspecialchars($p['nombre']); ?></td>
+                <td><?php echo number_format($p['precio'],2); ?>€</td>
+                <td><?php echo (int)$p['stock']; ?></td>
+                <td>
+                    <form action="" method="POST" style="display:inline;" onsubmit="return confirm('¿Eliminar producto?');">
+                        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(get_csrf_token()); ?>">
+                        <input type="hidden" name="action" value="delete">
+                        <input type="hidden" name="id" value="<?php echo $p['id']; ?>">
+                        <button type="submit">Eliminar</button>
+                    </form>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+</div>
+</body>
+</html>

--- a/database_setup/03_create_tienda_productos.sql
+++ b/database_setup/03_create_tienda_productos.sql
@@ -1,0 +1,12 @@
+-- SQL script for creating the tienda_productos table
+
+CREATE TABLE tienda_productos (
+    id SERIAL PRIMARY KEY,
+    nombre VARCHAR(255) NOT NULL,
+    descripcion TEXT,
+    precio DECIMAL(10,2) NOT NULL,
+    imagen_nombre VARCHAR(255) NOT NULL,
+    stock INTEGER DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/tienda/index.php
+++ b/tienda/index.php
@@ -1,0 +1,48 @@
+<?php
+if (session_status() == PHP_SESSION_NONE) {
+    @session_start();
+}
+require_once __DIR__ . '/../includes/auth.php';
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tienda</title>
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+</head>
+<body>
+<?php require_once __DIR__ . '/../_header.html'; ?>
+<main class="container page-content-block">
+    <h1 class="section-title">Tienda</h1>
+    <div class="card-grid">
+        <div class="card">
+            <img src="/assets/img/AlfozCerasioLantaron.jpg" alt="Producto 1">
+            <div class="card-content">
+                <h3>Producto 1</h3>
+                <p>Descripción breve del producto 1.</p>
+                <p><strong>Precio: 10€</strong></p>
+            </div>
+        </div>
+        <div class="card">
+            <img src="/assets/img/escudo.jpg" alt="Producto 2">
+            <div class="card-content">
+                <h3>Producto 2</h3>
+                <p>Descripción breve del producto 2.</p>
+                <p><strong>Precio: 15€</strong></p>
+            </div>
+        </div>
+        <div class="card">
+            <img src="/assets/img/Yanna.jpg" alt="Producto 3">
+            <div class="card-content">
+                <h3>Producto 3</h3>
+                <p>Descripción breve del producto 3.</p>
+                <p><strong>Precio: 20€</strong></p>
+            </div>
+        </div>
+    </div>
+</main>
+<?php require_once __DIR__ . '/../_footer.html'; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `tienda/index.php` with placeholder product cards
- link shop from the main navigation
- add SQL script `03_create_tienda_productos.sql`
- create admin page `dashboard/tienda_admin.php` for CRUD actions
- provide API endpoint `api_tienda.php`
- document the new table and page in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843017c7b708329b7e6f39b1ff60c8b