### PR TITLE
Improve http error handling in ai_utils

### DIFF
--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -161,11 +161,6 @@ function _call_gemini_api(array $payload, ?string &$error = null): ?array {
             ]
         ]);
         $response = @file_get_contents(GEMINI_API_ENDPOINT, false, $context);
-        if ($response === false) {
-            $error = 'Gemini API fopen error';
-            error_log($error);
-            return null;
-        }
 
         if (isset($http_response_header[0]) &&
             preg_match('#^HTTP/\S+\s+(\d+)#', $http_response_header[0], $m)) {
@@ -175,6 +170,12 @@ function _call_gemini_api(array $payload, ?string &$error = null): ?array {
                 error_log('Gemini API HTTP error: ' . $error);
                 return null;
             }
+        }
+
+        if ($response === false) {
+            $error = 'Gemini API fopen error';
+            error_log($error);
+            return null;
         }
     }
 

--- a/scripts/test_gemini_error.php
+++ b/scripts/test_gemini_error.php
@@ -1,5 +1,7 @@
 <?php
-// Simple script to demonstrate _call_gemini_api error reporting
+// Simple script to demonstrate _call_gemini_api error reporting.
+// The endpoint returns a 404 status so the script will display the
+// status line captured by _call_gemini_api.
 
 define('GEMINI_API_KEY', 'dummy');
 define('GEMINI_API_ENDPOINT', 'https://httpstat.us/404');


### PR DESCRIPTION
## Summary
- inspect `$http_response_header` after `file_get_contents`
- report HTTP errors using the status line
- document in test script how the error appears

## Testing
- `php -l includes/ai_utils.php`
- `php -l scripts/test_gemini_error.php`
- `php scripts/test_gemini_error.php` *(fails without network)*

------
https://chatgpt.com/codex/tasks/task_e_6843141b24f8832985f65edb9df1dfed