### PR TITLE
Add PHP CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+          coverage: xdebug
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --coverage-clover build/coverage.xml
+
+      - name: Upload coverage artifact
+        if: success() && always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: php-coverage
+          path: build/coverage.xml


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run PHPStan and PHPUnit

## Testing
- `php -v` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431f61bb6883298245dbe8f46dcb77