### PR TITLE
Fix submit button attribute

### DIFF
--- a/dashboard/edit_texts.php
+++ b/dashboard/edit_texts.php
@@ -94,7 +94,7 @@ $edit_id_highlight = $_GET['edit_id'] ?? null;
                     <textarea id="new_text_content" name="text_content" required></textarea>
                 </div>
                 <input type="hidden" name="action" value="create">
-                <button type_submit" class="add-new-button">Añadir Nuevo Texto</button>
+                <button type="submit" class="add-new-button">Añadir Nuevo Texto</button>
             </form>
         </div>
 


### PR DESCRIPTION
## Summary
- fix typo in button `type` attribute in the dashboard text editor

## Testing
- `php -l dashboard/edit_texts.php`
- `php dashboard/test_text_manager.php`

------
https://chatgpt.com/codex/tasks/task_e_68431f6029b48329950f2199a8f93a12