### PR TITLE
Add DB check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ Si dicha variable no está definida, `dashboard/db_connect.php` lanzará una
 `RuntimeException` indicando el problema.
 Para preparar la base de datos ejecuta en orden los scripts de `database_setup`: `01_create_tables.sql`, `02_create_museo_piezas_table.sql` y `03_create_tienda_productos.sql`.
 
+## Comprobacion de la base de datos
+
+Para verificar que PostgreSQL esta disponible y que la variable `CONDADO_DB_PASSWORD` se ha definido, ejecuta:
+
+```bash
+export CONDADO_DB_PASSWORD="tu_contrasena"
+./scripts/check_db.sh
+```
+
+El script usa `pg_isready` para comprobar la conexion y mostrara un mensaje de exito o error.
+
+
 ## Servidor de desarrollo
 
 Para probar el sitio de forma local puedes usar el servidor embebido de PHP. Sitúate en la raíz del repositorio y ejecuta:

--- a/scripts/check_db.sh
+++ b/scripts/check_db.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Simple check for PostgreSQL connectivity and environment variable
+
+DB_HOST="localhost"
+DB_PORT="5432"
+DB_NAME="condado_castilla_db"
+DB_USER="condado_user"
+
+if [ -z "$CONDADO_DB_PASSWORD" ]; then
+  echo "CONDADO_DB_PASSWORD environment variable is not set" >&2
+  exit 1
+fi
+
+if ! command -v pg_isready >/dev/null 2>&1; then
+  echo "pg_isready command not found" >&2
+  exit 1
+fi
+
+PGPASSWORD="$CONDADO_DB_PASSWORD" pg_isready -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USER" >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "Database is running and environment variable works"
+else
+  echo "Failed to connect to database" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `scripts/check_db.sh` for verifying DB connectivity and env var
- document database check in `README.md`

## Testing
- `./scripts/check_db.sh` *(fails: `pg_isready` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431f9dfa58832980fbf9f8aedab0ae