### PR TITLE
Implement AI translation and correction utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ es necesario definir las siguientes variables de entorno:
 Si está disponible, puedes revisar el script opcional `scripts/gemini_request.sh`
 para ver un ejemplo básico de invocación que hace uso de `GEMINI_API_KEY`.
 Encuentra la tienda en [tienda/index.php](tienda/index.php).
+
+### Funciones de IA disponibles
+
+El archivo `includes/ai_utils.php` proporciona utilidades que hacen uso de la API de Gemini. Entre ellas destacan:
+
+- `get_real_ai_summary($texto)`: genera resúmenes concisos.
+- `get_ai_translation($texto, $idioma)`: traduce el texto al idioma indicado.
+- `get_ai_correction($texto)`: devuelve una versión corregida del texto.
+
+Si no se configuran las credenciales reales de la API, se utilizará un simulador que produce textos de demostración.

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -280,4 +280,88 @@ function translate_with_gemini(string $content_id, string $target_language, stri
     return $outputText;
 }
 
+/**
+ * Genera una traducción real mediante la API de Gemini (o el simulador).
+ * Devuelve solo la traducción en el idioma solicitado.
+ *
+ * @param string $text            Texto de origen en castellano.
+ * @param string $target_language Código del idioma de destino, ej. "en".
+ * @return string Traducción generada o mensaje de error.
+ */
+function get_ai_translation(string $text, string $target_language): string {
+    if (empty(trim($text))) {
+        return "Error: No se proporcionó texto a traducir.";
+    }
+
+    $prompt = "Traduce el siguiente texto al idioma '" . $target_language . "'. Devuelve solo la traducción:\n\n\"" . $text . "\"";
+
+    $payload = [
+        'contents' => [
+            [
+                'parts' => [
+                    ['text' => $prompt]
+                ]
+            ]
+        ]
+    ];
+
+    $error = null;
+    $api_response = _call_gemini_api($payload, $error);
+
+    if ($api_response === null) {
+        $msg = $error !== null ? $error : 'La llamada a la API de IA para la traducción falló.';
+        return "Error: " . $msg;
+    }
+
+    if (isset($api_response['candidates'][0]['content']['parts'][0]['text'])) {
+        $translation = trim($api_response['candidates'][0]['content']['parts'][0]['text']);
+        return !empty($translation) ? nl2br(htmlspecialchars($translation)) : "Error: La traducción generada por la IA estaba vacía.";
+    } elseif (isset($api_response['error']['message'])) {
+        return "Error de la API de IA: " . htmlspecialchars($api_response['error']['message']);
+    }
+
+    return "Error: Respuesta inesperada del servicio de traducción de IA.";
+}
+
+/**
+ * Genera una versión corregida de un texto usando la API de Gemini.
+ *
+ * @param string $text Texto original en castellano.
+ * @return string Texto corregido o mensaje de error.
+ */
+function get_ai_correction(string $text): string {
+    if (empty(trim($text))) {
+        return "Error: No se proporcionó texto a corregir.";
+    }
+
+    $prompt = "Corrige ortografía y gramática del siguiente texto. Devuelve solo la versión corregida:\n\n\"" . $text . "\"";
+
+    $payload = [
+        'contents' => [
+            [
+                'parts' => [
+                    ['text' => $prompt]
+                ]
+            ]
+        ]
+    ];
+
+    $error = null;
+    $api_response = _call_gemini_api($payload, $error);
+
+    if ($api_response === null) {
+        $msg = $error !== null ? $error : 'La llamada a la API de IA para la corrección falló.';
+        return "Error: " . $msg;
+    }
+
+    if (isset($api_response['candidates'][0]['content']['parts'][0]['text'])) {
+        $correction = trim($api_response['candidates'][0]['content']['parts'][0]['text']);
+        return !empty($correction) ? nl2br(htmlspecialchars($correction)) : "Error: La corrección generada por la IA estaba vacía.";
+    } elseif (isset($api_response['error']['message'])) {
+        return "Error de la API de IA: " . htmlspecialchars($api_response['error']['message']);
+    }
+
+    return "Error: Respuesta inesperada del servicio de corrección de IA.";
+}
+
 


### PR DESCRIPTION
## Summary
- implement `get_ai_translation` and `get_ai_correction` in `includes/ai_utils.php`
- document available AI helpers in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684322bd0fac8329a1c8236af7113d51