### PR TITLE
Fix index loading without DB password

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ $db_port = "5432";                // Puerto de PostgreSQL
 Ajusta esos valores según tu entorno para que la aplicación pueda acceder a la base de datos.
 
 El script obtiene la contraseña real desde la variable de entorno `CONDADO_DB_PASSWORD`.
-Si dicha variable no está definida, `dashboard/db_connect.php` lanzará una
-`RuntimeException` indicando el problema.
+Si dicha variable no está definida, el sitio seguirá funcionando con los textos por defecto
+y se registrará un aviso en el log del servidor.
 Para preparar la base de datos ejecuta en orden los scripts de `database_setup`: `01_create_tables.sql`, `02_create_museo_piezas_table.sql` y `03_create_tienda_productos.sql`.
 
 ## Comprobacion de la base de datos

--- a/dashboard/db_connect.php
+++ b/dashboard/db_connect.php
@@ -17,8 +17,10 @@ $db_name = "condado_castilla_db"; // Nombre de tu base de datos PostgreSQL
 $db_user = "condado_user";        // Usuario de tu base de datos PostgreSQL
 $db_pass = getenv('CONDADO_DB_PASSWORD'); // Definido vía variable de entorno
 if ($db_pass === false) {
-    // Generar un error claro si la variable de entorno no existe
-    throw new RuntimeException('Environment variable CONDADO_DB_PASSWORD is not set');
+    // Si la variable no existe, deja $pdo como null y registra el problema
+    error_log('dashboard/db_connect.php - CONDADO_DB_PASSWORD not set');
+    $pdo = null;
+    return;
 }
 $db_port = "5432";                // Puerto estándar de PostgreSQL
 

--- a/includes/text_manager.php
+++ b/includes/text_manager.php
@@ -14,7 +14,11 @@ if (!function_exists('is_admin_logged_in')) { // Evitar re-declaración si ya es
  * Obtiene el contenido de un texto desde la base de datos.
  * Si no se encuentra, inserta el texto por defecto y lo devuelve.
  */
-function getTextContentFromDB(string $text_id, PDO $pdo, string $default_text): string {
+function getTextContentFromDB(string $text_id, ?PDO $pdo, string $default_text): string {
+    if ($pdo === null) {
+        // Si no hay conexión a la base de datos, usar el valor por defecto
+        return $default_text;
+    }
     try {
         $stmt = $pdo->prepare("SELECT text_content FROM site_texts WHERE text_id = :text_id");
         $stmt->bindParam(':text_id', $text_id);
@@ -54,9 +58,13 @@ function getTextContentFromDB(string $text_id, PDO $pdo, string $default_text): 
  * @param string $css_classes Clases CSS adicionales para la etiqueta HTML contenedora.
  * @param bool $allow_html Si se permite HTML en el contenido (default: false, se usa htmlspecialchars).
  */
-function editableText(string $text_id, PDO $pdo, string $default_text, string $html_tag = 'span', string $css_classes = '', bool $allow_html = false) {
-    // Obtener el contenido del texto. Esta función ahora maneja la creación si no existe.
-    $content = getTextContentFromDB($text_id, $pdo, $default_text);
+function editableText(string $text_id, ?PDO $pdo, string $default_text, string $html_tag = 'span', string $css_classes = '', bool $allow_html = false) {
+    if ($pdo === null) {
+        $content = $default_text;
+    } else {
+        // Obtener el contenido del texto. Esta función ahora maneja la creación si no existe.
+        $content = getTextContentFromDB($text_id, $pdo, $default_text);
+    }
 
     // Escapar HTML si no está permitido, para prevenir XSS
     $display_content = $allow_html ? $content : htmlspecialchars($content);


### PR DESCRIPTION
## Summary
- gracefully handle missing `CONDADO_DB_PASSWORD` in `db_connect.php`
- allow `text_manager` functions to work when DB connection is unavailable
- document new behaviour in `README`

## Testing
- `php dashboard/test_text_manager.php`

------
https://chatgpt.com/codex/tasks/task_e_684325770a448329bbd3b999a83c830b