### PR TITLE
Add history-focused AI chat sidebar

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -6,6 +6,9 @@
 <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
     <i class="fas fa-moon"></i>
 </button>
+<button id="ia-chat-toggle" class="ia-chat-toggle" aria-label="Abrir chat IA">
+    <i class="fas fa-comments"></i>
+</button>
 <div id="sidebar" class="sidebar">
     <a href="/index.php" class="logo-link">
         <img src="/assets/img/AlfozCerasioLantaron.jpg" alt="Logo Alfoz de Cerasio y Lantarón" class="logo-image">
@@ -30,8 +33,15 @@
         <li><a href="https://chat.whatsapp.com/JWJ6mWXPuekIBZ8HJSSsZx" target="_blank" rel="noopener noreferrer"><i class="fab fa-whatsapp"></i> WhatsApp</a></li>
     </ul>
 </div>
-<div id="ia-tools-menu">
-    <button id="ia-summary-btn" type="button">Resumen IA</button>
-    <button id="ia-correction-btn" type="button">Corrección IA</button>
-    <button id="ia-translate-btn" type="button">Traducción IA</button>
+<div id="ia-chat-sidebar" class="ia-chat-sidebar">
+    <div id="ia-tools-menu" class="ia-tools-container">
+        <button id="ia-summary-btn" type="button">Resumen IA</button>
+        <button id="ia-correction-btn" type="button">Corrección IA</button>
+        <button id="ia-translate-btn" type="button">Traducción IA</button>
+    </div>
+    <div id="ia-chat-messages" class="ia-chat-messages"></div>
+    <form id="ia-chat-form" class="ia-chat-form">
+        <input type="text" id="ia-chat-input" placeholder="Pregunta sobre historia..." required />
+        <button type="submit">Enviar</button>
+    </form>
 </div>

--- a/ajax_actions/get_history_chat.php
+++ b/ajax_actions/get_history_chat.php
@@ -1,0 +1,28 @@
+<?php
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Método no permitido.']);
+    exit;
+}
+require_once __DIR__ . '/../includes/ai_utils.php';
+header('Content-Type: application/json; charset=utf-8');
+$input = json_decode(file_get_contents('php://input'), true);
+$question = isset($input['message']) ? trim($input['message']) : '';
+if ($question === '') {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'No se proporcionó mensaje.']);
+    exit;
+}
+if (function_exists('get_history_chat_response')) {
+    $reply = get_history_chat_response($question);
+    if (stripos($reply, 'Error:') === 0) {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => $reply]);
+    } else {
+        echo json_encode(['success' => true, 'reply' => $reply]);
+    }
+} else {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Funcionalidad no disponible.']);
+}
+?>

--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -277,6 +277,117 @@ th {
     transform: rotate(20deg);
 }
 
+/* --- IA Chat Sidebar and Toggle --- */
+#ia-chat-sidebar {
+    position: fixed;
+    top: 0;
+    right: -320px;
+    width: 320px;
+    height: 100vh;
+    background-color: var(--epic-transparent-overlay-dark);
+    backdrop-filter: blur(5px);
+    padding: 20px;
+    box-shadow: -3px 0 15px rgba(var(--epic-text-color-rgb), 0.25);
+    transition: right var(--global-transition-speed) ease-in-out;
+    overflow-y: auto;
+    z-index: 1001;
+    display: flex;
+    flex-direction: column;
+    border-left: 2px solid var(--epic-gold-secondary);
+}
+
+#ia-chat-sidebar.sidebar-visible {
+    right: 0;
+}
+
+#ia-chat-toggle {
+    position: fixed;
+    top: 15px;
+    right: 65px;
+    background-color: var(--epic-purple-emperor);
+    border: 2px solid var(--epic-gold-secondary);
+    border-radius: var(--global-border-radius);
+    padding: 10px;
+    cursor: pointer;
+    z-index: 1002;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    transition: right var(--global-transition-speed) ease-in-out,
+                background-color var(--global-transition-speed) ease;
+}
+
+#ia-chat-toggle i {
+    color: var(--epic-gold-main);
+}
+
+#ia-chat-toggle:hover {
+    background-color: var(--epic-gold-main);
+}
+
+#ia-chat-toggle:hover i {
+    color: var(--epic-purple-emperor);
+}
+
+body.ia-chat-active #ia-chat-toggle {
+    right: 335px;
+}
+
+#ia-chat-sidebar .ia-tools-container {
+    position: static;
+    margin-bottom: 15px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+#ia-chat-messages {
+    flex-grow: 1;
+    overflow-y: auto;
+    text-align: left;
+    margin-bottom: 10px;
+    color: var(--epic-text-light);
+}
+
+#ia-chat-form {
+    display: flex;
+    gap: 6px;
+}
+
+#ia-chat-input {
+    flex-grow: 1;
+    padding: 6px;
+    border-radius: var(--global-border-radius);
+    border: 1px solid var(--epic-gold-secondary);
+}
+
+#ia-chat-form button {
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+    border: 1px solid var(--epic-gold-secondary);
+    border-radius: var(--global-border-radius);
+    padding: 6px 12px;
+    cursor: pointer;
+}
+
+#ia-chat-form button:hover {
+    background-color: var(--epic-gold-secondary);
+}
+
+.chat-user {
+    color: var(--epic-gold-main);
+}
+
+.chat-ai {
+    color: var(--epic-alabaster-bg);
+}
+
+.chat-error {
+    color: red;
+}
+
 #sidebar-toggle .bar {
     display: block;
     width: 22px;
@@ -2642,9 +2753,6 @@ body.dark-mode #theme-toggle:hover i {
 
 /* === IA Tools Menu === */
 #ia-tools-menu {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
     margin: 0;
     padding: 10px;
     border: 1px solid var(--epic-gold-secondary);
@@ -2654,7 +2762,6 @@ body.dark-mode #theme-toggle:hover i {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    z-index: 1000;
 }
 
 #ia-tools-menu button {


### PR DESCRIPTION
## Summary
- add a right sidebar for an AI chat and tools
- implement JS to handle chat interactions
- style the new sidebar and toggle
- extend AI utilities with a history-only chat function that uses `nuevo4.md`
- add an endpoint to serve chat replies

## Testing
- `phpstan --version` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843275ce8a483299ca59a812894a367