### PR TITLE
Add CTA links on Alfoz page

### DIFF
--- a/alfoz/alfoz.html
+++ b/alfoz/alfoz.html
@@ -26,6 +26,11 @@
     </header>
 
     <main>
+        <section class="section">
+            <div class="container-epic">
+                <a href="indexalfoz.html" class="cta-button">Ver todas las aldeas del Alfoz</a>
+            </div>
+        </section>
         <section class="section detailed-intro-section">
             <div class="container page-content-block"> <p class="intro-paragraph">
                     En el umbral del amanecer, cuando la oscuridad aún abraza las cumbres de la <strong>Cordillera Ibérica</strong> y el primer rayo de sol tiñe el cielo de un dorado celestial, un halo de misterio se posa sobre las <strong>Tierras de Oca</strong>. Las ruinas de la <strong>Civitate Auca Patricia</strong> cobran vida en ese preciso instante, vibrando al compás de un tiempo perdido que todavía susurra. El aire frío lleva consigo el aliento de las montañas, mezclado con el aroma silvestre del tomillo, mientras la tierra despierta como si fuera la piel de un gigante que lentamente abre sus ojos, prometiendo vida, fertilidad y sueños.
@@ -133,6 +138,11 @@
                     <p>Según la regla, y su dominio en el CERESIS Azenar Sanz y Ennego Fortiz; Dominic Michael Merino; García, el fuerte y obecs Domínguez, corriendo en el juicio;</p>
                 </div>
 
+            </div>
+        </section>
+        <section class="section">
+            <div class="container-epic">
+                <a href="indexalfoz.html" class="cta-button">Listado completo de aldeas</a>
             </div>
         </section>
     </main>


### PR DESCRIPTION
## Summary
- link from Alfoz article to list of villages
- repeat CTA at end of article for easy access

## Testing
- `npm test` *(fails: package.json missing)*
- `vendor/bin/phpunit --version` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684328794dc8832999389bb3372642a0