### PR TITLE
Secure admin pages with login

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -26,7 +26,7 @@
         <li><a href="/visitas/visitas.html">Planifica Tu Visita</a></li>
         <li><a href="/cultura/cultura.html">Cultura y Legado</a></li>
         <li><a href="/personajes/indice_personajes.html">Personajes</a></li>
-        <li><a href="/empresa/index.html">Gestión de Yacimientos</a></li>
+        <li><a href="/empresa/index.php">Gestión de Yacimientos</a></li>
         <li><a href="/contacto/contacto.html">Contacto</a></li>
         <li><a href="/dashboard/login.php">Admin</a></li>
         <li><a href="https://www.facebook.com/groups/1052427398664069" target="_blank" rel="noopener noreferrer"><i class="fab fa-facebook-square"></i> Comunidad</a></li>

--- a/dashboard/get_stats.php
+++ b/dashboard/get_stats.php
@@ -1,5 +1,13 @@
 <?php
 header('Content-Type: application/json');
+
+if (session_status() == PHP_SESSION_NONE) {
+    @session_start();
+}
+
+require_once __DIR__ . '/../includes/auth.php';
+require_admin_login();
+
 require_once 'db_connect.php'; // Establece la conexión $pdo
 
 $response = ['success' => false, 'message' => 'Error desconocido.', 'data' => []];

--- a/empresa/index.php
+++ b/empresa/index.php
@@ -1,3 +1,7 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_admin_login();
+?>
 <!DOCTYPE html>
 <html lang="es">
 <head>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -109,7 +109,7 @@
     <lastmod>2025-06-06</lastmod>
   </url>
   <url>
-    <loc>https://condadodecastilla.com/empresa/index.html</loc>
+    <loc>https://condadodecastilla.com/empresa/index.php</loc>
     <lastmod>2025-06-06</lastmod>
   </url>
   <url>


### PR DESCRIPTION
## Summary
- protect yacimientos administration page behind login
- enforce login for dashboard stats endpoint
- update navigation link and sitemap

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6843280588988329a8cef9dc26970ddd