### PR TITLE
Use config constants in museum layout

### DIFF
--- a/js/museum-3d/museumLayout.js
+++ b/js/museum-3d/museumLayout.js
@@ -9,11 +9,8 @@ MUSEUM_3D.Layout = (function() {
     let scene; // Will be set by SceneManager
     const wallBoundingBoxes = [];
 
-    // Room definitions - these could be loaded from a config file in a more complex setup
-    // For now, keep them here. Positions are relative to (0,0,0) or each other.
-    const mainRoom = { name: 'MainRoom', x:0, y:0, z:0, width: 20, height: 5, depth: 25, doorWidth: 2, doorHeight: 2.5 };
-    const corridorA = { name: 'CorridorA', width: 4, height: 3.5, depth: 10, doorWidth: 2, doorHeight: 2.2 }; // Connects MainRoom to Room2
-    const room2 = { name: 'Room2', width: 15, height: 4.5, depth: 15, doorWidth: 2, doorHeight: 2.5 };
+    // Room definitions are centralized in MUSEUM_3D.Config
+    const { mainRoom, corridorA, room2 } = MUSEUM_3D.Config;
 
 
     function init(threeScene) {


### PR DESCRIPTION
## Summary
- import room dimensions from `MUSEUM_3D.Config`
- use these config values instead of local hard-coded objects

## Testing
- `npm test` *(fails: package.json missing)*
- `composer install` *(fails: composer not found)*
- `vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684328f7a6c083299c9c0e9569f3c532