### PR TITLE
Improve AI chat UX

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -349,6 +349,17 @@ body.ia-chat-active #ia-chat-toggle {
     text-align: left;
     margin-bottom: 10px;
     color: var(--epic-text-light);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.chat-message {
+    padding: 8px 12px;
+    border-radius: var(--global-border-radius);
+    box-shadow: var(--global-box-shadow-light);
+    margin: 2px 0;
+    line-height: 1.4;
 }
 
 #ia-chat-form {
@@ -378,14 +389,26 @@ body.ia-chat-active #ia-chat-toggle {
 
 .chat-user {
     color: var(--epic-gold-main);
+    background-color: rgba(var(--epic-gold-secondary-rgb), 0.25);
+    align-self: flex-end;
 }
 
 .chat-ai {
     color: var(--epic-alabaster-bg);
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.3);
+    align-self: flex-start;
+}
+
+.chat-typing {
+    font-style: italic;
+    color: var(--epic-alabaster-bg);
+    background-color: rgba(var(--epic-gold-main-rgb), 0.15);
+    align-self: flex-start;
 }
 
 .chat-error {
     color: red;
+    align-self: flex-start;
 }
 
 #sidebar-toggle .bar {

--- a/js/layout.js
+++ b/js/layout.js
@@ -113,6 +113,7 @@ function initializeIAChatSidebar() {
             if (!text) return;
             appendMessage('user', text);
             input.value = '';
+            const typingEl = appendMessage('typing', 'Gemini está escribiendo...');
             fetch('/ajax_actions/get_history_chat.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
@@ -121,21 +122,31 @@ function initializeIAChatSidebar() {
             .then(res => res.json())
             .then(data => {
                 if (data.success && data.reply) {
-                    appendMessage('ai', data.reply);
+                    typingEl.className = 'chat-ai chat-message';
+                    typingEl.innerHTML = data.reply;
                 } else if (data.error) {
-                    appendMessage('error', data.error);
+                    typingEl.className = 'chat-error chat-message';
+                    typingEl.innerHTML = data.error;
+                } else {
+                    typingEl.className = 'chat-error chat-message';
+                    typingEl.innerHTML = 'Error inesperado';
                 }
+                messages.scrollTop = messages.scrollHeight;
             })
-            .catch(err => appendMessage('error', err.message));
+            .catch(err => {
+                typingEl.className = 'chat-error chat-message';
+                typingEl.textContent = err.message;
+            });
         });
     }
 
     function appendMessage(role, text) {
         const p = document.createElement('p');
-        p.className = `chat-${role}`;
+        p.className = `chat-${role} chat-message`;
         p.innerHTML = text;
         messages.appendChild(p);
         messages.scrollTop = messages.scrollHeight;
+        return p;
     }
 }
 


### PR DESCRIPTION
## Summary
- style chat messages as bubbles for a slick look
- add typing indicator and interactive responses

## Testing
- `phpunit tests` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68432d3516408329a1c8b28eb1be79e7