### PR TITLE
Add museum page tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true">
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/MuseumPagesTest.php
+++ b/tests/MuseumPagesTest.php
@@ -1,0 +1,34 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class MuseumPagesTest extends TestCase {
+    private function runPage(string $script): array {
+        $cmd = sprintf('php -d auto_prepend_file=%s %s',
+            escapeshellarg(__DIR__.'/fixtures/prepend.php'),
+            escapeshellarg($script)
+        );
+        $descriptor = [1 => ['pipe','w'], 2 => ['pipe','w']];
+        $proc = proc_open($cmd, $descriptor, $pipes);
+        $output = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        $status = proc_close($proc);
+        return [$status, $output, $err];
+    }
+
+    public function pageProvider(): array {
+        return [
+            [__DIR__ . '/../subir_pieza.php'],
+            [__DIR__ . '/../galeria.php'],
+            [__DIR__ . '/../museo_3d.php'],
+        ];
+    }
+
+    /**
+     * @dataProvider pageProvider
+     */
+    public function testPagesLoad(string $path): void {
+        [$status, $out, $err] = $this->runPage($path);
+        $this->assertSame(0, $status, $err);
+        $this->assertNotEmpty($out);
+    }
+}


### PR DESCRIPTION
## Summary
- add `MuseumPagesTest` to verify pages load
- configure PHPUnit with a new `phpunit.xml`

## Testing
- `phpunit --configuration phpunit.xml` *(fails: Could not open input files and missing PDO driver)*

------
https://chatgpt.com/codex/tasks/task_e_68432f49dcc08329beb5803b49aeeee0