### PR TITLE
Improve text contrast in dark mode

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -2805,15 +2805,18 @@ body.dark-mode {
     --epic-alabaster-bg-rgb: 28, 32, 41;
     --epic-alabaster-medium: #2a2f39;
     --epic-alabaster-medium-rgb: 42, 47, 57;
-    --epic-text-color: #e5e5e5;
-    --epic-text-color-rgb: 229,229,229;
-    --epic-text-light: #b0b0b0;
-    --epic-text-light-rgb: 176,176,176;
+    --epic-text-color: #ffffff; /* Increased contrast */
+    --epic-text-color-rgb: 255,255,255; /* Increased contrast */
+    --epic-text-light: #f5f5f5; /* Lighter secondary text */
+    --epic-text-light-rgb: 245,245,245;
     --epic-icon-color: #a0b8d8; /* Base blue-gray for icons */
     --epic-icon-hover: #87cefa; /* Light sky blue for icon hover */
     background-image: none;
     background-color: var(--epic-alabaster-bg);
     filter: none;
+}
+body.dark-mode p {
+    text-shadow: 0 0 3px rgba(0, 0, 0, 0.6);
 }
 
 body.dark-mode #theme-toggle i {


### PR DESCRIPTION
## Summary
- increase text contrast in dark mode by adjusting `--epic-text-color` and related variables
- add a text shadow for paragraphs when in dark mode

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843334647708329a4f05f791215d035