### PR TITLE
Move crosshair div into body

### DIFF
--- a/museo/museo.php
+++ b/museo/museo.php
@@ -16,7 +16,6 @@
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/shaders/LuminosityHighPassShader.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/shaders/CopyShader.js"></script>
 
-    <div id="crosshair" style="position: fixed; top: 50%; left: 50%; width: 6px; height: 6px; background-color: rgba(255,255,255,0.6); border-radius: 50%; transform: translate(-50%, -50%); z-index: 9998; pointer-events: none; display: none;"></div>
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -26,7 +25,8 @@
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
-    <div id="linterna-condado"></div> 
+    <div id="crosshair" style="position: fixed; top: 50%; left: 50%; width: 6px; height: 6px; background-color: rgba(255,255,255,0.6); border-radius: 50%; transform: translate(-50%, -50%); z-index: 9998; pointer-events: none; display: none;"></div>
+    <div id="linterna-condado"></div>
     
     <div id="header-placeholder"></div> 
 

--- a/museo/museo_3d.php
+++ b/museo/museo_3d.php
@@ -14,7 +14,6 @@
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/postprocessing/UnrealBloomPass.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/shaders/LuminosityHighPassShader.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/shaders/CopyShader.js"></script>
-    <div id="crosshair" style="position: fixed; top: 50%; left: 50%; width: 6px; height: 6px; background-color: rgba(255,255,255,0.6); border-radius: 50%; transform: translate(-50%, -50%); z-index: 9998; pointer-events: none; display: none;"></div>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
@@ -22,6 +21,7 @@
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
+    <div id="crosshair" style="position: fixed; top: 50%; left: 50%; width: 6px; height: 6px; background-color: rgba(255,255,255,0.6); border-radius: 50%; transform: translate(-50%, -50%); z-index: 9998; pointer-events: none; display: none;"></div>
     <div id="linterna-condado"></div>
     <?php require_once __DIR__ . '/../_header.html'; ?>
 


### PR DESCRIPTION
## Summary
- fix markup by moving `#crosshair` into `<body>` for Museo pages

## Testing
- `composer install` *(fails: composer.lock invalid)*
- `phpunit --configuration phpunit.xml` *(fails: PDO driver missing and pages not found)*
- `phpstan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843353f64048329891d0abeb646f870