### PR TITLE
Use textContent for user chat messages

### DIFF
--- a/js/layout.js
+++ b/js/layout.js
@@ -173,7 +173,11 @@ function initializeIAChatSidebar() {
     function appendMessage(role, text) {
         const p = document.createElement('p');
         p.className = `chat-${role} chat-message`;
-        p.innerHTML = text;
+        if (role === 'user') {
+            p.textContent = text;
+        } else {
+            p.innerHTML = text;
+        }
         messages.appendChild(p);
         messages.scrollTop = messages.scrollHeight;
         return p;


### PR DESCRIPTION
## Summary
- sanitize user messages in chat by assigning via `textContent`
- preserve `innerHTML` usage for other roles

## Testing
- `node test_appendMessage.js` (with jsdom)

------
https://chatgpt.com/codex/tasks/task_e_6843371002988329883105c9dcbcbb45