### PR TITLE
Enable GeminiAPI env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ La API del museo está disponible en la ruta `/api/museo/piezas`, gestionada por
 
 Para realizar una prueba con la API de Gemini puedes utilizar el script `scripts/gemini_request.sh`. Este script envía una solicitud al modelo *gemini-2.0-flash* y muestra la respuesta.
 
-Antes de ejecutarlo, define la variable de entorno `GEMINI_API_KEY` con tu clave de API de Google:
+Antes de ejecutarlo, define la variable de entorno `GEMINI_API_KEY` con tu clave de API de Google (también se acepta la variable `GeminiAPI` como alternativa):
 
 ```bash
 export GEMINI_API_KEY="tu_clave"
@@ -78,6 +78,7 @@ Para que las funciones de IA de `includes/ai_utils.php` puedan comunicarse con l
 es necesario definir las siguientes variables de entorno:
 
 - `GEMINI_API_KEY`: clave de autenticación para las peticiones.
+- `GeminiAPI`: nombre alternativo para la clave de autenticación, útil si tu sistema ya define esta variable.
 - `GEMINI_API_ENDPOINT`: URL del servicio al que se enviarán las solicitudes. Si no se establece,
   se usa un valor de ejemplo que activa un simulador interno.
 

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -4,6 +4,10 @@
 // Read Gemini API settings from environment variables when available
 if (!defined('GEMINI_API_KEY')) {
     $envKey = getenv('GEMINI_API_KEY');
+    if ($envKey === false) {
+        // Compatibility: allow the variable name 'GeminiAPI'
+        $envKey = getenv('GeminiAPI');
+    }
     define('GEMINI_API_KEY', $envKey !== false ? $envKey : 'TU_API_KEY_AQUI_CONFIGURACION_ENTORNO');
 }
 if (!defined('GEMINI_API_ENDPOINT')) {

--- a/scripts/gemini_request.sh
+++ b/scripts/gemini_request.sh
@@ -4,8 +4,13 @@
 
 API_URL="https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
 
+# Allow the variable name GeminiAPI as an alternative
 if [ -z "$GEMINI_API_KEY" ]; then
-  echo "GEMINI_API_KEY environment variable not set" >&2
+  GEMINI_API_KEY="$GeminiAPI"
+fi
+
+if [ -z "$GEMINI_API_KEY" ]; then
+  echo "GEMINI_API_KEY or GeminiAPI environment variable not set" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- support `GeminiAPI` env var as alias of `GEMINI_API_KEY`
- document alternate variable in README
- allow gemini_request.sh to read either env var

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_68433859cad4832983e59c319aa1a7b6