### PR TITLE
Fix IA chat toggle when header is loaded dynamically

### DIFF
--- a/js/layout.js
+++ b/js/layout.js
@@ -17,6 +17,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 // in case the elements weren't ready on the first call.
                 initializeSidebarNavigation();
                 loadIAToolsScript();
+                // Ensure chat sidebar is initialized when header is loaded
+                initializeIAChatSidebar();
             })
             .catch(error => console.error('Error fetching _header.html:', error));
     }


### PR DESCRIPTION
## Summary
- reinitialize IA chat after dynamically loading the header so the chat button works on static pages

## Testing
- `composer install --no-interaction --no-progress --prefer-dist` *(fails: composer not found)*
- `vendor/bin/phpunit --version` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_68433e779f048329bf0695d5218cc17f