### PR TITLE
Activate unused code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__/
 .DS_Store
 Thumbs.db
 vendor/
+.phpunit.result.cache

--- a/ajax_actions/get_summary.php
+++ b/ajax_actions/get_summary.php
@@ -52,17 +52,26 @@ if (mb_strlen($text_to_summarize) > MAX_TEXT_LENGTH_FOR_SUMMARY) {
 if (function_exists('get_real_ai_summary')) {
     $summary_html = get_real_ai_summary($text_to_summarize);
 
-    // La función get_real_ai_summary ya formatea con nl2br(htmlspecialchars()) y devuelve "Error: ..."
-    // así que podemos confiar en su salida. Si empieza con "Error:", es un error.
     if (stripos($summary_html, "Error:") === 0) {
-        http_response_code(500); // O un código más específico si la función de resumen da más detalles.
-        echo json_encode(['success' => false, 'error' => $summary_html]);
-    } else {
-        echo json_encode(['success' => true, 'summary' => $summary_html]);
+        // Fallback to simple placeholder summary
+        if (function_exists('get_smart_summary')) {
+            $summary_html = get_smart_summary('fallback', $text_to_summarize);
+        } else {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => $summary_html]);
+            exit;
+        }
     }
+    echo json_encode(['success' => true, 'summary' => $summary_html]);
 } else {
-    http_response_code(500); // Internal Server Error
-    echo json_encode(['success' => false, 'error' => 'La funcionalidad de resumen IA no está disponible en el servidor.']);
+    // If real AI summary not available, use the placeholder if possible
+    if (function_exists('get_smart_summary')) {
+        $summary_html = get_smart_summary('fallback', $text_to_summarize);
+        echo json_encode(['success' => true, 'summary' => $summary_html]);
+    } else {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => 'La funcionalidad de resumen IA no está disponible en el servidor.']);
+    }
 }
 
 exit;

--- a/dashboard/logout.php
+++ b/dashboard/logout.php
@@ -5,21 +5,9 @@ if (session_status() == PHP_SESSION_NONE) {
     @session_start();
 }
 
-// Unset all session variables.
-$_SESSION = array();
+require_once __DIR__ . '/../includes/auth.php';
 
-// If it's desired to kill the session, also delete the session cookie.
-// Note: This will destroy the session, and not just the session data!
-if (ini_get("session.use_cookies")) {
-    $params = session_get_cookie_params();
-    setcookie(session_name(), '', time() - 42000,
-        $params["path"], $params["domain"],
-        $params["secure"], $params["httponly"]
-    );
-}
-
-// Finally, destroy the session.
-session_destroy();
+logout_user();
 
 // Redirect to the login page or homepage.
 // Redirecting to login.php is a common choice after logout.

--- a/index.php
+++ b/index.php
@@ -6,6 +6,7 @@ require_once 'includes/auth.php';      // For is_admin_logged_in()
 require_once 'dashboard/db_connect.php'; // Provides $pdo
 /** @var PDO $pdo */
 require_once 'includes/text_manager.php';// For editableText()
+require_once 'includes/ai_utils.php';
 ?>
 <!--
     IMPORTANTE: Este archivo ha sido convertido a PHP para permitir contenido editable.
@@ -48,6 +49,10 @@ require_once 'includes/text_manager.php';// For editableText()
         </div>
         <a href="/historia/historia.html" class="cta-button">Descubre la Historia</a>
     </header>
+    <?php
+        $hero_text = getTextContentFromDB('hero_parrafo_index', $pdo, 'Explora las ruinas del Alcázar de Casio, la Civitate Auca Patricia y descubre el origen de tu cultura milenaria en Cerezo de Río Tirón.');
+        echo get_smart_summary('index_hero', $hero_text);
+    ?>
 
     <section class="video-section section spotlight-active">
         <div class="container">


### PR DESCRIPTION
## Summary
- add ai utils include and show a smart summary on the home page
- fall back to get_smart_summary in get_summary.php
- rely on logout_user() in dashboard logout page
- ignore phpunit cache

## Testing
- `phpunit --configuration phpunit.xml` *(fails: PDO driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_68433e9db7188329a9c393adacfe654e