### PR TITLE
Add per-page CSS loader and styles

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -33,6 +33,19 @@
     --alabaster-background-image: url('/assets/img/alabastro.jpg');
 }
 
+@media (prefers-color-scheme: dark) {
+    :root:not(.light-mode) {
+        --epic-alabaster-bg: #1c2029;
+        --epic-alabaster-bg-rgb: 28, 32, 41;
+        --epic-alabaster-medium: #2a2f39;
+        --epic-alabaster-medium-rgb: 42, 47, 57;
+        --epic-text-color: #ffffff;
+        --epic-text-color-rgb: 255, 255, 255;
+        --epic-text-light: #f5f5f5;
+        --epic-text-light-rgb: 245, 245, 245;
+    }
+}
+
 /* --- Global Reset & Box Sizing --- */
 *,
 *::before,

--- a/assets/css/pages/galeria_colaborativa.css
+++ b/assets/css/pages/galeria_colaborativa.css
@@ -1,0 +1,14 @@
+/* Styles for galeria/galeria_colaborativa.php */
+body {
+    background-color: var(--epic-alabaster-bg, #F9F7F4);
+    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-size: cover;
+    background-attachment: fixed;
+}
+
+.upload-form-container {
+    background: var(--epic-transparent-overlay-light);
+    padding: 1.5em;
+    border-radius: var(--global-border-radius);
+    box-shadow: var(--global-box-shadow-light);
+}

--- a/assets/css/pages/index.css
+++ b/assets/css/pages/index.css
@@ -1,0 +1,17 @@
+/* Page-specific styles for index.php */
+body {
+    /* Use alabaster background, rely on global CSS variables if defined */
+    background-color: var(--epic-alabaster-bg, #F9F7F4);
+    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-size: cover;
+    background-attachment: fixed;
+}
+
+.hero {
+    animation: hero-fade 20s infinite alternate;
+}
+
+@keyframes hero-fade {
+    from { filter: brightness(1); }
+    to { filter: brightness(1.1) saturate(1.2); }
+}

--- a/assets/css/pages/tienda.css
+++ b/assets/css/pages/tienda.css
@@ -1,0 +1,14 @@
+/* Page-specific styles for tienda/index.php */
+body {
+    background-color: var(--epic-alabaster-bg, #F9F7F4);
+    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-attachment: fixed;
+}
+
+.card-grid .card {
+    transition: transform 0.3s ease;
+}
+.card-grid .card:hover {
+    transform: scale(1.05);
+    box-shadow: var(--global-box-shadow-medium);
+}

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -51,6 +51,7 @@ if (is_dir($gallery_dir)) {
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
+    <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
 </head>
 <body>
     <div id="linterna-condado"></div> <!-- Para el efecto de linterna -->

--- a/includes/load_page_css.php
+++ b/includes/load_page_css.php
@@ -1,0 +1,7 @@
+<?php
+$cssFile = '/assets/css/pages/' . basename($_SERVER['SCRIPT_NAME'], '.php') . '.css';
+$root = dirname(__DIR__);
+if (file_exists($root . $cssFile)) {
+    echo "<link rel=\"stylesheet\" href=\"{$cssFile}\">\n";
+}
+?>

--- a/index.php
+++ b/index.php
@@ -34,6 +34,7 @@ require_once 'includes/ai_utils.php';
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
+    <?php require_once __DIR__ . '/includes/load_page_css.php'; ?>
 
 </head>
 <body>

--- a/js/layout.js
+++ b/js/layout.js
@@ -1,4 +1,5 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener("DOMContentLoaded", function() {
+    loadPageCss();
     // Always initialize sidebar navigation. For PHP pages, elements are already there.
     // For static HTML pages, this will run, and then the header fetch below will populate the necessary elements.
     // The initializeSidebarNavigation function itself checks for element existence.
@@ -291,3 +292,18 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 });
+
+function loadPageCss() {
+    let page = window.location.pathname.split('/').pop();
+    if (!page) { page = 'index'; }
+    page = page.split('.')[0];
+    const cssPath = `/assets/css/pages/${page}.css`;
+    fetch(cssPath, { method: 'HEAD' }).then(res => {
+        if (res.ok) {
+            const link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.href = cssPath;
+            document.head.appendChild(link);
+        }
+    }).catch(() => {});
+}

--- a/tienda/index.php
+++ b/tienda/index.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/../includes/auth.php';
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tienda</title>
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
+    <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
 </head>
 <body>
 <?php require_once __DIR__ . '/../_header.html'; ?>


### PR DESCRIPTION
## Summary
- load page-specific CSS automatically from a new `load_page_css.php`
- create `tienda.css` and `galeria_colaborativa.css` for their respective pages
- inject automatic CSS loading for HTML pages via `layout.js`
- update index, tienda and galeria pages to use the loader

## Testing
- `phpunit --configuration phpunit.xml` *(fails: phpunit command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684393e4228c83299a92a6b47f10aaeb