### PR TITLE
Add dedicated header and footer styles

### DIFF
--- a/assets/css/components/footer.css
+++ b/assets/css/components/footer.css
@@ -1,0 +1,28 @@
+/* Dedicated footer styles with subtle animations */
+
+.footer {
+    background: linear-gradient(180deg, var(--epic-purple-emperor), var(--epic-gold-secondary));
+    color: var(--epic-text-light);
+    position: relative;
+    overflow: hidden;
+}
+
+.footer::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background-image: radial-gradient(circle at center, rgba(var(--epic-gold-main-rgb),0.2), transparent 70%);
+    animation: footerGlow 8s infinite alternate;
+}
+
+@keyframes footerGlow {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+body.dark-mode .footer {
+    background: linear-gradient(180deg, var(--epic-purple-emperor), var(--epic-alabaster-medium));
+}

--- a/assets/css/components/header.css
+++ b/assets/css/components/header.css
@@ -1,0 +1,29 @@
+/* Styles specific to the shared header loaded on most pages */
+
+#sidebar,
+#ia-chat-sidebar {
+    background-color: rgba(var(--epic-alabaster-bg-rgb), 0.95);
+    box-shadow: 0 0 25px rgba(var(--epic-gold-main-rgb), 0.2);
+}
+
+body.dark-mode #sidebar,
+body.dark-mode #ia-chat-sidebar {
+    background-color: rgba(var(--epic-alabaster-medium-rgb), 0.9);
+}
+
+#sidebar-toggle,
+#theme-toggle,
+#ia-chat-toggle {
+    backdrop-filter: blur(3px);
+    background-color: rgba(var(--epic-alabaster-medium-rgb), 0.8);
+    transition: transform var(--global-transition-speed) ease,
+                background-color var(--global-transition-speed) ease;
+}
+
+#sidebar-toggle:hover,
+#theme-toggle:hover,
+#ia-chat-toggle:hover {
+    transform: scale(1.1);
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+}

--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -33,6 +33,19 @@
     --alabaster-background-image: url('/assets/img/alabastro.jpg');
 }
 
+@media (prefers-color-scheme: dark) {
+    :root:not(.light-mode) {
+        --epic-alabaster-bg: #1c2029;
+        --epic-alabaster-bg-rgb: 28, 32, 41;
+        --epic-alabaster-medium: #2a2f39;
+        --epic-alabaster-medium-rgb: 42, 47, 57;
+        --epic-text-color: #ffffff;
+        --epic-text-color-rgb: 255, 255, 255;
+        --epic-text-light: #f5f5f5;
+        --epic-text-light-rgb: 245, 245, 245;
+    }
+}
+
 /* --- Global Reset & Box Sizing --- */
 *,
 *::before,

--- a/assets/css/pages/galeria_colaborativa.css
+++ b/assets/css/pages/galeria_colaborativa.css
@@ -1,0 +1,14 @@
+/* Styles for galeria/galeria_colaborativa.php */
+body {
+    background-color: var(--epic-alabaster-bg, #F9F7F4);
+    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-size: cover;
+    background-attachment: fixed;
+}
+
+.upload-form-container {
+    background: var(--epic-transparent-overlay-light);
+    padding: 1.5em;
+    border-radius: var(--global-border-radius);
+    box-shadow: var(--global-box-shadow-light);
+}

--- a/assets/css/pages/index.css
+++ b/assets/css/pages/index.css
@@ -1,0 +1,17 @@
+/* Page-specific styles for index.php */
+body {
+    /* Use alabaster background, rely on global CSS variables if defined */
+    background-color: var(--epic-alabaster-bg, #F9F7F4);
+    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-size: cover;
+    background-attachment: fixed;
+}
+
+.hero {
+    animation: hero-fade 20s infinite alternate;
+}
+
+@keyframes hero-fade {
+    from { filter: brightness(1); }
+    to { filter: brightness(1.1) saturate(1.2); }
+}

--- a/assets/css/pages/tienda.css
+++ b/assets/css/pages/tienda.css
@@ -1,0 +1,14 @@
+/* Page-specific styles for tienda/index.php */
+body {
+    background-color: var(--epic-alabaster-bg, #F9F7F4);
+    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-attachment: fixed;
+}
+
+.card-grid .card {
+    transition: transform 0.3s ease;
+}
+.card-grid .card:hover {
+    transform: scale(1.05);
+    box-shadow: var(--global-box-shadow-medium);
+}

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -51,6 +51,7 @@ if (is_dir($gallery_dir)) {
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
+    <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
 </head>
 <body>
     <div id="linterna-condado"></div> <!-- Para el efecto de linterna -->

--- a/includes/load_page_css.php
+++ b/includes/load_page_css.php
@@ -1,0 +1,18 @@
+<?php
+$script = $_SERVER['SCRIPT_NAME'];
+$root = dirname(__DIR__);
+
+// Determine CSS file based on script path
+$base = basename($script, '.php');
+$dir  = trim(dirname($script), '/');
+
+if ($base === 'index' && $dir !== '') {
+    $cssFile = "/assets/css/pages/{$dir}.css";
+} else {
+    $cssFile = "/assets/css/pages/{$base}.css";
+}
+
+if (file_exists($root . $cssFile)) {
+    echo "<link rel=\"stylesheet\" href=\"{$cssFile}\">\n";
+}
+?>

--- a/index.php
+++ b/index.php
@@ -34,6 +34,7 @@ require_once 'includes/ai_utils.php';
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
+    <?php require_once __DIR__ . '/includes/load_page_css.php'; ?>
 
 </head>
 <body>

--- a/js/layout.js
+++ b/js/layout.js
@@ -1,4 +1,6 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener("DOMContentLoaded", function() {
+    loadPageCss();
+    loadCommonCss();
     // Always initialize sidebar navigation. For PHP pages, elements are already there.
     // For static HTML pages, this will run, and then the header fetch below will populate the necessary elements.
     // The initializeSidebarNavigation function itself checks for element existence.
@@ -291,3 +293,45 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 });
+
+function loadPageCss() {
+    let path = window.location.pathname;
+    if (path.endsWith('/')) path += 'index.php';
+    const segments = path.split('/').filter(Boolean);
+    let base = segments.pop() || 'index.php';
+    base = base.replace('.php', '');
+    const dir = segments.pop();
+
+    let cssPath;
+    if (base === 'index' && dir) {
+        cssPath = `/assets/css/pages/${dir}.css`;
+    } else {
+        cssPath = `/assets/css/pages/${base}.css`;
+    }
+
+    fetch(cssPath, { method: 'HEAD' }).then(res => {
+        if (res.ok) {
+            const link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.href = cssPath;
+            document.head.appendChild(link);
+        }
+    }).catch(() => {});
+}
+
+function loadCommonCss() {
+    const files = [
+        '/assets/css/components/header.css',
+        '/assets/css/components/footer.css'
+    ];
+    files.forEach(path => {
+        fetch(path, { method: 'HEAD' }).then(res => {
+            if (res.ok) {
+                const link = document.createElement('link');
+                link.rel = 'stylesheet';
+                link.href = path;
+                document.head.appendChild(link);
+            }
+        }).catch(() => {});
+    });
+}

--- a/tienda/index.php
+++ b/tienda/index.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/../includes/auth.php';
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tienda</title>
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
+    <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
 </head>
 <body>
 <?php require_once __DIR__ . '/../_header.html'; ?>
@@ -44,5 +45,6 @@ require_once __DIR__ . '/../includes/auth.php';
     </div>
 </main>
 <?php require_once __DIR__ . '/../_footer.html'; ?>
+<script src="/js/layout.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create `header.css` and `footer.css` for component-specific styling
- load these shared styles automatically via `layout.js`
- include component styles in `index.php`, `tienda/index.php`, and gallery page
- fix page CSS loader for subdirectory pages and remove duplicate `<link>` tags
- load `layout.js` on the shop page

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684393e4228c83299a92a6b47f10aaeb