### PR TITLE
Add daily maintenance agent

### DIFF
--- a/.github/workflows/daily_agent.yml
+++ b/.github/workflows/daily_agent.yml
@@ -1,0 +1,18 @@
+name: Daily Agent
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  daily-tasks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run daily agent
+        run: |
+          python scripts/daily_agent.py

--- a/README.md
+++ b/README.md
@@ -128,3 +128,13 @@ Ejemplo de creación del directorio en Linux:
 mkdir -p uploads_storage/museo_piezas
 chmod 775 uploads_storage/museo_piezas
 ```
+
+## Agente diario
+
+Se incluye el script `scripts/daily_agent.py` que ejecuta tareas de mantenimiento automáticas:
+
+- Generación del `sitemap.xml`.
+- Comprobación de enlaces internos.
+- Opcionalmente, verificación de la base de datos y una solicitud de prueba a la API de Gemini.
+
+Puede programarse con `cron` o utilizar el *workflow* de GitHub en `.github/workflows/daily_agent.yml`, el cual se ejecuta cada día de forma automática.

--- a/scripts/daily_agent.py
+++ b/scripts/daily_agent.py
@@ -1,0 +1,44 @@
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(cmd: str) -> bool:
+    print(f"Running: {cmd}")
+    result = subprocess.run(cmd, shell=True, cwd=REPO_ROOT)
+    if result.returncode != 0:
+        print(f"Command failed with code {result.returncode}: {cmd}")
+        return False
+    return True
+
+
+def main() -> None:
+    success = True
+
+    # Generate sitemap
+    success &= run("python scripts/generate_sitemap.py")
+
+    # Check internal links
+    success &= run("python scripts/link_checker.py")
+
+    # Optional database connectivity check
+    if os.getenv("CONDADO_DB_PASSWORD"):
+        success &= run("./scripts/check_db.sh")
+    else:
+        print("CONDADO_DB_PASSWORD not set, skipping database check.")
+
+    # Optional Gemini API test
+    if os.getenv("GEMINI_API_KEY") or os.getenv("GeminiAPI"):
+        run("bash scripts/gemini_request.sh")
+    else:
+        print("GEMINI_API_KEY not set, skipping Gemini API test.")
+
+    if not success:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `daily_agent.py` script to run sitemap and link checks daily
- schedule workflow with `daily_agent.yml`
- document daily agent in the README

## Testing
- `python scripts/daily_agent.py`
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844239c7d10832997fa3f4c740f1302