### PR TITLE
Improve Museo 3D player experience

### DIFF
--- a/js/museum-3d/playerControls.js
+++ b/js/museum-3d/playerControls.js
@@ -59,6 +59,11 @@ MUSEUM_3D.PlayerControls = (function() {
         // ^ This line should be called from museo-3d-main.js after scene is available.
 
         instructionsElement.addEventListener('click', function () {
+            if (!document.fullscreenElement && document.body.requestFullscreen) {
+                document.body.requestFullscreen().catch(function(err) {
+                    console.warn('Fullscreen request failed:', err);
+                });
+            }
             controlsFPS.lock();
         });
 
@@ -83,6 +88,11 @@ MUSEUM_3D.PlayerControls = (function() {
             if (crosshairElement) crosshairElement.style.display = 'none';
             document.removeEventListener('keydown', onKeyDown);
             document.removeEventListener('keyup', onKeyUp);
+            if (document.fullscreenElement && document.exitFullscreen) {
+                document.exitFullscreen().catch(function(err) {
+                    console.warn('Exiting fullscreen failed:', err);
+                });
+            }
             // Clear any interaction highlights when controls are unlocked
             if (MUSEUM_3D.ExhibitManager) {
                 MUSEUM_3D.ExhibitManager.clearFocus();


### PR DESCRIPTION
## Summary
- request fullscreen mode when entering Museo 3D
- exit fullscreen when controls unlock

## Testing
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684423d554748329b9f38b1a212f04a4