### PR TITLE
Refactor header and chat menu

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -14,7 +14,7 @@
 <button id="ia-chat-toggle" class="ia-chat-toggle" aria-label="Abrir chat IA">
     <i class="fas fa-comments"></i>
 </button>
-<div id="sidebar" class="sidebar">
+<nav id="sidebar" class="sidebar" role="navigation">
     <a href="/index.php" class="logo-link">
         <img src="/assets/img/AlfozCerasioLantaron.jpg" alt="Logo Alfoz de Cerasio y Lantarón" class="logo-image">
     </a>
@@ -40,7 +40,7 @@
         <li><a href="https://www.facebook.com/groups/1052427398664069" target="_blank" rel="noopener noreferrer"><i class="fab fa-facebook-square"></i> Comunidad</a></li>
         <li><a href="https://chat.whatsapp.com/JWJ6mWXPuekIBZ8HJSSsZx" target="_blank" rel="noopener noreferrer"><i class="fab fa-whatsapp"></i> WhatsApp</a></li>
     </ul>
-</div>
+</nav>
     <div id="ia-chat-sidebar" class="ia-chat-sidebar">
         <div class="ia-chat-header drag-handle">
             <form id="ia-chat-form" class="ia-chat-form">

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -1,0 +1,361 @@
+/* --- Sidebar Navigation (#sidebar, #sidebar-toggle from _header.html) --- */
+#sidebar {
+    position: fixed;
+    top: 0;
+    left: -280px; /* Initial hidden state */
+    width: 280px;
+    height: 100vh;
+    background-color: var(--epic-alabaster-bg);
+    backdrop-filter: blur(5px); /* Optional: frosted glass effect */
+    padding: 25px 15px; /* Refined padding */
+    box-shadow: 3px 0 15px rgba(var(--epic-text-color-rgb), 0.25);
+    transition: left var(--global-transition-speed) ease-in-out;
+    overflow-y: auto;
+    z-index: 3000;
+    display: flex;
+    flex-direction: column;
+    border-right: 2px solid var(--epic-gold-secondary);
+}
+
+#sidebar.sidebar-visible {
+    left: 0;
+}
+
+#sidebar-toggle {
+    position: fixed;
+    top: 15px;
+    left: 15px;
+    /* font-size: 1.8em; Removed as icon is no longer text */
+    background-color: var(--epic-alabaster-bg);
+    border: 2px solid var(--epic-gold-secondary);
+    border-radius: var(--global-border-radius);
+    padding: 10px; /* Adjusted padding for icon */
+    cursor: pointer;
+    z-index: 3001;
+    transition: left var(--global-transition-speed) ease-in-out, background-color var(--global-transition-speed) ease, color var(--global-transition-speed) ease;
+    display: flex; /* For centering bars if needed, or for layout of bars */
+    flex-direction: column;
+    justify-content: space-around;
+    width: 44px; /* Fixed width for consistency */
+    height: 44px; /* Fixed height for consistency */
+}
+
+/* Theme Toggle Button */
+#theme-toggle {
+    position: fixed;
+    top: 15px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: var(--epic-alabaster-bg);
+    border: 2px solid var(--epic-gold-secondary);
+    border-radius: var(--global-border-radius);
+    padding: 10px;
+    cursor: pointer;
+    z-index: 3001;
+    transition: background-color var(--global-transition-speed) ease,
+                color var(--global-transition-speed) ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+}
+
+#theme-toggle i {
+    color: var(--epic-gold-main);
+    font-size: 1.2em;
+    transition: transform var(--global-transition-speed) ease;
+}
+
+#theme-toggle:hover {
+    background-color: var(--epic-gold-main);
+}
+
+#theme-toggle:hover i {
+    color: var(--epic-purple-emperor);
+    transform: rotate(20deg);
+}
+
+/* --- IA Chat Sidebar and Toggle --- */
+#ia-chat-sidebar {
+    position: fixed;
+    top: 0;
+    right: -25vw; /* Initial hidden state, JS will change to 0 */
+    left: auto;
+    width: clamp(280px, 70vw, 400px);
+    height: 100vh;
+    background-color: var(--epic-alabaster-bg);
+    backdrop-filter: blur(5px);
+    padding: 20px;
+    box-shadow: 0 0 15px rgba(var(--epic-text-color-rgb), 0.25);
+    transition: right var(--global-transition-speed) ease-in-out;
+    overflow: auto;
+    z-index: 3000;
+    display: flex;
+    flex-direction: column;
+    border: 2px solid var(--epic-gold-secondary);
+    resize: both;
+    opacity: 1;
+    pointer-events: none;
+}
+
+#ia-chat-sidebar.sidebar-visible {
+    right: 0;
+    pointer-events: auto;
+}
+
+#ia-chat-sidebar.dragging {
+    opacity: 0.9;
+    cursor: move;
+}
+
+#ia-chat-toggle {
+    position: fixed;
+    top: 15px;
+    right: 15px;
+    background-color: var(--epic-alabaster-bg);
+    border: 2px solid var(--epic-gold-secondary);
+    border-radius: var(--global-border-radius);
+    padding: 10px;
+    cursor: pointer;
+    z-index: 3001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    transition: right var(--global-transition-speed) ease-in-out,
+                background-color var(--global-transition-speed) ease;
+}
+
+#ia-chat-toggle i {
+    color: var(--epic-gold-main);
+}
+
+#ia-chat-toggle:hover {
+    background-color: var(--epic-gold-main);
+}
+
+#ia-chat-toggle:hover i {
+    color: var(--epic-purple-emperor);
+}
+
+body.dark-mode #ia-chat-toggle i {
+    color: var(--epic-icon-color);
+}
+
+body.dark-mode #ia-chat-toggle:hover i {
+    color: var(--epic-icon-hover);
+}
+
+body.ia-chat-active #ia-chat-toggle {
+    /* Keep toggle in place when chat is active */
+    right: 15px;
+}
+
+.ia-chat-header {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 10px;
+    cursor: move;
+}
+
+#ia-chat-sidebar .ia-tools-container {
+    position: static;
+    margin-bottom: 15px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+#ia-chat-messages {
+    flex-grow: 1;
+    overflow-y: auto;
+    text-align: left;
+    margin-bottom: 10px;
+    color: var(--epic-text-light);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.chat-message {
+    padding: 8px 12px;
+    border-radius: var(--global-border-radius);
+    box-shadow: var(--global-box-shadow-light);
+    margin: 2px 0;
+    line-height: 1.4;
+}
+
+#ia-chat-form {
+    display: flex;
+    gap: 6px;
+}
+
+#ia-chat-input {
+    flex-grow: 1;
+    padding: 6px;
+    border-radius: var(--global-border-radius);
+    border: 1px solid var(--epic-gold-secondary);
+    resize: none;
+    overflow-y: auto; /* Changed from hidden */
+    min-height: calc(1.4em + 12px + 2px); /* Added */
+    max-height: 100px; /* Added */
+}
+
+#ia-chat-response {
+    border: 1px solid var(--epic-gold-secondary);
+    background-color: var(--epic-alabaster-bg);
+    border-radius: var(--global-border-radius);
+    padding: 8px;
+    margin: 6px 0;
+    min-height: 50px;
+    overflow-y: auto;
+}
+
+#ia-chat-form button {
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+    border: 1px solid var(--epic-gold-secondary);
+    border-radius: var(--global-border-radius);
+    padding: 6px 12px;
+    cursor: pointer;
+}
+
+#ia-chat-form button:hover {
+    background-color: var(--epic-gold-secondary);
+}
+
+
+.chat-user {
+    color: var(--epic-text-color);
+    background-color: var(--epic-alabaster-bg);
+    align-self: flex-end;
+}
+
+.chat-ai {
+    color: var(--epic-text-color);
+    background-color: var(--epic-alabaster-bg);
+    align-self: flex-start;
+}
+
+.chat-typing {
+    font-style: italic;
+    color: var(--epic-text-color);
+    background-color: var(--epic-alabaster-bg);
+    align-self: flex-start;
+}
+
+.chat-error {
+    color: red;
+    align-self: flex-start;
+}
+
+/* Container to display IA tool responses inside the chat sidebar */
+#ia-tools-response {
+    background-color: var(--epic-alabaster-bg);
+    border: 1px solid var(--epic-gold-secondary);
+    border-radius: var(--global-border-radius);
+    padding: 8px;
+    max-height: 200px;
+    overflow-y: auto;
+    margin-bottom: 10px;
+}
+
+#ia-tools-response.hidden {
+    display: none;
+}
+
+#sidebar-toggle .bar {
+    display: block;
+    width: 22px;
+    height: 3px;
+    background-color: var(--epic-gold-main); /* Default bar color */
+    margin: 2px auto; /* Adjusted margin for tighter packing, auto for horizontal centering */
+    transition: all 0.3s ease-in-out;
+    border-radius: 1px;
+}
+
+#sidebar-toggle:hover .bar {
+    background-color: var(--epic-purple-emperor); /* Bars turn purple when button is hovered (gold bg) */
+}
+
+#sidebar-toggle:hover {
+    background-color: var(--epic-gold-main);
+    /* color: var(--epic-purple-emperor); No longer needed for text icon */
+}
+
+/* Adjust toggle button position and icon animation when sidebar is visible */
+body.sidebar-active #sidebar-toggle {
+    left: 300px; /* sidebar width + desired offset */
+}
+
+body.sidebar-active #sidebar-toggle .bar:nth-child(1) {
+    transform: translateY(7px) rotate(45deg); /* height (3px) + margin (4px from example, using 2px*2=4 + 3/2 for center = ~7) */
+}
+body.sidebar-active #sidebar-toggle .bar:nth-child(2) {
+    opacity: 0;
+}
+body.sidebar-active #sidebar-toggle .bar:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+}
+
+/* Ensure bars maintain correct color on hover when active (X shape) */
+body.sidebar-active #sidebar-toggle:hover .bar {
+    background-color: var(--epic-purple-emperor); /* Or whatever the X color should be on hover */
+}
+
+
+#sidebar .logo-link {
+    display: block;
+    /* text-align: center; */
+    margin-bottom: 30px; /* Refined margin */
+    padding: 10px 0;
+}
+
+#sidebar .logo-image {
+    max-width: 80%;
+    height: auto;
+    border-radius: var(--global-border-radius);
+    margin: 0 auto; /* Centering already handled by parent text-align and block display */
+    border: 3px solid var(--epic-gold-secondary);
+    background-color: var(--epic-alabaster-bg); /* Alabaster background for logo */
+}
+
+#sidebar .nav-links { /* Uses existing .nav-links class */
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start; /* Align items to the start for left text align */
+    width: 100%;
+}
+
+#sidebar .nav-links li {
+    width: 100%;
+    margin-bottom: 8px;
+}
+
+#sidebar .nav-links a {
+    display: block;
+    padding: 12px 15px;
+    color: var(--epic-text-light); /* Light text for dark sidebar */
+    font-family: var(--font-headings);
+    font-size: 1.1em;
+    font-weight: 600;
+    text-decoration: none;
+    border-radius: var(--global-border-radius);
+    transition: background-color var(--global-transition-speed) ease-in-out, color var(--global-transition-speed) ease-in-out, padding-left var(--global-transition-speed) ease-in-out;
+    text-align: left; /* Explicitly left align sidebar links */
+}
+
+#sidebar .nav-links a:hover,
+#sidebar .nav-links a:focus-visible,
+#sidebar .nav-links a.active-link { /* active-link might need JS to set based on current page */
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+    padding-left: 25px; /* Indent on hover/active */
+    outline: none;
+}
+

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -1,0 +1,14 @@
+<?php
+if (session_status() == PHP_SESSION_NONE) {
+    @session_start();
+}
+?>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+<link rel="stylesheet" href="/assets/css/epic_theme.css">
+<link rel="stylesheet" href="/assets/css/header.css">

--- a/index.php
+++ b/index.php
@@ -26,14 +26,7 @@ require_once 'includes/ai_utils.php';
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Condado de Castilla - Cuna de tu Cultura y Lengua</title>
-    <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+    <?php include __DIR__ . '/includes/head_common.php'; ?>
     <?php require_once __DIR__ . '/includes/load_page_css.php'; ?>
 
 </head>

--- a/js/layout.js
+++ b/js/layout.js
@@ -1,5 +1,6 @@
 document.addEventListener("DOMContentLoaded", function() {
     loadPageCss();
+    loadHeaderCss();
     // Always initialize sidebar navigation. For PHP pages, elements are already there.
     // For static HTML pages, this will run, and then the header fetch below will populate the necessary elements.
     // The initializeSidebarNavigation function itself checks for element existence.
@@ -140,6 +141,12 @@ function initializeIAChatSidebar() {
         toggle.addEventListener('click', () => {
             sidebar.classList.toggle('sidebar-visible');
             document.body.classList.toggle('ia-chat-active');
+        });
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && sidebar.classList.contains('sidebar-visible')) {
+                sidebar.classList.remove('sidebar-visible');
+                document.body.classList.remove('ia-chat-active');
+            }
         });
     }
 
@@ -306,4 +313,14 @@ function loadPageCss() {
             document.head.appendChild(link);
         }
     }).catch(() => {});
+}
+
+function loadHeaderCss() {
+    if (!document.getElementById('header-css')) {
+        const link = document.createElement('link');
+        link.id = 'header-css';
+        link.rel = 'stylesheet';
+        link.href = '/assets/css/header.css';
+        document.head.appendChild(link);
+    }
 }


### PR DESCRIPTION
## Summary
- convert header sidebar to semantic `<nav>`
- load common head contents via new include
- extract header styles to new `header.css`
- auto inject header CSS from layout script
- add escape key handling for chat sidebar

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442671032c8329ade396d06ad6eebf