### PR TITLE
Unify styling across site

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -3006,3 +3006,261 @@ body.dark-mode #ia-tools-output .ia-output-close:hover {
 body {
     top: 0 !important;
 }
+
+/* === galeria_personajes.css === */
+/* Inherits body background from epic_theme.css or specific page */
+
+/* Container for the gallery section - already styled by .container in the HTML from previous step,
+   or if we want specific styles for this section's container that differ from the global .container */
+.character-gallery-container {
+    padding: 20px 0; /* Vertical padding, horizontal handled by .container or auto margins */
+    margin-top: 2em;
+    margin-bottom: 2em;
+    /* background-color: var(--epic-alabaster-bg); /* Optional: if it needs a distinct background */
+    /* border-radius: var(--global-border-radius); */
+    /* box-shadow: var(--global-box-shadow-light); */
+}
+
+/* Heading for the gallery */
+.character-gallery-container h2 {
+    text-align: center; /* Default from theme, but can be explicit */
+    color: var(--epic-gold-secondary); /* Consistent with other H2s */
+    font-family: var(--font-headings);
+    font-size: clamp(2em, 5vw, 3em); /* Consistent with .section-title */
+    margin-bottom: 1em;
+}
+.character-gallery-container h2::after { /* Optional: decorative element like .section-title */
+    content: '';
+    display: block;
+    width: 40px;
+    height: 40px;
+    background-image: url('/assets/img/estrella.png'); /* Assuming this is a theme element */
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    margin: 15px auto 30px auto;
+    opacity: 0.7;
+    filter: drop-shadow(0 0 6px var(--epic-gold-main));
+}
+
+
+/* Grid layout for the gallery items */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); /* Responsive columns */
+    gap: 25px; /* Space between items */
+    padding: 20px;
+    max-width: 1200px; /* Optional: constrain max width of the grid itself */
+    margin: 0 auto; /* Center the grid if max-width is set */
+}
+
+/* Individual gallery item card */
+.gallery-item {
+    background-color: var(--epic-alabaster-bg); /* Light background for card */
+    border: 2px solid var(--epic-gold-secondary); /* Gold border */
+    border-radius: var(--global-border-radius); /* Theme border radius */
+    box-shadow: var(--global-box-shadow-medium); /* Theme shadow */
+    padding: 20px;
+    text-align: center; /* Center text and image (if block and margin auto) */
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    display: flex;
+    flex-direction: column;
+    align-items: center; /* Center items like image and text block */
+}
+
+.gallery-item:hover {
+    transform: translateY(-8px) scale(1.03);
+    box-shadow: var(--global-box-shadow-dark);
+}
+
+/* Character image within the card */
+.gallery-item img {
+    width: 100%; /* Make image take full width of its container part */
+    max-width: 180px; /* Max width for the image itself */
+    height: 180px; /* Fixed height for consistency */
+    object-fit: cover; /* Cover the area, cropping if necessary */
+    border-radius: 50%; /* Circular images */
+    border: 4px solid var(--epic-gold-main); /* Gold border for image */
+    margin-bottom: 15px; /* Space below image */
+    box-shadow: 0 2px 6px rgba(var(--epic-text-color-rgb), 0.15);
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.gallery-item:hover img {
+    transform: scale(1.05);
+    border-color: var(--epic-purple-emperor);
+}
+
+/* Character name paragraph */
+.gallery-item p {
+    font-family: var(--font-headings); /* Cinzel for names */
+    font-size: clamp(1.1em, 2.5vw, 1.3em);
+    color: var(--epic-purple-emperor); /* Purple for names */
+    margin-top: 0.5em;
+    margin-bottom: 0; /* Remove default p margin if not needed */
+    font-weight: 700;
+    line-height: 1.3;
+}
+
+/* Ensure styles from the old galeria_personajes.css are not interfering
+   or are properly overridden if this file is meant to replace it.
+   The styles provided here are for the new .character-gallery-container, .gallery-grid, .gallery-item.
+   The old .character-gallery, .character-card might still exist if the HTML wasn't fully changed.
+   Assuming the new HTML structure is used.
+*/
+
+/* Previous styles from the first version of galeria_personajes.css for .character-card, etc.
+   can be removed or adapted if the HTML structure has completely changed to .gallery-item.
+   For this task, we focus on styling the new structure.
+*/
+
+/* Removing old styles that might conflict if HTML was not updated:
+body {
+    background-image: url('../img/fondo.jpeg');
+    background-size: cover;
+} -> This is handled by epic_theme.css or page-specific body styles
+
+.container {
+    width: 80%;
+    margin: 20px auto;
+    background-color: white;
+    padding: 20px;
+    border: 2px solid black;
+} -> This is an old .container, the new page uses .container-epic or .page-content-block from the theme,
+    and the HTML for indice_personajes.html uses <div class="container page-content-block">.
+    The existing rules in epic_theme.css for .page-content-block and .container (from estilos.css)
+    will apply to that element. We don't need to redefine .container here unless it's a different one.
+
+.character-gallery { ... }
+.character-card { ... }
+.character-card img { ... }
+    -> These were for the old structure. The new structure is .gallery-grid and .gallery-item.
+       If the old HTML is still present elsewhere and needs these, they should be in a separate file
+       or carefully namespaced. For this task, we are styling the new gallery.
+*/
+
+/* === demo_transparencia_movimiento.css === */
+:root {
+    --morado-emperador: #4A0D67;
+    --albastro: #F9F7F4;
+    --oro-viejo: #CFB53B;
+}
+
+.demo-hero {
+    background: linear-gradient(
+        rgba(74, 13, 103, 0.7),
+        rgba(74, 13, 103, 0.7)
+    ), url('/imagenes/alabastro.jpg') center/cover no-repeat;
+    color: var(--albastro);
+    padding: 5rem 2rem;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+}
+
+.demo-hero h1 {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+    animation: fade-slide-in 1s ease forwards;
+}
+
+.demo-card {
+    background: rgba(255, 255, 255, 0.25);
+    backdrop-filter: blur(8px);
+    border: 2px solid var(--oro-viejo);
+    border-radius: 10px;
+    padding: 2rem;
+    max-width: 500px;
+    margin: 2rem auto;
+    color: var(--morado-emperador);
+    opacity: 0;
+    animation: fade-up 1s ease forwards 0.5s;
+}
+
+.demo-button {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    background: var(--oro-viejo);
+    color: var(--morado-emperador);
+    border: none;
+    border-radius: 4px;
+    font-weight: bold;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+    transition: color 0.3s;
+}
+
+.demo-button::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.3);
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+.demo-button:hover::after {
+    opacity: 1;
+}
+
+@keyframes fade-slide-in {
+    from { opacity: 0; transform: translateY(-20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fade-up {
+    from { opacity: 0; transform: translateY(40px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* === index.css === */
+/* Page-specific styles for index.php */
+body {
+    /* Use alabaster background, rely on global CSS variables if defined */
+    background-color: var(--epic-alabaster-bg, #F9F7F4);
+    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-size: cover;
+    background-attachment: fixed;
+}
+
+.hero {
+    animation: hero-fade 20s infinite alternate;
+}
+
+@keyframes hero-fade {
+    from { filter: brightness(1); }
+    to { filter: brightness(1.1) saturate(1.2); }
+}
+
+/* === galeria_colaborativa.css === */
+/* Styles for galeria/galeria_colaborativa.php */
+body {
+    background-color: var(--epic-alabaster-bg, #F9F7F4);
+    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-size: cover;
+    background-attachment: fixed;
+}
+
+.upload-form-container {
+    background: var(--epic-transparent-overlay-light);
+    padding: 1.5em;
+    border-radius: var(--global-border-radius);
+    box-shadow: var(--global-box-shadow-light);
+}
+
+/* === tienda.css === */
+/* Page-specific styles for tienda/index.php */
+body {
+    background-color: var(--epic-alabaster-bg, #F9F7F4);
+    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-attachment: fixed;
+}
+
+.card-grid .card {
+    transition: transform 0.3s ease;
+}
+.card-grid .card:hover {
+    transform: scale(1.05);
+    box-shadow: var(--global-box-shadow-medium);
+}

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -51,7 +51,6 @@ if (is_dir($gallery_dir)) {
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
-    <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
 </head>
 <body>
     <div id="linterna-condado"></div> <!-- Para el efecto de linterna -->

--- a/includes/load_page_css.php
+++ b/includes/load_page_css.php
@@ -1,7 +1,5 @@
 <?php
-$cssFile = '/assets/css/pages/' . basename($_SERVER['SCRIPT_NAME'], '.php') . '.css';
-$root = dirname(__DIR__);
-if (file_exists($root . $cssFile)) {
-    echo "<link rel=\"stylesheet\" href=\"{$cssFile}\">\n";
-}
+// Legacy loader kept for backward compatibility.
+// All page-specific styles are now bundled into epic_theme.css,
+// so this script intentionally outputs nothing.
 ?>

--- a/index.php
+++ b/index.php
@@ -34,7 +34,6 @@ require_once 'includes/ai_utils.php';
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
-    <?php require_once __DIR__ . '/includes/load_page_css.php'; ?>
 
 </head>
 <body>

--- a/js/layout.js
+++ b/js/layout.js
@@ -293,17 +293,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
+// All individual page styles have been consolidated into epic_theme.css.
+// This function now intentionally left blank to avoid loading per-page files.
 function loadPageCss() {
-    let page = window.location.pathname.split('/').pop();
-    if (!page) { page = 'index'; }
-    page = page.split('.')[0];
-    const cssPath = `/assets/css/pages/${page}.css`;
-    fetch(cssPath, { method: 'HEAD' }).then(res => {
-        if (res.ok) {
-            const link = document.createElement('link');
-            link.rel = 'stylesheet';
-            link.href = cssPath;
-            document.head.appendChild(link);
-        }
-    }).catch(() => {});
+    // no-op
 }

--- a/tienda/index.php
+++ b/tienda/index.php
@@ -11,7 +11,6 @@ require_once __DIR__ . '/../includes/auth.php';
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tienda</title>
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
-    <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
 </head>
 <body>
 <?php require_once __DIR__ . '/../_header.html'; ?>


### PR DESCRIPTION
## Summary
- combine all page styles into `epic_theme.css`
- stop loading per-page styles in `layout.js`
- disable old `load_page_css.php`
- remove includes to that loader from pages

## Testing
- `composer install --no-interaction --no-progress --prefer-dist` *(fails: composer not found)*
- `vendor/bin/phpstan` *(fails: no such file or directory)*
- `vendor/bin/phpunit --coverage-clover build/coverage.xml` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684427aff6888329b73ef3f3e4ed12e8