### PR TITLE
Add German translation demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ El archivo `includes/ai_utils.php` proporciona utilidades que hacen uso de la AP
 
 Si no se configuran las credenciales reales de la API, se utilizará un simulador que produce textos de demostración.
 
+La página `historia/atapuerca.php` incluye un selector de idioma de demostración que muestra traducciones simuladas generadas por IA. Actualmente se ofrecen versiones en inglés, francés y **alemán**.
+
 ## Galería 2D y Museo 3D
 
 El sitio cuenta con dos formas de visualizar las piezas:

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -39,6 +39,7 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                     <button class="lang-btn active" data-lang="es" title="Ver contenido en Español (original)">Español (Original)</button>
                     <button class="lang-btn" data-lang="en-ai" title="Simular traducción al Inglés por IA">Inglés (Traducción IA)</button>
                     <button class="lang-btn" data-lang="fr-ai" title="Simular traducción al Francés por IA">Francés (Traducción IA)</button>
+                    <button class="lang-btn" data-lang="de-ai" title="Simular traducción al Alemán por IA">Alemán (Traducción IA)</button>
                 </div>
                 <article class="content-article"> <!-- Using a generic class for content styling -->
                     <div id="textoPrincipalAtapuerca">
@@ -167,6 +168,7 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                 $original_text_snippet_for_demo = "Contenido original de la página de Atapuerca..."; // Un snippet muy corto o incluso vacío
                 $translation_placeholders['en-ai'] = translate_with_gemini('atapuerca_main_content', 'en-ai', $original_text_snippet_for_demo);
                 $translation_placeholders['fr-ai'] = translate_with_gemini('atapuerca_main_content', 'fr-ai', $original_text_snippet_for_demo);
+                $translation_placeholders['de-ai'] = translate_with_gemini('atapuerca_main_content', 'de-ai', $original_text_snippet_for_demo);
             }
         ?>
         const translations = <?php echo json_encode($translation_placeholders); ?>;

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -277,6 +277,10 @@ function translate_with_gemini(string $content_id, string $target_language, stri
             $outputText .= "<p><strong>Traduction Française Simulée :</strong> Ceci montre où le texte français généré par l'IA apparaîtrait. Le contenu original en espagnol commençait par : '<em>" . $original_snippet . "</em>'.</p>";
             $outputText .= "<p>Dans un système de production, le texte intégral serait traité par un modèle avancé de traduction automatique neuronale pour fournir une version française précise et nuancée.</p>";
             break;
+        case 'de-ai':
+            $outputText .= "<p><strong>Simulierte Deutsche Übersetzung:</strong> Hier würde der von KI generierte deutsche Text erscheinen. Der ursprüngliche spanische Inhalt begann mit: '<em>" . $original_snippet . "</em>'.</p>";
+            $outputText .= "<p>In einem Produktivsystem würde der vollständige Text von einem fortgeschrittenen neuronalen Übersetzungsmodell verarbeitet, um eine präzise und nuancierte deutsche Version bereitzustellen.</p>";
+            break;
         // No hay caso 'default' o 'es' aquí porque ya se manejó al inicio de la función.
     }
     $outputText .= "<p style='font-size:0.8em; color:#1976d2; margin-top:10px;'><em>(Esta es una simulación. La funcionalidad de traducción real con IA está pendiente de implementación).</em></p>";

--- a/js/ia-tools.js
+++ b/js/ia-tools.js
@@ -81,7 +81,7 @@ function handleSummary(output) {
 
 function handleTranslation(output) {
     const text = getMainText();
-    const target = prompt('Código de idioma destino (ej. en-ai, fr-ai):', 'en-ai');
+    const target = prompt('Código de idioma destino (ej. en-ai, fr-ai, de-ai):', 'en-ai');
     if (!target) return;
     showOutput(output, '<p><em>Generando traducción...</em></p>');
     fetch('/ajax_actions/get_translation.php', {


### PR DESCRIPTION
## Summary
- include German option in the translation selector
- add german case to AI demo translations
- document demo in README

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442a13bb148329b538be5e06dde021