### PR TITLE
Add support for more languages

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -1,6 +1,16 @@
 <div class="language-bar">
     <a href="?lang=es" class="lang-flag" title="Español">🇪🇸</a>
     <a href="?lang=en" class="lang-flag" title="English">🇬🇧</a>
+    <a href="?lang=fr" class="lang-flag" title="Français">🇫🇷</a>
+    <a href="?lang=de" class="lang-flag" title="Deutsch">🇩🇪</a>
+    <a href="?lang=it" class="lang-flag" title="Italiano">🇮🇹</a>
+    <a href="?lang=pt" class="lang-flag" title="Português">🇵🇹</a>
+    <a href="?lang=ru" class="lang-flag" title="Русский">🇷🇺</a>
+    <a href="?lang=zh-CN" class="lang-flag" title="中文">🇨🇳</a>
+    <a href="?lang=ja" class="lang-flag" title="日本語">🇯🇵</a>
+    <a href="?lang=ko" class="lang-flag" title="한국어">🇰🇷</a>
+    <a href="?lang=ar" class="lang-flag" title="العربية">🇸🇦</a>
+    <a href="?lang=hi" class="lang-flag" title="हिन्दी">🇮🇳</a>
 </div>
 <div id="google_translate_element" style="display:none;"></div>
 <button id="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle Menu" aria-expanded="false">

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -25,7 +25,7 @@ function loadGoogleTranslate(targetLang) {
     window._targetLang = targetLang;
     if (!window.googleTranslateElementInit) {
         window.googleTranslateElementInit = function() {
-            new google.translate.TranslateElement({pageLanguage: 'es', includedLanguages: 'en,es'}, 'google_translate_element');
+            new google.translate.TranslateElement({pageLanguage: 'es', includedLanguages: 'en,es,fr,de,it,pt,ru,zh-CN,ja,ko,ar,hi'}, 'google_translate_element');
             translatePage(window._targetLang);
         };
         const script = document.createElement('script');


### PR DESCRIPTION
## Summary
- expand the language selection bar with major languages such as Arabic, French, German and more
- update `js/lang-bar.js` to allow Google Translate to handle the new languages

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68442f3060b083298c663a02007aa9ea