### PR TITLE
Add multi-language translation placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ El archivo `includes/ai_utils.php` proporciona utilidades que hacen uso de la AP
 
 Si no se configuran las credenciales reales de la API, se utilizará un simulador que produce textos de demostración.
 
+La página `historia/atapuerca.php` incluye un selector de idioma de demostración que muestra traducciones simuladas generadas por IA. Actualmente se ofrecen versiones en inglés, francés, alemán, portugués, italiano, chino, coreano e **hindi**.
+
 ## Galería 2D y Museo 3D
 
 El sitio cuenta con dos formas de visualizar las piezas:

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -39,6 +39,12 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                     <button class="lang-btn active" data-lang="es" title="Ver contenido en Español (original)">Español (Original)</button>
                     <button class="lang-btn" data-lang="en-ai" title="Simular traducción al Inglés por IA">Inglés (Traducción IA)</button>
                     <button class="lang-btn" data-lang="fr-ai" title="Simular traducción al Francés por IA">Francés (Traducción IA)</button>
+                    <button class="lang-btn" data-lang="de-ai" title="Simular traducción al Alemán por IA">Alemán (Traducción IA)</button>
+                    <button class="lang-btn" data-lang="pt-ai" title="Simular traducción al Portugués por IA">Portugués (Traducción IA)</button>
+                    <button class="lang-btn" data-lang="it-ai" title="Simular traducción al Italiano por IA">Italiano (Traducción IA)</button>
+                    <button class="lang-btn" data-lang="zh-ai" title="Simular traducción al Chino por IA">Chino (Traducción IA)</button>
+                    <button class="lang-btn" data-lang="ko-ai" title="Simular traducción al Coreano por IA">Coreano (Traducción IA)</button>
+                    <button class="lang-btn" data-lang="hi-ai" title="Simular traducción al Hindi por IA">Hindi (Traducción IA)</button>
                 </div>
                 <article class="content-article"> <!-- Using a generic class for content styling -->
                     <div id="textoPrincipalAtapuerca">
@@ -167,6 +173,12 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                 $original_text_snippet_for_demo = "Contenido original de la página de Atapuerca..."; // Un snippet muy corto o incluso vacío
                 $translation_placeholders['en-ai'] = translate_with_gemini('atapuerca_main_content', 'en-ai', $original_text_snippet_for_demo);
                 $translation_placeholders['fr-ai'] = translate_with_gemini('atapuerca_main_content', 'fr-ai', $original_text_snippet_for_demo);
+                $translation_placeholders['de-ai'] = translate_with_gemini('atapuerca_main_content', 'de-ai', $original_text_snippet_for_demo);
+                $translation_placeholders['pt-ai'] = translate_with_gemini('atapuerca_main_content', 'pt-ai', $original_text_snippet_for_demo);
+                $translation_placeholders['it-ai'] = translate_with_gemini('atapuerca_main_content', 'it-ai', $original_text_snippet_for_demo);
+                $translation_placeholders['zh-ai'] = translate_with_gemini('atapuerca_main_content', 'zh-ai', $original_text_snippet_for_demo);
+                $translation_placeholders['ko-ai'] = translate_with_gemini('atapuerca_main_content', 'ko-ai', $original_text_snippet_for_demo);
+                $translation_placeholders['hi-ai'] = translate_with_gemini('atapuerca_main_content', 'hi-ai', $original_text_snippet_for_demo);
             }
         ?>
         const translations = <?php echo json_encode($translation_placeholders); ?>;

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -277,6 +277,30 @@ function translate_with_gemini(string $content_id, string $target_language, stri
             $outputText .= "<p><strong>Traduction Française Simulée :</strong> Ceci montre où le texte français généré par l'IA apparaîtrait. Le contenu original en espagnol commençait par : '<em>" . $original_snippet . "</em>'.</p>";
             $outputText .= "<p>Dans un système de production, le texte intégral serait traité par un modèle avancé de traduction automatique neuronale pour fournir une version française précise et nuancée.</p>";
             break;
+        case 'de-ai':
+            $outputText .= "<p><strong>Simulierte Deutsche Übersetzung:</strong> Hier würde der von KI generierte deutsche Text erscheinen. Der ursprüngliche spanische Inhalt begann mit: '<em>" . $original_snippet . "</em>'.</p>";
+            $outputText .= "<p>In einem Produktivsystem würde der vollständige Text von einem fortgeschrittenen neuronalen Übersetzungsmodell verarbeitet, um eine präzise und nuancierte deutsche Version bereitzustellen.</p>";
+            break;
+        case 'pt-ai':
+            $outputText .= "<p><strong>Tradução Simulada para Português:</strong> Aqui apareceria o texto em português gerado pela IA. O conteúdo original em espanhol começava assim: '<em>" . $original_snippet . "</em>'.</p>";
+            $outputText .= "<p>Em um sistema de produção, todo o texto seria processado por um modelo avançado de tradução automática para fornecer uma versão em português precisa e rica em nuances.</p>";
+            break;
+        case 'it-ai':
+            $outputText .= "<p><strong>Traduzione Italiana Simulata:</strong> Qui comparirebbe il testo italiano generato dall'IA. Il contenuto originale in spagnolo iniziava con: '<em>" . $original_snippet . "</em>'.</p>";
+            $outputText .= "<p>In un sistema di produzione, l'intero testo sarebbe elaborato da un avanzato modello di traduzione automatica neurale per fornire una versione italiana accurata e sfumata.</p>";
+            break;
+        case 'zh-ai':
+            $outputText .= "<p><strong>模拟中文翻译：</strong> 这里将显示由AI生成的中文文本。西班牙语原文的开头是: '<em>" . $original_snippet . "</em>'。</p>";
+            $outputText .= "<p>在生产环境中，完整文本会由先进的神经机器翻译模型处理，以提供准确而细致的中文版本。</p>";
+            break;
+        case 'ko-ai':
+            $outputText .= "<p><strong>AI가 생성한 한국어 번역 예시:</strong> 이곳에 한국어 번역 내용이 표시됩니다. 스페인어 원문은 다음과 같이 시작했습니다: '<em>" . $original_snippet . "</em>'.</p>";
+            $outputText .= "<p>실제 서비스에서는 전체 텍스트가 고급 신경망 번역 모델을 거쳐 정확하고 자연스러운 한국어로 제공될 것입니다.</p>";
+            break;
+        case 'hi-ai':
+            $outputText .= "<p><strong>हिंदी अनुवाद का डेमो:</strong> यहाँ AI द्वारा उत्पन्न हिंदी पाठ दिखाई देगा। मूल स्पेनिश सामग्री इस प्रकार शुरू हुई थी: '<em>" . $original_snippet . "</em>'।</p>";
+            $outputText .= "<p>उत्पादन प्रणाली में, पूर्ण पाठ को एक उन्नत न्यूरल मशीन अनुवाद मॉडल द्वारा संसाधित किया जाएगा ताकि सटीक और सहज हिंदी संस्करण प्रदान किया जा सके।</p>";
+            break;
         // No hay caso 'default' o 'es' aquí porque ya se manejó al inicio de la función.
     }
     $outputText .= "<p style='font-size:0.8em; color:#1976d2; margin-top:10px;'><em>(Esta es una simulación. La funcionalidad de traducción real con IA está pendiente de implementación).</em></p>";

--- a/js/ia-tools.js
+++ b/js/ia-tools.js
@@ -81,7 +81,7 @@ function handleSummary(output) {
 
 function handleTranslation(output) {
     const text = getMainText();
-    const target = prompt('Código de idioma destino (ej. en-ai, fr-ai):', 'en-ai');
+    const target = prompt('Código de idioma destino (ej. en-ai, fr-ai, de-ai, pt-ai, it-ai, zh-ai, ko-ai, hi-ai):', 'en-ai');
     if (!target) return;
     showOutput(output, '<p><em>Generando traducción...</em></p>');
     fetch('/ajax_actions/get_translation.php', {


### PR DESCRIPTION
## Summary
- extend demo translation selector to include Portuguese, Italian, Chinese, Korean and Hindi
- add placeholder cases for these languages in the AI utilities
- document new options in README
- clarify JS prompt for available language codes

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442a13bb148329b538be5e06dde021