### PR TITLE
Improve header markup and navigation

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -1,9 +1,10 @@
-<div class="language-bar">
-    <a href="?lang=es" class="lang-flag" title="Español">🇪🇸</a>
-    <a href="?lang=en" class="lang-flag" title="English">🇬🇧</a>
-    <a href="?lang=fr" class="lang-flag" title="Français">🇫🇷</a>
-    <a href="?lang=de" class="lang-flag" title="Deutsch">🇩🇪</a>
-    <a href="?lang=it" class="lang-flag" title="Italiano">🇮🇹</a>
+<header id="main-header">
+    <div class="language-bar">
+        <a href="?lang=es" class="lang-flag" title="Español">🇪🇸</a>
+        <a href="?lang=en" class="lang-flag" title="English">🇬🇧</a>
+        <a href="?lang=fr" class="lang-flag" title="Français">🇫🇷</a>
+        <a href="?lang=de" class="lang-flag" title="Deutsch">🇩🇪</a>
+        <a href="?lang=it" class="lang-flag" title="Italiano">🇮🇹</a>
     <a href="?lang=pt" class="lang-flag" title="Português">🇵🇹</a>
     <a href="?lang=ru" class="lang-flag" title="Русский">🇷🇺</a>
     <a href="?lang=zh-CN" class="lang-flag" title="中文">🇨🇳</a>
@@ -12,24 +13,25 @@
     <a href="?lang=ar" class="lang-flag" title="العربية">🇸🇦</a>
     <a href="?lang=hi" class="lang-flag" title="हिन्दी">🇮🇳</a>
 </div>
-<div id="google_translate_element" style="display:none;"></div>
-<button id="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle Menu" aria-expanded="false">
-    <span class="bar"></span>
-    <span class="bar"></span>
-    <span class="bar"></span>
+    </div>
+    <div id="google_translate_element" style="display:none;"></div>
+    <button id="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
 </button>
-<button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-    <i class="fas fa-moon"></i>
+    <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
+        <i class="fas fa-moon"></i>
 </button>
-<button id="ia-chat-toggle" class="ia-chat-toggle" aria-label="Abrir chat IA">
-    <i class="fas fa-comments"></i>
+    <button id="ia-chat-toggle" class="ia-chat-toggle" aria-label="Abrir chat IA">
+        <i class="fas fa-comments"></i>
 </button>
-<nav id="sidebar" class="sidebar" role="navigation">
-    <a href="/index.php" class="logo-link">
-        <img src="/assets/img/AlfozCerasioLantaron.jpg" alt="Logo Alfoz de Cerasio y Lantarón" class="logo-image">
-    </a>
-    <ul class="nav-links">
-        <li><a href="/index.php" class="active-link">Inicio</a></li>
+    <nav id="sidebar" class="sidebar" role="navigation">
+        <a href="/index.php" class="logo-link">
+            <img src="/assets/img/AlfozCerasioLantaron.jpg" alt="Logo Alfoz de Cerasio y Lantarón" class="logo-image">
+        </a>
+        <ul class="nav-links">
+            <li><a href="/index.php" class="active-link">Inicio</a></li>
         <li><a href="/historia/historia.html">Nuestra Historia</a></li>
         <li><a href="/historia_cerezo/index.html">Historia de Cerezo</a></li>
         <li><a href="/alfoz/alfoz.html">El Alfoz</a></li>
@@ -49,9 +51,10 @@
         <li><a href="/dashboard/login.php">Admin</a></li>
         <li><a href="https://www.facebook.com/groups/1052427398664069" target="_blank" rel="noopener noreferrer"><i class="fab fa-facebook-square"></i> Comunidad</a></li>
         <li><a href="https://chat.whatsapp.com/JWJ6mWXPuekIBZ8HJSSsZx" target="_blank" rel="noopener noreferrer"><i class="fab fa-whatsapp"></i> WhatsApp</a></li>
-    </ul>
-</nav>
-    <div id="ia-chat-sidebar" class="ia-chat-sidebar">
+        </ul>
+    </nav>
+</header>
+<div id="ia-chat-sidebar" class="ia-chat-sidebar">
         <div class="ia-chat-header drag-handle">
             <form id="ia-chat-form" class="ia-chat-form">
                 <textarea id="ia-chat-input" rows="1" placeholder="Pregunta sobre historia..." required></textarea>

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -1,3 +1,4 @@
+@import url('header/layout.css');
 @import url('header/nav.css');
 @import url('header/ia-chat.css');
 @import url('header/topbar.css');

--- a/assets/css/header/layout.css
+++ b/assets/css/header/layout.css
@@ -1,0 +1,10 @@
+/* Layout styles for header container */
+#main-header {
+    position: relative;
+    z-index: 3000;
+}
+
+#main-header button {
+    z-index: 3001;
+}
+

--- a/js/layout.js
+++ b/js/layout.js
@@ -58,6 +58,25 @@ function initializeSidebarNavigation() {
                 // sidebarToggle.textContent = '☰'; // Example: Change back to burger
             }
         });
+
+        const links = sidebar.querySelectorAll('a');
+        links.forEach(link => {
+            link.addEventListener('click', () => {
+                if (window.innerWidth <= 768 && sidebar.classList.contains('sidebar-visible')) {
+                    sidebar.classList.remove('sidebar-visible');
+                    body.classList.remove('sidebar-active');
+                    sidebarToggle.setAttribute('aria-expanded', 'false');
+                }
+            });
+        });
+
+        window.addEventListener('resize', () => {
+            if (window.innerWidth > 768 && sidebar.classList.contains('sidebar-visible')) {
+                sidebar.classList.remove('sidebar-visible');
+                body.classList.remove('sidebar-active');
+                sidebarToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
     } else {
         console.error("Sidebar toggle, sidebar element, or body not found.");
     }


### PR DESCRIPTION
## Summary
- wrap header markup in `<header id="main-header">`
- add layout CSS for the header and include it from `header.css`
- update sidebar navigation JS so links close menu on mobile

## Testing
- `vendor/bin/phpstan` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684433d481fc83299059f27cf7df0bbf