### PR TITLE
Improve IA chat usability

### DIFF
--- a/assets/css/header/ia-chat.css
+++ b/assets/css/header/ia-chat.css
@@ -80,6 +80,16 @@ body.ia-chat-active #ia-chat-toggle {
     gap: 6px;
     margin-bottom: 10px;
     cursor: move;
+    align-items: center;
+}
+
+#ia-chat-close {
+    background: transparent;
+    border: none;
+    color: var(--epic-text-color);
+    font-size: 1.2em;
+    cursor: pointer;
+    margin-right: auto;
 }
 
 #ia-chat-sidebar .ia-tools-container {

--- a/fragments/header/ia-chat.html
+++ b/fragments/header/ia-chat.html
@@ -1,5 +1,6 @@
 <div id="ia-chat-sidebar" class="ia-chat-sidebar bg-white dark:bg-gray-900 p-4 shadow-lg">
     <div class="ia-chat-header drag-handle">
+        <button id="ia-chat-close" class="ia-chat-close" aria-label="Cerrar chat">&times;</button>
         <form id="ia-chat-form" class="ia-chat-form flex gap-2">
             <textarea id="ia-chat-input" class="flex-grow border rounded p-1" rows="1" placeholder="Pregunta sobre historia..." required></textarea>
             <button type="submit" class="bg-purple-600 text-white px-3 py-1 rounded">Enviar</button>

--- a/js/layout.js
+++ b/js/layout.js
@@ -144,11 +144,27 @@ function loadIAToolsScript() {
 function initializeIAChatSidebar() {
     const toggle = document.getElementById('ia-chat-toggle');
     const sidebar = document.getElementById('ia-chat-sidebar');
+    const closeBtn = document.getElementById('ia-chat-close');
     const form = document.getElementById('ia-chat-form');
     const input = document.getElementById('ia-chat-input');
     const messages = document.getElementById('ia-chat-messages');
     const responseBox = document.getElementById('ia-chat-response');
     const CHAT_STORAGE_KEY = 'iaChatHistory';
+    let hideTimer;
+
+    function startAutoHide() {
+        clearTimeout(hideTimer);
+        hideTimer = setTimeout(hideSidebar, 30000); // 30s
+    }
+
+    function hideSidebar() {
+        if (sidebar && sidebar.classList.contains('sidebar-visible')) {
+            sidebar.classList.remove('sidebar-visible');
+            document.body.classList.remove('ia-chat-active');
+        }
+    }
+
+    function resetAutoHide() { startAutoHide(); }
 
     function saveChatHistory() {
         if (!messages) return;
@@ -183,14 +199,21 @@ function initializeIAChatSidebar() {
     loadChatHistory();
 
     if (toggle && sidebar) {
-        toggle.addEventListener('click', () => {
-            sidebar.classList.toggle('sidebar-visible');
-            document.body.classList.toggle('ia-chat-active');
+        const toggleSidebar = () => {
+            const visible = sidebar.classList.toggle('sidebar-visible');
+            document.body.classList.toggle('ia-chat-active', visible);
+            if (visible) startAutoHide();
+        };
+        toggle.addEventListener('click', toggleSidebar);
+        if (closeBtn) closeBtn.addEventListener('click', hideSidebar);
+        document.addEventListener('click', (e) => {
+            if (sidebar.classList.contains('sidebar-visible') && !sidebar.contains(e.target) && e.target !== toggle) {
+                hideSidebar();
+            }
         });
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape' && sidebar.classList.contains('sidebar-visible')) {
-                sidebar.classList.remove('sidebar-visible');
-                document.body.classList.remove('ia-chat-active');
+                hideSidebar();
             }
         });
     }
@@ -224,6 +247,7 @@ function initializeIAChatSidebar() {
         input.addEventListener('input', () => {
             input.style.height = 'auto';
             input.style.height = `${input.scrollHeight}px`;
+            resetAutoHide();
         });
         form.addEventListener('submit', (e) => {
             e.preventDefault();
@@ -231,6 +255,7 @@ function initializeIAChatSidebar() {
             if (!text) return;
             appendMessage('user', text);
             input.value = '';
+            resetAutoHide();
             const typingEl = appendMessage('typing', 'Gemini está escribiendo...');
             fetch('/ajax_actions/get_history_chat.php', {
                 method: 'POST',
@@ -268,6 +293,9 @@ function initializeIAChatSidebar() {
                 }
             });
         });
+        sidebar.addEventListener('mousemove', resetAutoHide);
+        sidebar.addEventListener('mousedown', resetAutoHide);
+        messages.addEventListener('scroll', resetAutoHide);
     }
 
     function appendMessage(role, text) {


### PR DESCRIPTION
## Summary
- add close button to IA chat sidebar
- implement auto-hide logic for the IA chat
- style close button in header CSS

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846b051e8448329ac36a8a965b09436