### PR TITLE
Improve IA chat usability

### DIFF
--- a/assets/css/header/ia-chat.css
+++ b/assets/css/header/ia-chat.css
@@ -80,6 +80,25 @@ body.ia-chat-active #ia-chat-toggle {
     gap: 6px;
     margin-bottom: 10px;
     cursor: move;
+    align-items: center;
+}
+
+#ia-chat-close {
+    background: transparent;
+    border: none;
+    color: var(--epic-text-color);
+    font-size: 1.2em;
+    cursor: pointer;
+    margin-right: auto;
+}
+
+#ia-tools-toggle {
+    background: transparent;
+    border: none;
+    color: var(--epic-text-color);
+    font-size: 1.1em;
+    cursor: pointer;
+    margin-left: 4px;
 }
 
 #ia-chat-sidebar .ia-tools-container {
@@ -88,6 +107,10 @@ body.ia-chat-active #ia-chat-toggle {
     display: flex;
     flex-direction: column;
     gap: 8px;
+}
+
+#ia-chat-sidebar .ia-tools-container.hidden {
+    display: none;
 }
 
 #ia-chat-messages {
@@ -103,7 +126,7 @@ body.ia-chat-active #ia-chat-toggle {
 
 .chat-message {
     padding: 8px 12px;
-    border-radius: var(--global-border-radius);
+    border-radius: 18px;
     box-shadow: var(--global-box-shadow-light);
     margin: 2px 0;
     line-height: 1.4;
@@ -151,14 +174,16 @@ body.ia-chat-active #ia-chat-toggle {
 
 .chat-user {
     color: var(--epic-text-color);
-    background-color: var(--epic-alabaster-bg);
+    background: linear-gradient(to bottom right, #d9fdd3, #c8f7c5);
     align-self: flex-end;
+    border-bottom-right-radius: 0;
 }
 
 .chat-ai {
     color: var(--epic-text-color);
-    background-color: var(--epic-alabaster-bg);
+    background: linear-gradient(to bottom right, #ececec, #dadada);
     align-self: flex-start;
+    border-bottom-left-radius: 0;
 }
 
 .chat-typing {

--- a/fragments/header/ia-chat.html
+++ b/fragments/header/ia-chat.html
@@ -1,5 +1,9 @@
 <div id="ia-chat-sidebar" class="ia-chat-sidebar bg-white dark:bg-gray-900 p-4 shadow-lg">
     <div class="ia-chat-header drag-handle">
+        <button id="ia-chat-close" class="ia-chat-close" aria-label="Cerrar chat">&times;</button>
+        <button id="ia-tools-toggle" class="ia-tools-toggle" aria-label="Mostrar herramientas">
+            <i class="fas fa-bars"></i>
+        </button>
         <form id="ia-chat-form" class="ia-chat-form flex gap-2">
             <textarea id="ia-chat-input" class="flex-grow border rounded p-1" rows="1" placeholder="Pregunta sobre historia..." required></textarea>
             <button type="submit" class="bg-purple-600 text-white px-3 py-1 rounded">Enviar</button>
@@ -8,7 +12,7 @@
     </div>
     <div id="ia-chat-messages" class="ia-chat-messages"></div>
     <div id="ia-tools-response" class="ia-tools-response hidden"></div>
-    <div id="ia-tools-menu" class="ia-tools-container flex flex-col gap-2 mt-2">
+    <div id="ia-tools-menu" class="ia-tools-container flex flex-col gap-2 mt-2 hidden">
         <button id="ia-summary-btn" type="button" class="bg-purple-600 text-white px-2 py-1 rounded">Resumen IA</button>
         <button id="ia-translate-btn" type="button" class="bg-purple-600 text-white px-2 py-1 rounded">Traducción IA</button>
         <button id="ia-research-btn" type="button" class="bg-purple-600 text-white px-2 py-1 rounded">Investigación IA</button>


### PR DESCRIPTION
## Summary
- add collapsible IA tools menu in chat header
- style chat bubbles to mimic ChatGPT
- load marked.js to render Markdown replies
- parse AI responses as Markdown

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846b051e8448329ac36a8a965b09436