### PR TITLE
Remove console logs from museum scripts

### DIFF
--- a/js/museo-3d-main.js
+++ b/js/museo-3d-main.js
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // After exhibits are loaded (or attempted to load), set all bounding boxes for collision
         const exhibitorBoundingBoxes = MUSEUM_3D.ExhibitManager.getExhibitorBoundingBoxes();
         MUSEUM_3D.PlayerControls.setCollisionBoundingBoxes(wallBoundingBoxes, exhibitorBoundingBoxes);
-        console.log("Exhibits loaded and collision boxes updated.");
+        // console.log("Exhibits loaded and collision boxes updated.");
     }).catch(error => {
         console.error("Error during exhibit loading process:", error);
         // Still set wall bounding boxes even if exhibits fail
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // 5. Start the animation loop (which is inside SceneManager)
     MUSEUM_3D.SceneManager.startAnimationLoop();
 
-    console.log("Museo 3D initialized.");
+    // console.log("Museo 3D initialized.");
 
     // Initial check for view state (show/hide 3D section based on 2D/3D toggle)
     // This assumes the 2D gallery script (museo-2d-gallery.js) might set the initial display style.

--- a/legacy/js/museo-3d.js
+++ b/legacy/js/museo-3d.js
@@ -3,7 +3,7 @@
 if (typeof THREE === 'undefined') {
     console.error('Three.js not loaded. Make sure the CDN link is correct in museo.html.');
 } else {
-    console.log('Three.js loaded successfully. Version: ' + THREE.REVISION);
+    // console.log('Three.js loaded successfully. Version: ' + THREE.REVISION);
     window.DEBUG_MODE = false; // Disable Box3Helpers for final output
 
     let scene, camera, renderer;


### PR DESCRIPTION
## Summary
- comment out debugging logs in `museo-3d-main.js`
- comment out debugging log in `legacy/js/museo-3d.js`

## Testing
- `grep -R "^[^/]*console.log" -n --include='*.js'`

------
https://chatgpt.com/codex/tasks/task_e_6846b730d3b8832986c0ba363bfe2b89