### PR TITLE
Add README testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,13 @@ Se incluye el script `scripts/daily_agent.py` que ejecuta tareas de mantenimient
 - Opcionalmente, verificación de la base de datos y una solicitud de prueba a la API de Gemini.
 
 Puede programarse con `cron` o utilizar el *workflow* de GitHub en `.github/workflows/daily_agent.yml`, el cual se ejecuta cada día de forma automática.
+
+## Testing
+
+Para ejecutar la batería de pruebas es necesario disponer de **PHP 7.4 o superior**. Tras instalar las dependencias con `composer install`, lanza:
+
+```bash
+vendor/bin/phpunit
+```
+
+Las pruebas hacen uso de los *fixtures* incluidos en `tests/fixtures/`, por lo que deben mantenerse para que los resultados sean coherentes.


### PR DESCRIPTION
## Summary
- document how to run tests with PHPUnit

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml`
- `vendor/bin/phpunit` *(fails: missing PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_e_6846b73c47e0832989b5976f3c0ad51f