### PR TITLE
Add CSRF protection for gallery deletion

### DIFF
--- a/dashboard/delete_gallery_image.php
+++ b/dashboard/delete_gallery_image.php
@@ -4,6 +4,7 @@ if (session_status() == PHP_SESSION_NONE) {
 }
 
 require_once __DIR__ . '/../includes/auth.php'; // For require_admin_login()
+require_once __DIR__ . '/../includes/csrf.php';
 
 header('Content-Type: application/json'); // Set content type to JSON for the response
 
@@ -16,6 +17,11 @@ if (!is_admin_logged_in()) {
 // Check if the request method is POST (as per the modified JS in galeria_colaborativa.php)
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     echo json_encode(['success' => false, 'error' => 'Método de solicitud no válido. Se esperaba POST.']);
+    exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    echo json_encode(['success' => false, 'error' => 'CSRF token inválido o faltante.']);
     exit;
 }
 

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -354,6 +354,10 @@ if (is_dir($gallery_dir)) {
                     const url = '/dashboard/delete_gallery_image.php'; // New endpoint
                     const formData = new FormData();
                     formData.append('filename', fotoId);
+                    const csrfInput = document.getElementById('csrfGaleryToken');
+                    if (csrfInput) {
+                        formData.append('csrf_token', csrfInput.value);
+                    }
 
                     const response = await fetch(url, { method: 'POST', body: formData }); // Changed to POST, can also be DELETE with FormData for some servers
                     if (!response.ok) {


### PR DESCRIPTION
## Summary
- secure `dashboard/delete_gallery_image.php` with CSRF token verification
- send token in delete requests from `galeria_colaborativa.php`

## Testing
- `php -l dashboard/delete_gallery_image.php`
- `php -l galeria/galeria_colaborativa.php`
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6846b73e64cc8329a5898944087d099e