### PR TITLE
Refactor session start logic

### DIFF
--- a/dashboard/delete_gallery_image.php
+++ b/dashboard/delete_gallery_image.php
@@ -1,7 +1,6 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php'; // For require_admin_login()
 

--- a/dashboard/edit_texts.php
+++ b/dashboard/edit_texts.php
@@ -1,7 +1,6 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
 require_once __DIR__ . '/db_connect.php'; // Provides $pdo

--- a/dashboard/get_stats.php
+++ b/dashboard/get_stats.php
@@ -1,9 +1,8 @@
 <?php
 header('Content-Type: application/json');
 
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
 require_admin_login();

--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -4,9 +4,8 @@
 //ini_set('display_startup_errors', 1);
 //error_reporting(E_ALL);
 
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
 require_admin_login();

--- a/dashboard/login.php
+++ b/dashboard/login.php
@@ -1,8 +1,7 @@
 <?php
 // It's crucial to start the session before any output and before including auth.php
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
 require_once __DIR__ . '/../includes/csrf.php';

--- a/dashboard/logout.php
+++ b/dashboard/logout.php
@@ -1,9 +1,8 @@
 <?php
 // Start the session to access session variables.
 // It's good practice to ensure it's started before trying to manipulate it.
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
 

--- a/dashboard/save_text.php
+++ b/dashboard/save_text.php
@@ -1,7 +1,6 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
 require_once __DIR__ . '/db_connect.php'; // Provides $pdo

--- a/dashboard/tienda_admin.php
+++ b/dashboard/tienda_admin.php
@@ -1,7 +1,6 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';
 require_once __DIR__ . '/db_connect.php';
 /** @var PDO $pdo */

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -1,7 +1,6 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';      // For is_admin_logged_in()
 // dashboard/db_connect.php ya podría estar comentado, asegurarse que se incluye para $pdo
 require_once __DIR__ . '/../dashboard/db_connect.php'; // Necesario para $pdo

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,9 +1,8 @@
 <?php
 // /includes/auth.php
 
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start(); // El @ suprime errores si la sesión ya está iniciada, aunque es mejor verificar.
-}
+require_once __DIR__ . '/session.php';
+ensure_session_started();
 
 define('ADMIN_ROLE', 'admin'); // Define el rol de administrador
 

--- a/includes/csrf.php
+++ b/includes/csrf.php
@@ -1,7 +1,6 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/session.php';
+ensure_session_started();
 
 function get_csrf_token() {
     if (empty($_SESSION['csrf_token'])) {

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -1,7 +1,6 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/session.php';
+ensure_session_started();
 ?>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/includes/session.php
+++ b/includes/session.php
@@ -1,0 +1,7 @@
+<?php
+function ensure_session_started() {
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
+}
+?>

--- a/includes/text_manager.php
+++ b/includes/text_manager.php
@@ -1,14 +1,10 @@
 <?php
 // /includes/text_manager.php
 
-// Asegurarse de que auth.php (para is_admin_logged_in) está incluido.
-// Esto podría hacerse en cada página que usa editableText, o aquí condicionalmente.
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
-if (!function_exists('is_admin_logged_in')) { // Evitar re-declaración si ya está incluido
-    require_once __DIR__ . '/auth.php';
-}
+// Asegurarse de que las utilidades de sesión y autenticación están cargadas.
+require_once __DIR__ . '/session.php';
+ensure_session_started();
+require_once __DIR__ . '/auth.php';
 
 /**
  * Obtiene el contenido de un texto desde la base de datos.

--- a/index.php
+++ b/index.php
@@ -1,7 +1,6 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/includes/session.php';
+ensure_session_started();
 require_once 'includes/auth.php';      // For is_admin_logged_in()
 require_once 'dashboard/db_connect.php'; // Provides $pdo
 /** @var PDO $pdo */

--- a/tests/IncludesTest.php
+++ b/tests/IncludesTest.php
@@ -7,9 +7,7 @@ require_once __DIR__ . '/../includes/text_manager.php';
 
 class IncludesTest extends TestCase {
     protected function setUp(): void {
-        if (session_status() == PHP_SESSION_NONE) {
-            @session_start();
-        }
+        ensure_session_started();
         $_SESSION = [];
     }
 

--- a/tienda/index.php
+++ b/tienda/index.php
@@ -1,7 +1,6 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    @session_start();
-}
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- centralize `session_start()` handling via `ensure_session_started()` helper
- use the helper across the codebase

## Testing
- `composer install` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b74103c08329bda572b5ce72e8ee