### PR TITLE
Add pipefail and failing pg_isready test

### DIFF
--- a/scripts/check_db.sh
+++ b/scripts/check_db.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Simple check for PostgreSQL connectivity and environment variable
 

--- a/tests/CheckDbScriptTest.php
+++ b/tests/CheckDbScriptTest.php
@@ -1,0 +1,24 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class CheckDbScriptTest extends TestCase {
+    public function testScriptFailsWhenPgIsreadyFails(): void {
+        $tmpDir = sys_get_temp_dir() . '/fakebin_' . uniqid('', true);
+        mkdir($tmpDir);
+        $fake = $tmpDir . '/pg_isready';
+        file_put_contents($fake, "#!/bin/sh\nexit 1\n");
+        chmod($fake, 0755);
+        $env = [
+            'PATH' => $tmpDir . ':' . getenv('PATH'),
+            'CONDADO_DB_PASSWORD' => 'password'
+        ];
+        $cmd = 'bash ' . escapeshellarg(__DIR__.'/../scripts/check_db.sh');
+        $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        $status = proc_close($proc);
+        unlink($fake);
+        rmdir($tmpDir);
+        $this->assertNotSame(0, $status, $out . $err);
+    }
+}


### PR DESCRIPTION
## Summary
- harden `check_db.sh` with `set -euo pipefail`
- ensure script exits non-zero if `pg_isready` fails

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6846bb078d2c8329bbe2b3caf5cbf9dd