### PR TITLE
Fix shell script safety

### DIFF
--- a/scripts/gemini_request.sh
+++ b/scripts/gemini_request.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Usage: GEMINI_API_KEY=your_api_key ./gemini_request.sh
 
@@ -6,7 +7,7 @@ API_URL="https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flas
 
 # Allow the variable name GeminiAPI as an alternative
 if [ -z "$GEMINI_API_KEY" ]; then
-  GEMINI_API_KEY="$GeminiAPI"
+  GEMINI_API_KEY="${GeminiAPI:-}"
 fi
 
 if [ -z "$GEMINI_API_KEY" ]; then

--- a/scripts/setup_frontend_libs.sh
+++ b/scripts/setup_frontend_libs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 JS_DIR="assets/vendor/js"
 CSS_DIR="assets/vendor/css"


### PR DESCRIPTION
## Summary
- make frontend setup and gemini request scripts fail fast
- treat optional env var more safely

## Testing
- `shellcheck scripts/setup_frontend_libs.sh && shellcheck scripts/gemini_request.sh`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6846e74c5ea88329b6c3ce708f2a1f42