### PR TITLE
Convert admin menu and footer into PHP fragments

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -2,7 +2,14 @@
     <div class="container-epic">
         <p>© <script>document.write(new Date().getFullYear());</script> CondadoDeCastilla.com - Todos los derechos reservados.</p>
         <p>Un proyecto para la difusión del patrimonio histórico de Cerezo de Río Tirón y el Alfoz de Cerasio y Lantarón.</p>
-        <p><a href="/dashboard/login.php">Acceso Administrador</a></p>
+        <?php
+        require_once __DIR__ . '/includes/auth.php';
+        if (is_admin_logged_in()) {
+            echo '<p><a href="/dashboard/logout.php">Cerrar sesión</a></p>';
+        } else {
+            echo '<p><a href="/dashboard/login.php">Acceso Administrador</a></p>';
+        }
+        ?>
         <div class="social-links">
             <a href="https://www.facebook.com/groups/1052427398664069" aria-label="Facebook" title="Síguenos en Facebook" target="_blank" rel="noopener noreferrer"><i class="fab fa-facebook-f"></i></a>
             <a href="/en_construccion.html" aria-label="Instagram" title="Síguenos en Instagram (Próximamente)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>

--- a/fragments/menus/admin-menu.html
+++ b/fragments/menus/admin-menu.html
@@ -1,3 +1,0 @@
-<ul id="admin-menu" class="nav-links">
-    <li><a href="/dashboard/login.php">Admin</a></li>
-</ul>

--- a/fragments/menus/admin-menu.php
+++ b/fragments/menus/admin-menu.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__ . '/../../includes/auth.php';
+echo '<ul id="admin-menu" class="nav-links">';
+if (is_admin_logged_in()) {
+    echo '<li><a href="/dashboard/logout.php">Cerrar sesión</a></li>';
+    echo '<li><a href="/dashboard/index.php">Panel</a></li>';
+} else {
+    echo '<li><a href="/dashboard/login.php">Admin</a></li>';
+}
+echo '</ul>';
+?>

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -88,7 +88,7 @@ require_once __DIR__ . '/../includes/ai_utils.php';
             </div>
         </section>
     </main>
-<?php require_once __DIR__ . '/../_footer.html'; ?>
+<?php require_once __DIR__ . '/../_footer.php'; ?>
     <script src="/js/layout.js"></script>
         <script>
         document.addEventListener('DOMContentLoaded', function() {

--- a/homonexus.php
+++ b/homonexus.php
@@ -14,7 +14,7 @@
         <p>Esta página demuestra una interfaz empática donde la IA y el ser humano se fusionan como <strong>Sofía</strong>.</p>
         <p>Utiliza el botón ∞ para activar o desactivar la metamorfosis de los menús y sentir el flujo telepático de la información.</p>
     </main>
-    <?php require_once __DIR__ . '/_footer.html'; ?>
+    <?php require_once __DIR__ . '/_footer.php'; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -164,7 +164,7 @@ require_once 'includes/ai_utils.php';
         </section>
     </main>
 
-    <?php require_once __DIR__ . '/_footer.html'; ?>
+    <?php require_once __DIR__ . '/_footer.php'; ?>
 
     <script src="/js/layout.js"></script>
 

--- a/js/header_loader.js
+++ b/js/header_loader.js
@@ -19,7 +19,7 @@
         ]);
         await Promise.all([
             loadFragment('#main-menu-placeholder', '/fragments/menus/main-menu.html'),
-            loadFragment('#admin-menu-placeholder', '/fragments/menus/admin-menu.html'),
+            loadFragment('#admin-menu-placeholder', '/fragments/menus/admin-menu.php'),
             loadFragment('#social-menu-placeholder', '/fragments/menus/social-menu.html')
         ]);
         if (window.initLanguageBar) {

--- a/js/layout.js
+++ b/js/layout.js
@@ -29,12 +29,12 @@ document.addEventListener("DOMContentLoaded", function() {
 
     const footerPlaceholder = document.getElementById('footer-placeholder');
     if (footerPlaceholder) {
-        fetch('/_footer.html')
+        fetch('/_footer.php')
             .then(response => response.text())
             .then(data => {
                 footerPlaceholder.innerHTML = data;
             })
-            .catch(error => console.error('Error fetching _footer.html:', error));
+            .catch(error => console.error('Error fetching _footer.php:', error));
     }
 
     // Theme toggle initialization

--- a/js/load_menu_parts.js
+++ b/js/load_menu_parts.js
@@ -9,6 +9,6 @@
     };
 
     loadFragment('#main-menu-placeholder', '/fragments/menus/main-menu.html');
-    loadFragment('#admin-menu-placeholder', '/fragments/menus/admin-menu.html');
+    loadFragment('#admin-menu-placeholder', '/fragments/menus/admin-menu.php');
     loadFragment('#social-menu-placeholder', '/fragments/menus/social-menu.html');
 })();

--- a/museo/galeria.php
+++ b/museo/galeria.php
@@ -34,7 +34,7 @@
         </section>
     </main>
 
-    <?php require_once __DIR__ . '/../_footer.html'; ?>
+    <?php require_once __DIR__ . '/../_footer.php'; ?>
     <script src="/js/config.js"></script>
     <script src="/js/layout.js"></script>
     <script src="/js/museo-2d-gallery.js"></script>

--- a/museo/museo_3d.php
+++ b/museo/museo_3d.php
@@ -41,7 +41,7 @@
         </div>
     </section>
 
-    <?php require_once __DIR__ . '/../_footer.html'; ?>
+    <?php require_once __DIR__ . '/../_footer.php'; ?>
     <script src="/js/config.js"></script>
     <script src="/js/layout.js"></script>
     <script src="/js/museum-3d/utils.js"></script>

--- a/museo/subir_pieza.php
+++ b/museo/subir_pieza.php
@@ -96,7 +96,7 @@
         </section>
     </main>
 
-    <?php require_once __DIR__ . '/../_footer.html'; ?>
+    <?php require_once __DIR__ . '/../_footer.php'; ?>
     <script src="/js/config.js"></script>
     <script src="/js/layout.js"></script>
     <script src="/js/museo-2d-gallery.js"></script>

--- a/tienda/index.php
+++ b/tienda/index.php
@@ -43,6 +43,6 @@ require_once __DIR__ . '/../includes/auth.php';
         </div>
     </div>
 </main>
-<?php require_once __DIR__ . '/../_footer.html'; ?>
+<?php require_once __DIR__ . '/../_footer.php'; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- turn admin menu into a PHP fragment checking `is_admin_logged_in`
- use PHP logic in the site footer and rename to `_footer.php`
- update JS loaders to fetch the new admin menu fragment
- update pages and scripts to include `_footer.php`

## Testing
- `pytest -q`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ecbe700883299b1eb54a4726f35c