### PR TITLE
Add login/logout test fixture

### DIFF
--- a/dashboard/edit_texts.php
+++ b/dashboard/edit_texts.php
@@ -3,7 +3,7 @@ require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
-require_once __DIR__ . '/db_connect.php'; // Provides $pdo
+require_once 'db_connect.php'; // Use include_path to allow test override
 /** @var PDO $pdo */
 require_once __DIR__ . '/../includes/text_manager.php'; // For getText, though not directly used for display here
 require_once __DIR__ . '/../includes/csrf.php';

--- a/dashboard/login.php
+++ b/dashboard/login.php
@@ -5,7 +5,7 @@ ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
 require_once __DIR__ . '/../includes/csrf.php';
-require_once __DIR__ . '/db_connect.php'; // Assumes db_connect.php is in the dashboard directory
+require_once 'dashboard/db_connect.php'; // Use include_path to allow test override
 /** @var PDO $pdo */
 
 $error_message = '';
@@ -17,7 +17,9 @@ if (is_admin_logged_in()) {
     if (!headers_sent()) {
         header("Location: /index.php"); // Or an admin dashboard if one exists
     }
-    exit;
+    if (empty($GLOBALS['TESTING'])) {
+        exit;
+    }
 }
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
@@ -59,7 +61,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                             $redirect_to = '/index.php';
                         }
                         header("Location: " . $redirect_to);
-                        exit;
+                        if (empty($GLOBALS['TESTING'])) {
+                            exit;
+                        }
                     }
                 } else {
                     $error_message = "El usuario no tiene permisos de administrador.";

--- a/dashboard/save_text.php
+++ b/dashboard/save_text.php
@@ -3,7 +3,7 @@ require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
-require_once __DIR__ . '/db_connect.php'; // Provides $pdo
+require_once 'db_connect.php'; // Use include_path to allow test override
 /** @var PDO $pdo */
 require_once __DIR__ . '/../includes/csrf.php';
 

--- a/dashboard/tienda_admin.php
+++ b/dashboard/tienda_admin.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';
-require_once __DIR__ . '/db_connect.php';
+require_once 'db_connect.php'; // Use include_path to allow test override
 /** @var PDO $pdo */
 require_once __DIR__ . '/../includes/csrf.php';
 

--- a/tests/LoginLogoutTest.php
+++ b/tests/LoginLogoutTest.php
@@ -1,0 +1,69 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class LoginLogoutTest extends TestCase {
+    private function runScript(string $script, array $env): array {
+        $cmd = sprintf('php -d auto_prepend_file=%s %s',
+            escapeshellarg(__DIR__.'/fixtures/login_prepend.php'),
+            escapeshellarg($script)
+        );
+        $env['PATH'] = getenv('PATH');
+        $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        $status = proc_close($proc);
+        return [$status, $out, $err];
+    }
+
+    private function parseHeaders(string $out): array {
+        $headers = [];
+        foreach (explode("\n", trim($out)) as $line) {
+            if ($line === '' || str_starts_with($line, 'Status:')) {
+                continue;
+            }
+            if (strpos($line, ':') !== false) {
+                [$k, $v] = array_map('trim', explode(':', $line, 2));
+                $headers[$k][] = $v;
+            }
+        }
+        return $headers;
+    }
+
+    public function testLoginLogout(): void {
+        $env = [
+            'REDIRECT_STATUS' => '1',
+            'SCRIPT_FILENAME' => __DIR__.'/../dashboard/login.php',
+            'REQUEST_METHOD' => 'POST',
+            'PHP_USERNAME' => 'admin',
+            'PHP_PASSWORD' => 'secret'
+        ];
+        [$status, $out, $err] = $this->runScript(__DIR__.'/../dashboard/login.php', $env);
+        $this->assertSame(0, $status, $err);
+        $headers = $this->parseHeaders($out);
+        $this->assertSame('/index.php', $headers['Location'][0] ?? null);
+        $this->assertArrayHasKey('Set-Cookie', $headers);
+        preg_match('/PHPSESSID=([^;]+)/', $headers['Set-Cookie'][0], $m);
+        $this->assertNotEmpty($m);
+        $sid = $m[1];
+
+        $sessionFile = ini_get('session.save_path').'/sess_'.$sid;
+        $data = file_get_contents($sessionFile);
+        $this->assertNotFalse($data);
+        session_start();
+        session_decode($data);
+        $this->assertSame('admin', $_SESSION['user_role']);
+        session_write_close();
+
+        $env = [
+            'REDIRECT_STATUS' => '1',
+            'SCRIPT_FILENAME' => __DIR__.'/../dashboard/logout.php',
+            'REQUEST_METHOD' => 'GET',
+            'PHP_SESSION_ID' => $sid
+        ];
+        [$status2, $out2, $err2] = $this->runScript(__DIR__.'/../dashboard/logout.php', $env);
+        $this->assertSame(0, $status2, $err2);
+        $headers2 = $this->parseHeaders($out2);
+        $this->assertSame('login.php', $headers2['Location'][0] ?? null);
+        $this->assertFileDoesNotExist($sessionFile);
+    }
+}

--- a/tests/fixtures/dashboard/db_connect.php
+++ b/tests/fixtures/dashboard/db_connect.php
@@ -32,7 +32,15 @@ $pdo->exec("CREATE TABLE tienda_productos (
     stock INTEGER,
     created_at TEXT
 );");
+$pdo->exec("CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    password_hash TEXT,
+    role TEXT
+);");
 $pdo->exec("INSERT INTO museo_piezas (titulo, descripcion, autor, imagen_nombre, fecha_subida) VALUES ('pieza1','desc','autor','img.jpg','2024-01-01 00:00:00');");
 $pdo->exec("INSERT INTO fotos_galeria (titulo, descripcion, autor, imagen_nombre, fecha_subida) VALUES ('foto1','desc','autor','img.jpg','2024-01-01 00:00:00');");
 $pdo->exec("INSERT INTO tienda_productos (nombre, descripcion, precio, imagen_nombre, stock, created_at) VALUES ('prod1','desc',10.5,'img.jpg',5,'2024-01-01 00:00:00');");
+$hash = password_hash('secret', PASSWORD_DEFAULT);
+$pdo->exec("INSERT INTO users (username, password_hash, role) VALUES ('admin', '{$hash}', 'admin');");
 ?>

--- a/tests/fixtures/login_prepend.php
+++ b/tests/fixtures/login_prepend.php
@@ -1,0 +1,20 @@
+<?php
+chdir(__DIR__ . '/..');
+set_include_path(__DIR__ . PATH_SEPARATOR . get_include_path());
+$_SERVER['HTTP_HOST'] = 'localhost';
+$_SERVER['HTTPS'] = 'off';
+$GLOBALS['TESTING'] = true;
+require_once __DIR__ . '/../../includes/session.php';
+$sessId = getenv('PHP_SESSION_ID');
+if ($sessId) {
+    session_id($sessId);
+}
+ensure_session_started();
+require_once __DIR__ . '/../../includes/csrf.php';
+$_SERVER['REQUEST_METHOD'] = getenv('REQUEST_METHOD') ?: 'GET';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $_POST['username'] = getenv('PHP_USERNAME') ?: '';
+    $_POST['password'] = getenv('PHP_PASSWORD') ?: '';
+    $_POST['csrf_token'] = get_csrf_token();
+}
+?>


### PR DESCRIPTION
## Summary
- add users table and admin user in test DB fixture
- expose a test auto-prepend file for login
- update dashboard scripts to use include path for DB connection
- create LoginLogoutTest validating login flow

## Testing
- `vendor/bin/phpunit` *(fails: LoginLogoutTest::testLoginLogout)*

------
https://chatgpt.com/codex/tasks/task_e_6846ecc16a5483298a9b62aec1d41972