### PR TITLE
Add project setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Luego copia el archivo `.env.example` a `.env` y rellena tus
 credenciales reales para `CONDADO_DB_PASSWORD`, `GEMINI_API_KEY`
 y cualquier otra variable necesaria.
 
+Si prefieres una configuración automática ejecuta `scripts/setup_project.sh`, el
+cual realizará todos los pasos anteriores, creará los directorios de subida y,
+si la variable `CONDADO_DB_PASSWORD` está definida, comprobará la conexión con
+la base de datos.
+
+```bash
+./scripts/setup_project.sh
+```
+
 
 ## Consideraciones de produccion
 

--- a/scripts/setup_project.sh
+++ b/scripts/setup_project.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure Composer is available
+COMPOSER_CMD=""
+if command -v composer >/dev/null 2>&1; then
+    COMPOSER_CMD="composer"
+elif [ -f composer.phar ]; then
+    COMPOSER_CMD="php composer.phar"
+else
+    echo "Composer no encontrado. Descargando composer.phar..."
+    curl -sS https://getcomposer.org/installer -o composer-setup.php
+    php composer-setup.php --quiet
+    rm composer-setup.php
+    COMPOSER_CMD="php composer.phar"
+fi
+
+# Install PHP dependencies
+$COMPOSER_CMD install --ignore-platform-req=ext-dom \
+                      --ignore-platform-req=ext-xmlwriter \
+                      --ignore-platform-req=ext-xml
+
+# Setup frontend libraries
+scripts/setup_frontend_libs.sh
+
+# Copy environment file if needed
+if [ ! -f .env ] && [ -f .env.example ]; then
+    cp .env.example .env
+    echo "Archivo .env creado a partir de .env.example"
+fi
+
+# Create upload directories
+mkdir -p uploads/galeria \
+         uploads_storage/museo_piezas \
+         uploads_storage/tienda_productos
+
+# Optional database check
+if [ -n "${CONDADO_DB_PASSWORD:-}" ] && [ -x scripts/check_db.sh ]; then
+    scripts/check_db.sh || echo "No se pudo comprobar la base de datos"
+fi
+
+cat <<MSG
+Configuración completada.
+MSG
+


### PR DESCRIPTION
## Summary
- add `scripts/setup_project.sh` to automate dependency installation and prepare uploads
- document script usage in README

## Testing
- `./scripts/setup_project.sh` *(fails: could not connect to network for some components, but composer install succeeded and script finished)*
- `./vendor/bin/phpunit` *(fails: missing PDO driver)*

------
https://chatgpt.com/codex/tasks/task_e_6847216b53a48329b57febe188d75da3