### PR TITLE
Fix: Comprehensive frontend UX corrections for menus, visibility, and…

### DIFF
--- a/assets/css/header/ia-chat.css
+++ b/assets/css/header/ia-chat.css
@@ -2,7 +2,7 @@
 #ia-chat-sidebar {
     position: fixed;
     top: 0;
-    right: -25vw; /* Initial hidden state, JS will change to 0 */
+    right: 0; /* Initial position on screen before transform */
     left: auto;
     width: clamp(280px, 70vw, 400px);
     height: 100vh;
@@ -10,7 +10,8 @@
     backdrop-filter: blur(5px);
     padding: 20px;
     box-shadow: 0 0 15px rgba(var(--epic-text-color-rgb), 0.25);
-    transition: right var(--global-transition-speed) ease-in-out;
+    transform: translateX(100%); /* Initially hidden off-screen to the right */
+    transition: transform var(--global-transition-speed) ease-in-out; /* Animate transform property */
     overflow: auto;
     z-index: 3000;
     display: flex;
@@ -22,7 +23,7 @@
 }
 
 #ia-chat-sidebar.sidebar-visible {
-    right: 0;
+    transform: translateX(0); /* Slide in to view */
     pointer-events: auto;
 }
 

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -33,7 +33,89 @@
     color: var(--epic-purple-emperor);
     transform: rotate(20deg);
 }
-/* Language selection bar */
+
+/* Sidebar Toggle Button (Hamburger) */
+#sidebar-toggle {
+    position: fixed;
+    top: 15px;
+    left: 15px;
+    background-color: var(--epic-alabaster-bg);
+    border: 2px solid var(--epic-gold-secondary);
+    border-radius: var(--global-border-radius);
+    padding: 8px; /* Adjusted for bar spacing */
+    cursor: pointer;
+    z-index: 3001;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around; /* Distribute space for bars */
+    width: 44px;
+    height: 44px;
+}
+
+#sidebar-toggle .bar {
+    display: block;
+    width: 80%; /* Relative to button padding */
+    height: 3px;
+    background-color: var(--epic-gold-main);
+    border-radius: 1px;
+    transition: all 0.3s ease-in-out;
+    margin: 2px auto; /* Centering bars, adjust vertical margin via justify-content */
+}
+
+#sidebar-toggle.active .bar:nth-child(1) {
+    transform: translateY(6.5px) rotate(45deg); /* Adjusted for 3px bar height + 2px margin */
+}
+
+#sidebar-toggle.active .bar:nth-child(2) {
+    opacity: 0;
+}
+
+#sidebar-toggle.active .bar:nth-child(3) {
+    transform: translateY(-6.5px) rotate(-45deg); /* Adjusted */
+}
+
+
+/* Homonexus Toggle Button */
+#homonexus-toggle {
+    position: fixed;
+    top: 15px;
+    right: 65px; /* (ia-chat-toggle width 44px + right 15px = 59px) + 6px gap */
+    background-color: var(--epic-alabaster-bg);
+    border: 2px solid var(--epic-gold-secondary);
+    border-radius: var(--global-border-radius);
+    padding: 10px;
+    cursor: pointer;
+    z-index: 3001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+}
+
+#homonexus-toggle i {
+    color: var(--epic-gold-main);
+    font-size: 1.2em; /* Match theme-toggle icon size */
+}
+
+#homonexus-toggle:hover {
+     background-color: var(--epic-gold-main);
+}
+
+#homonexus-toggle:hover i {
+     color: var(--epic-purple-emperor);
+}
+
+body.dark-mode #homonexus-toggle i {
+     color: var(--epic-icon-color);
+}
+
+body.dark-mode #homonexus-toggle:hover i {
+     color: var(--epic-icon-hover);
+}
+
+
+/* Language selection bar - No changes, kept for context */
 .language-bar {
     position: fixed;
     top: 0;
@@ -42,7 +124,7 @@
     background: var(--epic-alabaster-medium);
     padding: 2px 8px;
     text-align: right;
-    z-index: 3000;
+    z-index: 3000; /* Lower than toggles */
     font-size: 1.2em;
 }
 
@@ -56,5 +138,29 @@
     display: none !important;
 }
 body {
-    top: 0 !important;
+    top: 0 !important; /* Note: This can sometimes conflict with Google Translate's own adjustments. Monitor if issues arise. */
+}
+
+/* Responsive adjustments for toggle buttons */
+@media (max-width: 768px) {
+    #theme-toggle {
+        left: auto; /* Override PC centering */
+        right: 115px; /* (homonexus-toggle right 65px + width 44px = 109px) + 6px gap */
+        /* If #ia-chat-toggle is also present on mobile, this might need further adjustment
+           Currently, ia-chat-toggle is fixed at right: 15px.
+           So, homonexus-toggle at right: 65px (15 + 44 + 6)
+           And theme-toggle at right: 115px (65 + 44 + 6)
+        */
+    }
+
+    #homonexus-toggle {
+        right: 65px; /* (ia-chat-toggle width 44px + right 15px = 59) + 6px gap */
+    }
+
+    /* #ia-chat-toggle is assumed to be fixed at right: 15px (from ia-chat.css) */
+
+    /* Ensure sidebar-toggle remains top-left */
+    #sidebar-toggle {
+        left: 15px;
+    }
 }

--- a/js/layout.js
+++ b/js/layout.js
@@ -352,7 +352,7 @@ function initializeIAChatSidebar() {
         const p = document.createElement('p');
         p.className = `chat-${role} chat-message`;
         p.dataset.role = role;
-        p.contentEditable = 'true';
+        // p.contentEditable = 'true'; // Removed for simplification
         if (role === 'user') {
             p.textContent = text;
         } else {


### PR DESCRIPTION
… IA chat.

This commit includes a series of fixes addressing multiple user-reported issues:
- Non-functional header buttons and menus (PC & Mobile).
- Missing language flags (PC).
- Poor text visibility / "transparent text" on the index page (PC).
- IA chat sidebar always visible or obstructing view on mobile.
- IA chat not being fully operative.
- Confusing layout of header toggle buttons on mobile.

Key changes implemented:

1.  **JavaScript Functionality & Timing:**
    -   Resolved a critical race condition: Ensured `js/header_loader.js` completes loading all HTML fragments (menus, toggles, language bar, IA chat) *before* JavaScript in `js/layout.js` and `js/lang-bar.js` attempts to initialize them or attach event listeners. This was done by moving initialization calls to the end of `js/header_loader.js`'s `init()` function and removing premature calls from `js/layout.js`.
    -   Streamlined fragment loading by removing redundant calls from `js/load_menu_parts.js` (functionality now centralized in `js/header_loader.js`).
    -   Added `try...catch` around `initLanguageBar()` call in `js/header_loader.js` for resilience.
    -   Cleaned up `appendMessage` function in `js/layout.js` (IA chat) by removing default `contentEditable=true`.

2.  **CSS for Text Visibility & Layout:**
    -   **Text Legibility:** Refactored `assets/css/epic_theme.css`. Moved aggressive `filter` properties from `body` and `body.dark-mode` to `body::before` and `body.dark-mode::before` pseudo-elements. This applies the desired stylistic filters to the background image layer only, preventing them from degrading text contrast and fixing the "transparent text" issue.
    -   **IA Chat Sidebar Visibility (Mobile):** Modified `assets/css/header/ia-chat.css`. Changed the hiding mechanism for `#ia-chat-sidebar` from `right: -25vw` to the more robust `transform: translateX(100%)` (and `translateX(0)` for visible state), ensuring it's correctly hidden off-screen by default.
    -   **Header Toggles Layout (Mobile):** Added and adjusted CSS rules in `assets/css/header/topbar.css` to provide explicit `position: fixed` and coordinate `top`/`left`/`right` values for all header toggles (`#sidebar-toggle`, `#theme-toggle`, `#ia-chat-toggle`, `#homonexus-toggle`). This includes mobile-specific adjustments using media queries for a cleaner and more usable layout.

3.  **IA Chat Behavior:**
    -   Prevented unintentional opening: Removed code in `js/layout.js` that programmatically opened the IA chat sidebar when the main navigation sidebar was toggled.

These cumulative changes aim to restore full functionality to header navigation and buttons, ensure content visibility, and correct layout issues with the IA chat system, particularly on mobile devices.