### PR TITLE
I've added a specific alert to the sidebar toggle for the Non-Firefox…

### DIFF
--- a/js/header_loader.js
+++ b/js/header_loader.js
@@ -66,7 +66,6 @@
                 console.error("Error loading IA tools script:", e);
             }
         }
-        alert("header_loader.js init() completed. Test PC.");
     }
 
     if (document.readyState === 'loading') {

--- a/js/layout.js
+++ b/js/layout.js
@@ -48,7 +48,7 @@ function initializeSidebarNavigation() {
 
     if (sidebarToggle && sidebar && body) { // Added body check
         sidebarToggle.addEventListener('click', () => {
-            alert("Sidebar toggle clicked! Test PC."); // Temporary debug
+            alert("Sidebar toggle clicked! Test Non-Firefox PC."); // Temporary debug
             const opening = !sidebar.classList.contains('sidebar-visible');
             sidebar.classList.toggle('sidebar-visible');
             body.classList.toggle('sidebar-active'); // For main content shift


### PR DESCRIPTION
… PC test.

This involves updating a JavaScript alert (`alert("Sidebar toggle clicked! Test Non-Firefox PC.");`) to the click event listener for the main sidebar toggle button (`#sidebar-toggle`) in `js/layout.js`.

This is a targeted diagnostic step to determine if the click event listener is being correctly attached and is firing in non-Firefox browsers on PC (Chrome, Opera, Konqueror), where you reported that header buttons are not working. My previous investigation confirmed `js/header_loader.js` (which calls the initializers in `js/layout.js`) completes its execution.

If this alert appears in the problematic browsers, it indicates the listener is firing, and the issue lies within the handler's logic for those browsers. If it does not appear, it suggests the listener is not being attached or triggered, possibly due to `document.getElementById('sidebar-toggle')` not finding the element or other cross-browser JavaScript discrepancies during initialization.