### PR TITLE
Fix: Improve js/lang-bar.js resilience and ensure initLanguageBar is …

### DIFF
--- a/js/header_loader.js
+++ b/js/header_loader.js
@@ -17,7 +17,7 @@
     }
 
     async function init() {
-        alert("INIT_START");
+        // alert("INIT_START"); // Removed
 
         await Promise.all([
             loadFragment('#header-language-bar-placeholder', '/fragments/header/language-bar.html'),
@@ -26,7 +26,7 @@
             loadFragment('#header-ia-chat-placeholder', '/fragments/header/ia-chat.html')
         ]);
 
-        alert("AFTER_FIRST_PROMISE_ALL");
+        // alert("AFTER_FIRST_PROMISE_ALL"); // Removed
 
         await Promise.all([
             loadFragment('#main-menu-placeholder', '/fragments/menus/main-menu.html'),
@@ -34,88 +34,88 @@
             loadFragment('#social-menu-placeholder', '/fragments/menus/social-menu.html')
         ]);
 
-        alert("AFTER_SECOND_PROMISE_ALL");
+        // alert("AFTER_SECOND_PROMISE_ALL"); // Removed
 
         if (window.initLanguageBar) {
-            alert("BEFORE_INIT_LANG_BAR");
+            // alert("BEFORE_INIT_LANG_BAR"); // Removed
             try {
                 window.initLanguageBar();
-                alert("AFTER_INIT_LANG_BAR_SUCCESS");
+                // alert("AFTER_INIT_LANG_BAR_SUCCESS"); // Removed
             } catch (e) {
                 console.error("Error initializing language bar:", e);
-                alert("ERROR_INIT_LANG_BAR: " + e.message);
+                // alert("ERROR_INIT_LANG_BAR: " + e.message); // Removed
             }
         } else {
-            alert("NO_INIT_LANG_BAR_FUNCTION");
+            // alert("NO_INIT_LANG_BAR_FUNCTION"); // Removed
         }
 
         // Call layout initializers after all fragments are loaded
         if (window.initializeSidebarNavigation) {
-            alert("BEFORE_INIT_SIDEBAR_NAV");
+            // alert("BEFORE_INIT_SIDEBAR_NAV"); // Removed
             try {
                 window.initializeSidebarNavigation();
-                alert("AFTER_INIT_SIDEBAR_NAV_SUCCESS");
+                // alert("AFTER_INIT_SIDEBAR_NAV_SUCCESS"); // Removed
             } catch (e) {
                 console.error("Error initializing sidebar navigation:", e);
-                alert("ERROR_INIT_SIDEBAR_NAV: " + e.message);
+                // alert("ERROR_INIT_SIDEBAR_NAV: " + e.message); // Removed
             }
         } else {
-            alert("NO_INIT_SIDEBAR_NAV_FUNCTION");
+            // alert("NO_INIT_SIDEBAR_NAV_FUNCTION"); // Removed
         }
 
         if (window.initializeThemeToggle) {
-            alert("BEFORE_INIT_THEME_TOGGLE");
+            // alert("BEFORE_INIT_THEME_TOGGLE"); // Removed
             try {
                 window.initializeThemeToggle();
-                alert("AFTER_INIT_THEME_TOGGLE_SUCCESS");
+                // alert("AFTER_INIT_THEME_TOGGLE_SUCCESS"); // Removed
             } catch (e) {
                 console.error("Error initializing theme toggle:", e);
-                alert("ERROR_INIT_THEME_TOGGLE: " + e.message);
+                // alert("ERROR_INIT_THEME_TOGGLE: " + e.message); // Removed
             }
         } else {
-            alert("NO_INIT_THEME_TOGGLE_FUNCTION");
+            // alert("NO_INIT_THEME_TOGGLE_FUNCTION"); // Removed
         }
 
         if (window.initializeHomonexusToggle) {
-            alert("BEFORE_INIT_HOMONEXUS_TOGGLE");
+            // alert("BEFORE_INIT_HOMONEXUS_TOGGLE"); // Removed
             try {
                 window.initializeHomonexusToggle();
-                alert("AFTER_INIT_HOMONEXUS_TOGGLE_SUCCESS");
+                // alert("AFTER_INIT_HOMONEXUS_TOGGLE_SUCCESS"); // Removed
             } catch (e) {
                 console.error("Error initializing homonexus toggle:", e);
-                alert("ERROR_INIT_HOMONEXUS_TOGGLE: " + e.message);
+                // alert("ERROR_INIT_HOMONEXUS_TOGGLE: " + e.message); // Removed
             }
         } else {
-            alert("NO_INIT_HOMONEXUS_TOGGLE_FUNCTION");
+            // alert("NO_INIT_HOMONEXUS_TOGGLE_FUNCTION"); // Removed
         }
 
         if (window.initializeIAChatSidebar) {
-            alert("BEFORE_INIT_IA_CHAT_SIDEBAR");
+            // alert("BEFORE_INIT_IA_CHAT_SIDEBAR"); // Removed
             try {
                 window.initializeIAChatSidebar();
-                alert("AFTER_INIT_IA_CHAT_SIDEBAR_SUCCESS");
+                // alert("AFTER_INIT_IA_CHAT_SIDEBAR_SUCCESS"); // Removed
             } catch (e) {
                 console.error("Error initializing IA chat sidebar:", e);
-                alert("ERROR_INIT_IA_CHAT_SIDEBAR: " + e.message);
+                // alert("ERROR_INIT_IA_CHAT_SIDEBAR: " + e.message); // Removed
             }
         } else {
-            alert("NO_INIT_IA_CHAT_SIDEBAR_FUNCTION");
+            // alert("NO_INIT_IA_CHAT_SIDEBAR_FUNCTION"); // Removed
         }
 
         if (window.loadIAToolsScript) {
-            alert("BEFORE_LOAD_IA_TOOLS_SCRIPT");
+            // alert("BEFORE_LOAD_IA_TOOLS_SCRIPT"); // Removed
             try {
                 window.loadIAToolsScript();
-                alert("AFTER_LOAD_IA_TOOLS_SCRIPT_SUCCESS");
+                // alert("AFTER_LOAD_IA_TOOLS_SCRIPT_SUCCESS"); // Removed
             } catch (e) {
                 console.error("Error loading IA tools script:", e);
-                alert("ERROR_LOAD_IA_TOOLS_SCRIPT: " + e.message);
+                // alert("ERROR_LOAD_IA_TOOLS_SCRIPT: " + e.message); // Removed
             }
         } else {
-            alert("NO_LOAD_IA_TOOLS_SCRIPT_FUNCTION");
+            // alert("NO_LOAD_IA_TOOLS_SCRIPT_FUNCTION"); // Removed
         }
 
-        alert("INIT_COMPLETED_FULLY");
+        // alert("INIT_COMPLETED_FULLY"); // Removed
     }
 
     if (document.readyState === 'loading') {

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -21,14 +21,6 @@ function setupLanguageBar() {
     }
 }
 
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', setupLanguageBar);
-} else {
-    setupLanguageBar();
-}
-
-window.initLanguageBar = setupLanguageBar;
-
 function loadGoogleTranslate(targetLang) {
     window._targetLang = targetLang;
     if (!window.googleTranslateElementInit) {
@@ -51,3 +43,17 @@ function translatePage(lang) {
         combo.dispatchEvent(new Event('change'));
     }
 }
+
+try {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', setupLanguageBar);
+    } else {
+        setupLanguageBar();
+    }
+} catch (e) {
+    console.error("Error during initial execution/setup of lang-bar.js:", e);
+    // Optionally, a user-facing alert for diagnostics if this phase is critical
+    // alert("Critical error in language bar initial setup. Some features might be affected.");
+}
+
+window.initLanguageBar = setupLanguageBar; // Ensure this is always assigned


### PR DESCRIPTION
…defined.

This commit addresses a potential issue where `js/lang-bar.js` might fail in non-Firefox browsers before defining `window.initLanguageBar`, which is needed by `js/header_loader.js`.

Changes:
- In `js/lang-bar.js`:
    - Wrapped the initial automatic execution of `setupLanguageBar()` (which happens if DOM is ready or on DOMContentLoaded) in a `try...catch` block. This prevents an early error in `setupLanguageBar` from halting the entire `js/lang-bar.js` script.
    - Ensured that `window.initLanguageBar = setupLanguageBar;` is always executed after this `try...catch` block.
- Reverted all diagnostic `alert()` statements from `js/header_loader.js`.
- Reverted a diagnostic `alert()` from `js/layout.js`.

This should ensure that `js/header_loader.js` can always find `window.initLanguageBar` (even if `js/lang-bar.js` had an early error during its own setup phase). Any errors during the execution of `initLanguageBar` when called by `header_loader.js` will be caught by the `try...catch` block already implemented in `header_loader.js`.

This aims to make the main menu buttons functional on PC in non-Firefox browsers by allowing `header_loader.js` to proceed with calling other initialization functions even if language bar setup encounters issues. Please test button functionality on PC (Chrome, Opera, etc.) and report any console errors.