### PR TITLE
Make setup_project.sh location independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ la base de datos.
 ./scripts/setup_project.sh
 ```
 
+El script puede ejecutarse desde cualquier directorio siempre que estés
+dentro del repositorio, ya que detecta automáticamente la raíz del proyecto.
+
 
 ## Consideraciones de produccion
 

--- a/scripts/setup_project.sh
+++ b/scripts/setup_project.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
+# Determine repository root and switch to it
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
 # Ensure Composer is available
 COMPOSER_CMD=""
 if command -v composer >/dev/null 2>&1; then
     COMPOSER_CMD="composer"
-elif [ -f composer.phar ]; then
-    COMPOSER_CMD="php composer.phar"
+elif [ -f "$PROJECT_ROOT/composer.phar" ]; then
+    COMPOSER_CMD="php $PROJECT_ROOT/composer.phar"
 else
     echo "Composer no encontrado. Descargando composer.phar..."
     curl -sS https://getcomposer.org/installer -o composer-setup.php
     php composer-setup.php --quiet
     rm composer-setup.php
-    COMPOSER_CMD="php composer.phar"
+    COMPOSER_CMD="php $PROJECT_ROOT/composer.phar"
 fi
 
 # Install PHP dependencies
@@ -21,25 +26,24 @@ $COMPOSER_CMD install --ignore-platform-req=ext-dom \
                       --ignore-platform-req=ext-xml
 
 # Setup frontend libraries
-scripts/setup_frontend_libs.sh
+"$PROJECT_ROOT"/scripts/setup_frontend_libs.sh
 
 # Copy environment file if needed
-if [ ! -f .env ] && [ -f .env.example ]; then
-    cp .env.example .env
+if [ ! -f "$PROJECT_ROOT/.env" ] && [ -f "$PROJECT_ROOT/.env.example" ]; then
+    cp "$PROJECT_ROOT/.env.example" "$PROJECT_ROOT/.env"
     echo "Archivo .env creado a partir de .env.example"
 fi
 
 # Create upload directories
-mkdir -p uploads/galeria \
-         uploads_storage/museo_piezas \
-         uploads_storage/tienda_productos
+mkdir -p "$PROJECT_ROOT"/uploads/galeria \
+         "$PROJECT_ROOT"/uploads_storage/museo_piezas \
+         "$PROJECT_ROOT"/uploads_storage/tienda_productos
 
 # Optional database check
-if [ -n "${CONDADO_DB_PASSWORD:-}" ] && [ -x scripts/check_db.sh ]; then
-    scripts/check_db.sh || echo "No se pudo comprobar la base de datos"
+if [ -n "${CONDADO_DB_PASSWORD:-}" ] && [ -x "$PROJECT_ROOT/scripts/check_db.sh" ]; then
+    "$PROJECT_ROOT"/scripts/check_db.sh || echo "No se pudo comprobar la base de datos"
 fi
 
 cat <<MSG
 Configuración completada.
 MSG
-


### PR DESCRIPTION
## Summary
- compute project root in scripts/setup_project.sh so it can run from anywhere
- use project root when invoking other scripts and setting up files
- document that the setup script is location-independent

## Testing
- `bash scripts/setup_project.sh` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472537adc08329903172759a3fc8e8