### PR TITLE
Update header layout and language support

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -1,5 +1,6 @@
 <div id="linterna-condado"></div>
 <header id="main-header" role="banner">
+    <div class="top-empty-bar"></div>
     <div id="header-language-bar-placeholder"></div>
     <div id="header-toggles-placeholder"></div>
     <div id="header-navigation-placeholder"></div>

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -1,12 +1,22 @@
 /* assets/css/header/topbar.css */
 
+.top-empty-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 48px;
+    background: var(--epic-transparent-overlay-medium);
+    z-index: 3000;
+}
+
 /* Theme Toggle Button - Original Position (will be adjusted for mobile) */
 #theme-toggle {
     position: fixed;
-    top: 55px; /* Was 15px, add 40px for spacer */
+    top: 88px; /* lowered position */
     left: 50%;
     transform: translateX(-50%);
-    background-color: var(--epic-alabaster-bg);
+    background-color: var(--epic-transparent-overlay-medium);
     border: 2px solid var(--epic-gold-secondary);
     border-radius: var(--global-border-radius);
     padding: 10px;
@@ -39,10 +49,10 @@
 /* Language selection bar */
 .language-bar {
     position: fixed;
-    top: 40px; /* Lowered to create space above it */
+    top: 48px; /* below empty top bar */
     left: 0;
     right: 0;
-    background: var(--epic-alabaster-medium);
+    background: var(--epic-transparent-overlay-light);
     padding: 2px 8px;
     text-align: right;
     z-index: 3000; /* Below toggles if they overlap, but above content */
@@ -65,9 +75,9 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
 /* Sidebar Toggle (Hamburger) */
 #sidebar-toggle {
     position: fixed;
-    top: 55px; /* Was 15px, add 40px for spacer */
+    top: 88px; /* moved lower */
     left: 15px;
-    background-color: var(--epic-alabaster-bg);
+    background-color: var(--epic-transparent-overlay-medium);
     border: 2px solid var(--epic-gold-secondary);
     border-radius: var(--global-border-radius);
     padding: 8px;
@@ -105,9 +115,9 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
 /* IA Chat Toggle */
 #ia-chat-toggle {
     position: fixed;
-    top: 55px; /* Was 15px, add 40px for spacer */
+    top: 88px; /* moved lower */
     right: 15px;
-    background-color: var(--epic-alabaster-bg);
+    background-color: var(--epic-transparent-overlay-medium);
     border: 2px solid var(--epic-gold-secondary);
     border-radius: var(--global-border-radius);
     padding: 10px;
@@ -137,9 +147,9 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
 /* Homonexus Toggle */
 #homonexus-toggle {
     position: fixed;
-    top: 55px; /* Was 15px, add 40px for spacer */
+    top: 88px; /* moved lower */
     right: 65px; /* (ia-chat-toggle width 44px + right 15px = 59px) + 6px gap */
-    background-color: var(--epic-alabaster-bg);
+    background-color: var(--epic-transparent-overlay-medium);
     border: 2px solid var(--epic-gold-secondary);
     border-radius: var(--global-border-radius);
     padding: 10px;
@@ -181,9 +191,9 @@ body.dark-mode #homonexus-toggle:hover i {
         right: 115px; /* (homonexus-toggle right 65px + width 44px = 109px) + 6px gap */
         /* Note: Ensure #ia-chat-toggle is at right: 15px and #homonexus-toggle at right: 65px */
     }
-    /* #sidebar-toggle remains top: 55px; left: 15px; */
-    /* #ia-chat-toggle remains top: 55px; right: 15px; */
-    /* #homonexus-toggle remains top: 55px; right: 65px; */
+    /* #sidebar-toggle remains top: 88px; left: 15px; */
+    /* #ia-chat-toggle remains top: 88px; right: 15px; */
+    /* #homonexus-toggle remains top: 88px; right: 65px; */
 }
 
 /* Consider further adjustments for very small screens if needed, e.g., hiding some toggles */

--- a/fragments/header/language-bar.html
+++ b/fragments/header/language-bar.html
@@ -11,5 +11,15 @@
     <a href="?lang=ko" class="lang-flag" title="한국어">🇰🇷</a>
     <a href="?lang=ar" class="lang-flag" title="العربية">🇸🇦</a>
     <a href="?lang=hi" class="lang-flag" title="हिन्दी">🇮🇳</a>
+    <a href="?lang=tr" class="lang-flag" title="Türkçe">🇹🇷</a>
+    <a href="?lang=id" class="lang-flag" title="Bahasa Indonesia">🇮🇩</a>
+    <a href="?lang=vi" class="lang-flag" title="Tiếng Việt">🇻🇳</a>
+    <a href="?lang=bn" class="lang-flag" title="বাংলা">🇧🇩</a>
+    <a href="?lang=ur" class="lang-flag" title="اردو">🇵🇰</a>
+    <a href="?lang=fa" class="lang-flag" title="فارسی">🇮🇷</a>
+    <a href="?lang=nl" class="lang-flag" title="Nederlands">🇳🇱</a>
+    <a href="?lang=pl" class="lang-flag" title="Polski">🇵🇱</a>
+    <a href="?lang=uk" class="lang-flag" title="Українська">🇺🇦</a>
+    <a href="?lang=sw" class="lang-flag" title="Kiswahili">🇰🇪</a>
 </div>
 <div id="google_translate_element" style="display:none;"></div>

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -25,7 +25,7 @@ function loadGoogleTranslate(targetLang) {
     window._targetLang = targetLang;
     if (!window.googleTranslateElementInit) {
         window.googleTranslateElementInit = function() {
-            new google.translate.TranslateElement({pageLanguage: 'es', includedLanguages: 'en,es,fr,de,it,pt,ru,zh-CN,ja,ko,ar,hi'}, 'google_translate_element');
+            new google.translate.TranslateElement({pageLanguage: 'es', includedLanguages: 'en,es,fr,de,it,pt,ru,zh-CN,ja,ko,ar,hi,tr,id,vi,bn,ur,fa,nl,pl,uk,sw'}, 'google_translate_element');
             translatePage(window._targetLang);
         };
         const script = document.createElement('script');


### PR DESCRIPTION
## Summary
- keep alabastro background visible with translucent UI elements
- add an empty bar above the language selector
- lower header toggle buttons
- include ten additional languages in the language bar

## Testing
- `php -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6848c0d1cb6883299da6717e954b8e3d