### PR TITLE
Add configurable upload dirs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ CONDADO_DB_PASSWORD="your_password"
 GEMINI_API_KEY=your_key
 GeminiAPI=your_key
 GEMINI_API_ENDPOINT=https://api.gemini.example.com/v1/generateContent
+# --- Upload directories (optional) ---
+# Rutas fuera de la carpeta pública para almacenar las imágenes
+MUSEO_UPLOAD_DIR="../uploads_storage/museo_piezas"
+TIENDA_UPLOAD_DIR="../uploads_storage/tienda_productos"

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwrit
 
 A continuación copia el archivo de ejemplo `.env.example` a `.env`
 y sustituye sus valores por tus credenciales reales para
-`CONDADO_DB_PASSWORD`, `GEMINI_API_KEY`
-y cualquier otra variable necesaria.
+`CONDADO_DB_PASSWORD`, `GEMINI_API_KEY` y, si lo deseas,
+ajusta las rutas de `MUSEO_UPLOAD_DIR` y `TIENDA_UPLOAD_DIR` u
+otras variables que necesites.
 
 Si prefieres una configuración automática ejecuta `scripts/setup_project.sh`, el
 cual realizará todos los pasos anteriores, creará los directorios de subida y,
@@ -109,6 +110,9 @@ es necesario definir las siguientes variables de entorno:
 - `GEMINI_API_ENDPOINT`: URL del servicio al que se enviarán las solicitudes. Si no se establece,
   se usa un valor de ejemplo que activa un simulador interno.
 
+Además puedes definir `MUSEO_UPLOAD_DIR` y `TIENDA_UPLOAD_DIR` para ajustar las
+carpetas donde se guardarán las imágenes subidas por las APIs.
+
 Si está disponible, puedes revisar el script opcional `scripts/gemini_request.sh`
 para ver un ejemplo básico de invocación que hace uso de `GEMINI_API_KEY`.
 Encuentra la tienda en [tienda/index.php](tienda/index.php).
@@ -146,16 +150,22 @@ La conexión a la base de datos requiere que la variable de entorno `CONDADO_DB_
 
 Se ha añadido una sección de foro en `foro/index.html`. Por el momento funciona como una página de aviso mientras se desarrolla el espacio de discusión.
 
-## Almacenamiento de imágenes del museo
+## Almacenamiento de imágenes del museo y la tienda
 
-Las imágenes subidas a través de la API del museo se guardan en el directorio `uploads_storage/museo_piezas`.
-Antes de ejecutar la API asegúrate de crear esta carpeta y asignar permisos de escritura al usuario que ejecute el servidor web.
+Las APIs guardan sus ficheros en rutas externas a la carpeta pública. Por defecto
+se utilizan `uploads_storage/museo_piezas` para el museo y
+`uploads_storage/tienda_productos` para la tienda. Puedes modificar estas rutas
+con las variables de entorno `MUSEO_UPLOAD_DIR` y `TIENDA_UPLOAD_DIR`.
 
-Ejemplo de creación del directorio en Linux:
+Si las carpetas no existen se crearán automáticamente cuando se ejecute la API,
+pero es recomendable prepararlas de antemano y otorgar permisos de escritura al
+usuario del servidor web.
+
+Ejemplo de creación en Linux:
 
 ```bash
-mkdir -p uploads_storage/museo_piezas
-chmod 775 uploads_storage/museo_piezas
+mkdir -p uploads_storage/museo_piezas uploads_storage/tienda_productos
+chmod 775 uploads_storage/museo_piezas uploads_storage/tienda_productos
 ```
 
 ## Agente diario

--- a/api_museo.php
+++ b/api_museo.php
@@ -30,8 +30,13 @@ function get_base_url() {
     return $protocol . $host;
 }
 
-// Define the upload directory outside the web root
-define('UPLOAD_DIR_BASE', dirname(__DIR__) . '/uploads_storage/museo_piezas/');
+// Define the upload directory outside the web root, configurable via env var
+$museoUpload = getenv('MUSEO_UPLOAD_DIR');
+if (!$museoUpload) {
+    $museoUpload = dirname(__DIR__) . '/uploads_storage/museo_piezas';
+}
+$museoUpload = rtrim($museoUpload, '/') . '/';
+define('UPLOAD_DIR_BASE', $museoUpload);
 define('IMAGE_ENDPOINT', '/serve_museo_image.php');
 
 // Ensure the upload directory exists

--- a/api_tienda.php
+++ b/api_tienda.php
@@ -17,7 +17,12 @@ function json_response($data, $status = 200) {
     exit;
 }
 
-define('UPLOAD_DIR_BASE', dirname(__DIR__) . '/uploads_storage/tienda_productos/');
+$tiendaUpload = getenv('TIENDA_UPLOAD_DIR');
+if (!$tiendaUpload) {
+    $tiendaUpload = dirname(__DIR__) . '/uploads_storage/tienda_productos';
+}
+$tiendaUpload = rtrim($tiendaUpload, '/') . '/';
+define('UPLOAD_DIR_BASE', $tiendaUpload);
 
 if (!is_dir(UPLOAD_DIR_BASE)) {
     @mkdir(UPLOAD_DIR_BASE, 0775, true);

--- a/serve_museo_image.php
+++ b/serve_museo_image.php
@@ -1,7 +1,12 @@
 <?php
 require_once __DIR__ . '/includes/csrf.php';
-// Use same upload dir definition as API
-define('UPLOAD_DIR_BASE', dirname(__DIR__) . '/uploads_storage/museo_piezas/');
+// Use same upload dir definition as API, configurable via env var
+$museoUpload = getenv('MUSEO_UPLOAD_DIR');
+if (!$museoUpload) {
+    $museoUpload = dirname(__DIR__) . '/uploads_storage/museo_piezas';
+}
+$museoUpload = rtrim($museoUpload, '/') . '/';
+define('UPLOAD_DIR_BASE', $museoUpload);
 
 $filename = basename($_GET['file'] ?? '');
 $path = UPLOAD_DIR_BASE . $filename;


### PR DESCRIPTION
## Summary
- allow overriding museo/tienda upload directories using env variables
- document MUSEO_UPLOAD_DIR and TIENDA_UPLOAD_DIR in the README and example env

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c2b19ccc83299c480640725342ac