### PR TITLE
Add admin interface for editing museum pieces

### DIFF
--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -87,6 +87,7 @@ require_admin_login();
         <a href="../index.php">Inicio</a>
         <a href="edit_texts.php">Textos</a>
         <a href="tienda_admin.php">Tienda</a>
+        <a href="../museo/editar_pieza.php">Piezas Museo</a>
         <a href="logout.php">Cerrar sesión</a>
     </nav>
     

--- a/museo/editar_pieza.php
+++ b/museo/editar_pieza.php
@@ -1,0 +1,100 @@
+<?php
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
+require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../dashboard/db_connect.php';
+/** @var PDO $pdo */
+require_once __DIR__ . '/../includes/csrf.php';
+
+require_admin_login();
+
+$feedback_message = '';
+$feedback_type = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+        $feedback_message = 'CSRF token inválido.';
+        $feedback_type = 'error';
+    } else {
+        $id = intval($_POST['id'] ?? 0);
+        $pos_x = ($_POST['pos_x'] !== '') ? (float)$_POST['pos_x'] : null;
+        $pos_y = ($_POST['pos_y'] !== '') ? (float)$_POST['pos_y'] : null;
+        $pos_z = ($_POST['pos_z'] !== '') ? (float)$_POST['pos_z'] : null;
+        $escala = ($_POST['escala'] !== '') ? (float)$_POST['escala'] : null;
+        if ($id > 0) {
+            try {
+                $stmt = $pdo->prepare('UPDATE museo_piezas SET pos_x=:x, pos_y=:y, pos_z=:z, escala=:e WHERE id=:id');
+                $stmt->bindValue(':x', $pos_x, PDO::PARAM_STR);
+                $stmt->bindValue(':y', $pos_y, PDO::PARAM_STR);
+                $stmt->bindValue(':z', $pos_z, PDO::PARAM_STR);
+                $stmt->bindValue(':e', $escala, PDO::PARAM_STR);
+                $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+                $stmt->execute();
+                $feedback_message = 'Pieza actualizada correctamente.';
+                $feedback_type = 'success';
+            } catch (PDOException $e) {
+                $feedback_message = 'Error al actualizar la pieza.';
+                $feedback_type = 'error';
+            }
+        }
+    }
+}
+
+$piezas = [];
+try {
+    $stmt = $pdo->query('SELECT id, titulo, pos_x, pos_y, pos_z, escala FROM museo_piezas ORDER BY id DESC');
+    $piezas = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $feedback_message = 'Error al cargar piezas: ' . $e->getMessage();
+    $feedback_type = 'error';
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Editar Piezas del Museo</title>
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+    <style>
+        body { font-family: Arial, sans-serif; margin:20px; }
+        table { width:100%; border-collapse: collapse; margin-bottom:20px; }
+        th, td { border:1px solid #ccc; padding:8px; text-align:left; }
+        th { background-color:#f2f2f2; }
+        .feedback.success { background:#d4edda; padding:10px; margin-bottom:10px; }
+        .feedback.error { background:#f8d7da; padding:10px; margin-bottom:10px; }
+    </style>
+</head>
+<body>
+<nav>
+    <a href="../index.php">Inicio</a>
+    <a href="../dashboard/index.php">Dashboard</a>
+    <a href="../dashboard/logout.php">Cerrar sesión</a>
+</nav>
+<h1>Editar Posición y Escala de Piezas</h1>
+<?php if ($feedback_message): ?>
+    <div class="feedback <?php echo htmlspecialchars($feedback_type); ?>">
+        <?php echo htmlspecialchars($feedback_message); ?>
+    </div>
+<?php endif; ?>
+<table>
+    <tr><th>ID</th><th>Título</th><th>Pos X</th><th>Pos Y</th><th>Pos Z</th><th>Escala</th><th>Acción</th></tr>
+<?php foreach ($piezas as $p): ?>
+    <tr>
+    <form method="post">
+        <td><?php echo (int)$p['id']; ?><input type="hidden" name="id" value="<?php echo (int)$p['id']; ?>"></td>
+        <td><?php echo htmlspecialchars($p['titulo']); ?></td>
+        <td><input type="number" step="0.1" name="pos_x" value="<?php echo htmlspecialchars($p['pos_x']); ?>"></td>
+        <td><input type="number" step="0.1" name="pos_y" value="<?php echo htmlspecialchars($p['pos_y']); ?>"></td>
+        <td><input type="number" step="0.1" name="pos_z" value="<?php echo htmlspecialchars($p['pos_z']); ?>"></td>
+        <td><input type="number" step="0.05" name="escala" value="<?php echo htmlspecialchars($p['escala']); ?>"></td>
+        <td>
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(get_csrf_token()); ?>">
+            <button type="submit">Guardar</button>
+        </td>
+    </form>
+    </tr>
+<?php endforeach; ?>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `museo/editar_pieza.php` page to allow admin users to update `pos_x`, `pos_y`, `pos_z` and `escala` of museum entries
- require admin login and CSRF checks for updates
- link the new page from the dashboard navigation

## Testing
- `phpunit` *(fails: LoginLogoutTest expecting redirect header)*

------
https://chatgpt.com/codex/tasks/task_e_6848c2b2c0808329ae873f345961351f