### PR TITLE
Refactor: Perform minor CSS cleanup in epic_theme.css

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -321,26 +321,6 @@ th {
     outline: none;
 }
 
-/* Alternative close button as an 'X' in the corner */
-/*
-#overlay-cerrar.corner-close {
-    position: absolute;
-    top: 15px;
-    right: 15px;
-    background: transparent;
-    border: none;
-    font-size: 2em;
-    color: var(--epic-text-color);
-    padding: 0;
-    line-height: 1;
-}
-#overlay-cerrar.corner-close:hover {
-    color: var(--epic-purple-emperor);
-}
-*/
-
-
-
 /* --- Footer Styling (.footer from _footer.html) --- */
 .footer {
     background-color: var(--epic-purple-emperor);
@@ -616,19 +596,6 @@ body.dark-mode .footer .social-links a:focus-visible {
     font-size: clamp(2em, 5vw, 3em);
     margin-bottom: 1.5em;
     color: var(--epic-purple-emperor);
-}
-.section-title::after { /* Decorative element after section titles */
-    content: '';
-    display: block;
-    width: 50px;
-    height: 50px;
-    background-image: url('/assets/img/estrella.png');
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: center;
-    margin: 20px auto 40px auto;
-    opacity: 0.8;
-    filter: drop-shadow(0 0 8px var(--epic-gold-main));
 }
 
 /* --- Cards (.card) --- */
@@ -1270,24 +1237,6 @@ body.dark-mode .footer .social-links a:focus-visible {
     /* text-align: center; */ /* Inherits from .card-content */
     margin-bottom: 1.5em;
     flex-grow: 1;
-}
-
-.card-content .read-more { /* epic_theme.css has .card-content .read-more. Appending. */
-    background-color: transparent;
-    color: var(--color-secundario-dorado, #B8860B); /* Mapped */
-    border: 2px solid var(--color-secundario-dorado, #B8860B); /* Mapped */
-    padding: 10px 20px;
-    font-size: 0.9em;
-    font-weight: 700;
-    margin-top: auto;
-    align-self: center;
-    text-decoration: none;
-}
-.card-content .read-more:hover, .card-content .read-more:focus-visible {
-    background-color: var(--color-secundario-dorado, #B8860B); /* Mapped */
-    color: var(--color-primario-purpura, #4A0D67); /* Mapped */
-    text-decoration: none;
-    outline: none;
 }
 
 /* --- Sección de Inmersión --- */

--- a/fresh_broken_links_report.txt
+++ b/fresh_broken_links_report.txt
@@ -1,0 +1,23 @@
+Link checking complete. Report generated in broken_links_report.txt
+Broken Link Report:
+---------------------
+Checking links in: index.php
+  OK: /historia/historia.html (points to historia/historia.html)
+  OK: /secciones_index/memoria_hispanidad.html (points to secciones_index/memoria_hispanidad.html)
+  OK: /historia/historia.html (points to historia/historia.html)
+  OK: /lugares/lugares.html (points to lugares/lugares.html)
+  OK: /visitas/visitas.html (points to visitas/visitas.html)
+  OK: /personajes/Militares_y_Gobernantes/conde_casio_cerasio.html (points to personajes/Militares_y_Gobernantes/conde_casio_cerasio.html)
+  OK: /personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html (points to personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html)
+  OK: /personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html (points to personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html)
+  OK: /personajes/indice_personajes.html (points to personajes/indice_personajes.html)
+  OK: /secciones_index/historia_tiempo_resumen.html (points to secciones_index/historia_tiempo_resumen.html)
+  OK: /cultura/cultura.html (points to cultura/cultura.html)
+
+Checking links in: _header.html
+No internal page/file links found to check in _header.html.
+Checking links in: _footer.php
+  OK: /dashboard/logout.php (points to dashboard/logout.php)
+  OK: /dashboard/login.php (points to dashboard/login.php)
+  OK: /en_construccion.html (points to en_construccion.html)
+  OK: /en_construccion.html (points to en_construccion.html)

--- a/fresh_broken_links_report_extended.txt
+++ b/fresh_broken_links_report_extended.txt
@@ -1,3 +1,4 @@
+Extended link checking complete. Report generated in broken_links_report_extended.txt
 Broken Link Report (Extended):
 ------------------------------
 Checked on: Wed Jun 11 11:05:37 UTC 2025


### PR DESCRIPTION
This commit addresses several minor issues within assets/css/epic_theme.css:

1.  Removed a block of commented-out CSS related to an alternative style for an overlay close button. This code was unused.
2.  Removed a redundant definition for the `.section-title::after` pseudo-element. The version from the `estilos.css` merge, which includes an animation and slightly different styling, has been preserved as the assumed intended style.
3.  Removed a redundant and conflicting definition for `.card-content .read-more` and its hover/focus states. The primary, more comprehensively styled version from `epic_theme.css` is now the sole definition, ensuring consistent styling for card action buttons.

These changes contribute to better maintainability and reduce potential confusion from duplicated or obsolete styles stemming from a previous merge of `estilos.css`.