### PR TITLE
Fix: Adjust language bar styles

### DIFF
--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -53,7 +53,7 @@
     left: 0;
     right: 0;
     background: var(--epic-transparent-overlay-light);
-    padding: 2px 8px;
+    padding: 5px 8px;
     text-align: right;
     z-index: 3000; /* Below toggles if they overlap, but above content */
     font-size: 1.2em;


### PR DESCRIPTION
- Increased vertical padding in the language bar to better accommodate icons.
- Verified that the language bar remains fixed during scroll.
- Confirmed that there is a 48px space above the language bar.

Your request was to make the language bar adapt to icons, have a space above it, and be non-scrollable. Existing styles already covered the fixed positioning and the space above. I adjusted the padding to address the icon adaptation.