### PR TITLE
Hi there, I'm Jules, your AI coding agent.

### DIFF
--- a/assets/css/header/fixed-toggles.css
+++ b/assets/css/header/fixed-toggles.css
@@ -1,7 +1,7 @@
 .fixed-vertical-toggles {
     position: fixed;
     top: 15px; /* Adjust as needed */
-    right: 15px; /* Adjust as needed */
+    left: 15px; /* Changed from right to left */
     display: flex;
     flex-direction: column;
     gap: 10px; /* Space between buttons, adjust as needed */

--- a/assets/css/header/nav.css
+++ b/assets/css/header/nav.css
@@ -161,9 +161,9 @@
 }
 
 #sidebar-toggle {
-    position: fixed;
-    top: 15px;
-    left: 15px;
+    /* position: fixed; */
+    /* top: 15px; */
+    /* left: 15px; */
     /* font-size: 1.8em; Removed as icon is no longer text */
     background-color: var(--epic-alabaster-bg);
     border: 2px solid var(--epic-gold-secondary);
@@ -198,9 +198,9 @@
 }
 
 /* Adjust toggle button position and icon animation when sidebar is visible */
-body.sidebar-active #sidebar-toggle {
-    left: 300px; /* sidebar width + desired offset */
-}
+/* body.sidebar-active #sidebar-toggle {
+    left: 300px; / * sidebar width + desired offset * /
+} */
 
 body.sidebar-active #sidebar-toggle .bar:nth-child(1) {
     transform: translateY(7px) rotate(45deg); /* height (3px) + margin (4px from example, using 2px*2=4 + 3/2 for center = ~7) */
@@ -306,7 +306,7 @@ body.ia-chat-active {
         display: none !important;
     }
     body.sidebar-active { margin-left: 0; }
-    body.sidebar-active #sidebar-toggle { left: 15px; }
+    /* body.sidebar-active #sidebar-toggle { left: 15px; } */
     body.ia-chat-active { margin-right: 0; }
     #ia-chat-sidebar {
         width: clamp(280px, 85vw, 320px);

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -73,9 +73,10 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
 }
 
 /* Sidebar Toggle (Hamburger) */
+/*
 #sidebar-toggle {
     position: fixed;
-    top: 88px; /* moved lower */
+    top: 88px; / * moved lower * /
     left: 15px;
     background-color: var(--epic-transparent-overlay-medium);
     border: 2px solid var(--epic-gold-secondary);
@@ -111,7 +112,7 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
 #sidebar-toggle.active .bar:nth-child(3) {
     transform: translateY(-6.5px) rotate(-45deg);
 }
-
+*/
 /* IA Chat Toggle */
 #ia-chat-toggle {
     position: fixed;
@@ -186,11 +187,13 @@ body.dark-mode #homonexus-toggle:hover i {
 
 /* Mobile Adjustments for Toggles */
 @media (max-width: 768px) {
+    /*
     #theme-toggle {
-        left: auto; /* Override PC centering */
-        right: 115px; /* (homonexus-toggle right 65px + width 44px = 109px) + 6px gap */
-        /* Note: Ensure #ia-chat-toggle is at right: 15px and #homonexus-toggle at right: 65px */
+        left: auto; / * Override PC centering * /
+        right: 115px; / * (homonexus-toggle right 65px + width 44px = 109px) + 6px gap * /
+        / * Note: Ensure #ia-chat-toggle is at right: 15px and #homonexus-toggle at right: 65px * /
     }
+    */
     /* #sidebar-toggle remains top: 88px; left: 15px; */
     /* #ia-chat-toggle remains top: 88px; right: 15px; */
     /* #homonexus-toggle remains top: 88px; right: 65px; */

--- a/fragments/header/toggles.html
+++ b/fragments/header/toggles.html
@@ -1,9 +1,9 @@
-<button id="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle Menu" aria-expanded="false">
-    <span class="bar"></span>
-    <span class="bar"></span>
-    <span class="bar"></span>
-</button>
 <div class="fixed-vertical-toggles">
+    <button id="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
+    </button>
     <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
         <i class="fas fa-moon"></i>
     </button>


### PR DESCRIPTION
I've just completed a refactor to align the header toggle buttons vertically on the left.

Here's a summary of the changes:

- Modified `fragments/header/toggles.html` to group `#sidebar-toggle`, `#theme-toggle`, and `#ia-chat-toggle` within a single `div.fixed-vertical-toggles`.
- Updated `assets/css/header/fixed-toggles.css` to position this group on the top-left (`left: 15px; top: 15px;`).
- Removed conflicting fixed positioning CSS for `#sidebar-toggle` from `assets/css/header/nav.css` and `assets/css/header/topbar.css`, allowing its position to be determined by the new flex group.
- Commented out mobile-specific CSS in `assets/css/header/topbar.css` for `#theme-toggle` that conflicted with the new left-aligned flex group positioning.

This results in the main header toggle buttons being presented as a single vertical stack on the top-left of the screen, consistent across desktop and mobile views.

Let me know if you have any questions or would like me to make further adjustments!