### PR TITLE
Here's how I've updated the color scheme to purple and old gold:

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -4,10 +4,10 @@
     --epic-error-red: #D9534F; /* Default error red */
     --epic-purple-emperor: #4A0D67;
     --epic-purple-emperor-rgb: 74, 13, 103;
-    --epic-gold-main: #FFD700;
-    --epic-gold-main-rgb: 255, 215, 0;
-    --epic-gold-secondary: #B8860B;
-    --epic-gold-secondary-rgb: 184, 134, 11;
+    --epic-gold-main: #cfb53b;
+    --epic-gold-main-rgb: 207, 181, 59;
+    --epic-gold-secondary: #a58f2b;
+    --epic-gold-secondary-rgb: 165, 143, 43;
     --epic-alabaster-bg: #E8EFF9; /* Very light celeste */
     --epic-alabaster-bg-rgb: 232, 239, 249; /* RGB for new light tone */
     --epic-alabaster-medium: #E6EEF9; /* Slightly darker celeste */

--- a/assets/css/pages/galeria_colaborativa.css
+++ b/assets/css/pages/galeria_colaborativa.css
@@ -1,7 +1,7 @@
 /* Styles for galeria/galeria_colaborativa.php */
 body {
-    background-color: var(--epic-alabaster-bg, #F9F7F4);
-    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-color: var(--epic-alabaster-bg);
+    background-image: var(--alabaster-background-image);
     background-size: cover;
     background-attachment: fixed;
 }

--- a/assets/css/pages/index.css
+++ b/assets/css/pages/index.css
@@ -1,8 +1,8 @@
 /* Page-specific styles for index.php */
 body {
     /* Use alabaster background, rely on global CSS variables if defined */
-    background-color: var(--epic-alabaster-bg, #F9F7F4);
-    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-color: var(--epic-alabaster-bg);
+    background-image: var(--alabaster-background-image);
     background-size: cover;
     background-attachment: fixed;
 }

--- a/assets/css/pages/tienda.css
+++ b/assets/css/pages/tienda.css
@@ -1,7 +1,7 @@
 /* Page-specific styles for tienda/index.php */
 body {
-    background-color: var(--epic-alabaster-bg, #F9F7F4);
-    background-image: var(--alabaster-background-image, url('/assets/img/alabastro.jpg'));
+    background-color: var(--epic-alabaster-bg);
+    background-image: var(--alabaster-background-image);
     background-attachment: fixed;
 }
 


### PR DESCRIPTION
I've adjusted the main CSS variables in `epic_theme.css` to reflect the new color palette:
- Main Purple: `#4A0D67` (this one remains the same)
- Main Old Gold: `#cfb53b`
- Secondary Old Gold: `#a58f2b`

I also removed unnecessary fallback colors in page-specific CSS files to ensure the theme is consistent.

These changes aim to provide a cohesive look and feel across the entire website with the new color palette.