### PR TITLE
Update Gemini request endpoint handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ export GEMINI_API_KEY="tu_clave"
 export GeminiAPI="$GEMINI_API_KEY"
 ```
 
-4. (Opcional) Establece la URL del servicio si no quieres usar el endpoint de ejemplo:
+4. (Opcional) Define `GEMINI_API_ENDPOINT` con la URL de tu servicio. 
+   El script la usará si está presente, de lo contrario mantendrá el endpoint de ejemplo:
 
 ```bash
 export GEMINI_API_ENDPOINT="https://tu-endpoint-real.example.com/v1/generateContent"

--- a/scripts/gemini_request.sh
+++ b/scripts/gemini_request.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # Usage: GEMINI_API_KEY=your_api_key ./gemini_request.sh
 
-API_URL="https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
+# Use the endpoint from GEMINI_API_ENDPOINT when available
+API_URL="${GEMINI_API_ENDPOINT:-https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent}"
 
 # Allow the variable name GeminiAPI as an alternative
 if [ -z "$GEMINI_API_KEY" ]; then


### PR DESCRIPTION
## Summary
- allow overriding Gemini API endpoint in `gemini_request.sh`
- clarify README about using `GEMINI_API_ENDPOINT`

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_684d4c98f88083298d3b9339d35489ff