### PR TITLE
Improve env loading and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ php -S localhost:8000
 ```
 
 Esto iniciará el servidor en `http://localhost:8000`.
+Abre tu navegador y visita `http://localhost:8000` para ver el sitio.
 
 ## Instalación de dependencias
 
@@ -63,7 +64,13 @@ composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwrit
 A continuación copia el archivo de ejemplo `.env.example` a `.env`
 y sustituye sus valores por tus credenciales reales para
 `CONDADO_DB_PASSWORD`, `GEMINI_API_KEY`
-y cualquier otra variable necesaria.
+y cualquier otra variable necesaria. El fichero se
+carga automáticamente mediante `env_loader.php`, por lo que no es
+necesario exportar las variables de entorno de forma manual. Si no se
+usa este cargador (por ejemplo en versiones anteriores) tendrás que
+definir cada variable con `export` para que PHP pueda leerla.
+El cargador se incluye desde `includes/session.php`, de modo que las
+variables se aplican en todas las páginas que usan esa cabecera.
 
 Si prefieres una configuración automática ejecuta `scripts/setup_project.sh`, el
 cual realizará todos los pasos anteriores, creará los directorios de subida y,

--- a/api_galeria.php
+++ b/api_galeria.php
@@ -1,6 +1,7 @@
 <?php
 // api_galeria.php - Endpoint para manejar la galeria colaborativa
 
+require_once __DIR__ . '/includes/env_loader.php';
 require_once 'dashboard/db_connect.php';
 require_once 'includes/auth.php';
 

--- a/api_museo.php
+++ b/api_museo.php
@@ -1,6 +1,7 @@
 <?php
 // api_museo.php
 
+require_once __DIR__ . '/includes/env_loader.php';
 // Include necessary files
 require_once 'dashboard/db_connect.php'; // Adjust path as necessary
 require_once 'includes/auth.php'; // Adjust path as necessary

--- a/api_tienda.php
+++ b/api_tienda.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/includes/env_loader.php';
 require_once 'dashboard/db_connect.php';
 require_once 'includes/auth.php';
 require_once 'includes/csrf.php';

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../includes/env_loader.php';
 if (session_status() == PHP_SESSION_NONE) {
     // Usar session_start() solo si no hay una sesión activa.
     // Es preferible no usar @ para suprimir errores aquí.

--- a/includes/env_loader.php
+++ b/includes/env_loader.php
@@ -1,0 +1,23 @@
+<?php
+// includes/env_loader.php
+// Load environment variables from .env using vlucas/phpdotenv if available.
+
+function env_load($root = null) {
+    static $loaded = false;
+    if ($loaded) {
+        return;
+    }
+    $root = $root ?: dirname(__DIR__);
+    $autoload = $root . '/vendor/autoload.php';
+    if (file_exists($autoload)) {
+        require_once $autoload;
+        if (class_exists('Dotenv\\Dotenv')) {
+            $dotenv = Dotenv\Dotenv::createImmutable($root);
+            $dotenv->safeLoad();
+        }
+    }
+    $loaded = true;
+}
+
+env_load();
+?>

--- a/includes/session.php
+++ b/includes/session.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . '/env_loader.php';
+
 function ensure_session_started() {
     if (session_status() !== PHP_SESSION_ACTIVE) {
         session_start();

--- a/serve_museo_image.php
+++ b/serve_museo_image.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/includes/env_loader.php';
 require_once __DIR__ . '/includes/csrf.php';
 // Use same upload dir definition as API
 define('UPLOAD_DIR_BASE', dirname(__DIR__) . '/uploads_storage/museo_piezas/');


### PR DESCRIPTION
## Summary
- add `env_loader.php` to load `.env` with phpdotenv
- automatically load environment variables via `includes/session.php`
- integrate loader in API and utility scripts
- clarify README environment section

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `php -v` *(fails: command not found)*
- `./check_links.sh`
- `./check_links_extended.sh`


------
https://chatgpt.com/codex/tasks/task_e_684d4c9abe30832992da30e56d638c1e