### PR TITLE
Move header rendering to server side

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -1,9 +1,6 @@
 <div id="linterna-condado"></div>
 <header id="main-header" role="banner">
     <div class="top-empty-bar"></div>
-    <div id="header-language-bar-placeholder"></div>
-    <div id="header-toggles-placeholder"></div>
-    <div id="header-navigation-placeholder"></div>
+    <?php require __DIR__ . '/includes/header.php'; ?>
 </header>
 <script defer src="/js/lang-bar.js"></script>
-<script defer src="/js/header_loader.js"></script>

--- a/_header.php
+++ b/_header.php
@@ -1,0 +1,3 @@
+<?php
+require_once __DIR__ . '/_header.html';
+

--- a/alfoz/alfoz.php
+++ b/alfoz/alfoz.php
@@ -28,11 +28,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 <body>
 
     <?php
-    if (file_exists(__DIR__ . '/../_header.php')) {
-        require_once __DIR__ . '/../_header.php';
-    } else {
-        require_once __DIR__ . '/../_header.html';
-    }
+    require_once __DIR__ . '/../_header.php';
     ?>
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_mis_tierras.jpg');">

--- a/contacto/contacto.php
+++ b/contacto/contacto.php
@@ -28,11 +28,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 <body>
 
     <?php
-    if (file_exists(__DIR__ . '/../_header.php')) {
-        require_once __DIR__ . '/../_header.php';
-    } else {
-        require_once __DIR__ . '/../_header.html';
-    }
+    require_once __DIR__ . '/../_header.php';
     ?>
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.75), rgba(var(--color-negro-contraste-rgb), 0.88)), url('/assets/img/hero_contacto_background.jpg');">

--- a/cultura/cultura.php
+++ b/cultura/cultura.php
@@ -28,11 +28,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 <body>
 
     <?php
-    if (file_exists(__DIR__ . '/../_header.php')) {
-        require_once __DIR__ . '/../_header.php';
-    } else {
-        require_once __DIR__ . '/../_header.html';
-    }
+    require_once __DIR__ . '/../_header.php';
     ?>
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.75), rgba(var(--color-negro-contraste-rgb), 0.88)), url('/assets/img/hero_cultura_background.jpg');">

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,40 @@
+<?php
+$baseDir = dirname(__DIR__);
+
+// Output language bar
+echo file_get_contents($baseDir . '/fragments/header/language-bar.html');
+
+// Output toggle buttons
+echo file_get_contents($baseDir . '/fragments/header/toggles.html');
+
+// Load navigation fragment with menu placeholders
+$navigation = file_get_contents($baseDir . '/fragments/header/navigation.html');
+
+// Replace main menu placeholder
+$navigation = str_replace(
+    '<div id="main-menu-placeholder"></div>',
+    file_get_contents($baseDir . '/fragments/menus/main-menu.html'),
+    $navigation
+);
+
+// Replace admin menu placeholder (this fragment contains PHP)
+ob_start();
+include $baseDir . '/fragments/menus/admin-menu.php';
+$adminMenu = ob_get_clean();
+$navigation = str_replace(
+    '<div id="admin-menu-placeholder"></div>',
+    $adminMenu,
+    $navigation
+);
+
+// Replace social menu placeholder
+$navigation = str_replace(
+    '<div id="social-menu-placeholder"></div>',
+    file_get_contents($baseDir . '/fragments/menus/social-menu.html'),
+    $navigation
+);
+
+// Output final navigation markup
+echo $navigation;
+
+

--- a/index.php
+++ b/index.php
@@ -34,11 +34,7 @@ require_once 'includes/ai_utils.php';
 <?php
 // Use dynamic PHP header if available so menu fragments can contain
 // server-side logic like the admin login menu.
-if (file_exists(__DIR__ . '/_header.php')) {
-    require_once __DIR__ . '/_header.php';
-} else {
-    require_once __DIR__ . '/_header.html';
-}
+require_once __DIR__ . '/_header.php';
 ?>
 
     <header class="hero">

--- a/js/header_loader.js
+++ b/js/header_loader.js
@@ -1,4 +1,5 @@
 (function(){
+    // Deprecated: header is now rendered server-side via includes/header.php
     async function loadFragment(selector, url) {
         const container = document.querySelector(selector);
         if (!container) {


### PR DESCRIPTION
## Summary
- add `includes/header.php` to echo header fragments server-side
- update `_header.html` to require the new include
- provide `_header.php` convenience wrapper
- switch a few pages to directly require `_header.php`
- mark `header_loader.js` as deprecated

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml` *(fails: `composer` not found)*
- `vendor/bin/phpstan` *(skipped: `php` not found)*
- `vendor/bin/phpunit` *(skipped: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddfcae478832980d14a2f2f76206f