### PR TITLE
Fix: Remove redundant JavaScript footer loading

### DIFF
--- a/js/layout.js
+++ b/js/layout.js
@@ -21,18 +21,18 @@ document.addEventListener("DOMContentLoaded", function() {
         })
         .catch(error => console.error('Error fetching _header.html:', error));
 
-    let footerPlaceholder = document.getElementById('footer-placeholder');
-    if (!footerPlaceholder) {
-        footerPlaceholder = document.createElement('div');
-        footerPlaceholder.id = 'footer-placeholder';
-        document.body.appendChild(footerPlaceholder);
-    }
-    fetch('/_footer.php')
-        .then(response => response.text())
-        .then(data => {
-            footerPlaceholder.innerHTML = data;
-        })
-        .catch(error => console.error('Error fetching _footer.php:', error));
+    // let footerPlaceholder = document.getElementById('footer-placeholder');
+    // if (!footerPlaceholder) {
+    //     footerPlaceholder = document.createElement('div');
+    //     footerPlaceholder.id = 'footer-placeholder';
+    //     document.body.appendChild(footerPlaceholder);
+    // }
+    // fetch('/_footer.php')
+    //     .then(response => response.text())
+    //     .then(data => {
+    //         footerPlaceholder.innerHTML = data;
+    //     })
+    //     .catch(error => console.error('Error fetching _footer.php:', error));
 
     // Theme toggle initialization
     initializeThemeToggle();


### PR DESCRIPTION
The footer was being loaded twice on pages: once via PHP include and again via a JavaScript fetch and injection in js/layout.js.

This commit removes the JavaScript-based footer loading mechanism from js/layout.js. PHP pages already correctly include the footer using `require_once`, so this change ensures the footer is displayed only once.