### PR TITLE
Fix: Set body background to transparent to show alabastro.jpg

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -65,7 +65,7 @@ html {
 body {
     font-family: var(--font-primary);
     color: var(--epic-text-color);
-    background-color: var(--epic-alabaster-bg); /* Fallback color, light or dark via variable */
+    background-color: transparent; /* MODIFIED: Was var(--epic-alabaster-bg) */
     line-height: 1.7;
     text-align: left; /* Default text alignment */
     position: relative; /* For z-index stacking with pseudo-element */


### PR DESCRIPTION
The body element had a solid background color which was obscuring the alabastro.jpg image set on the body::before pseudo-element.

This change makes the body background-color transparent, allowing the intended background image to be visible.