### PR TITLE
Fix: Ensure alabastro.jpg background is visible

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,7 +1,7 @@
 body {
   font-family: "Lora", serif;
-  background-color: #F0E9E0;
-  background-image: url('../img/alabastro.jpg');
+  background-color: transparent; /* MODIFIED: Was #F0E9E0 */
+  /* background-image: url('../img/alabastro.jpg'); REMOVED */
   background-attachment: fixed;
   background-size: cover;
   background-position: center center;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -40,7 +40,7 @@
 
 body {
     font-family: 'Lora', serif;
-    background-color: var(--current-bg);
+    background-color: transparent; /* MODIFIED: Was var(--current-bg) */
     color: var(--current-text);
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Previously, the body background color was being overridden by rules in `styles.css` and `custom.css`, preventing the intended `alabastro.jpg` image (set on `body::before` in `epic_theme.css`) from showing.

This commit modifies:
- `assets/css/styles.css`: Changed `body` background-color from `var(--current-bg)` to `transparent`.
- `assets/css/custom.css`: Changed `body` background-color from `#F0E9E0` to `transparent` and removed the redundant `background-image` declaration from this rule.