### PR TITLE
fix: Resolve sidebar toggle issues and clean up redundant buttons

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -8,19 +8,7 @@
 
     <hr class="panel-separator">
 
-    <div class="action-buttons">
-        <button id="menu-toggle" title="Abrir menú">
-            <img src="assets/icons/menu-icon.svg" alt="Menú">
-        </button>
-
-        <button id="theme-toggle" title="Cambiar tema">
-            <img src="assets/icons/moon-icon.svg" alt="Tema">
-        </button>
-
-        <button id="ai-drawer-toggle" title="Asistente IA">
-            <img src="assets/icons/ai-icon.svg" alt="IA">
-        </button>
-    </div>
+    <!-- The action-buttons div that was here is now removed -->
 
 </div>
 <div id="linterna-condado"></div>

--- a/assets/css/header/fixed-toggles.css
+++ b/assets/css/header/fixed-toggles.css
@@ -9,10 +9,24 @@
 }
 
 .fixed-vertical-toggles button {
-    /* You might want to add some specific styling for these buttons if needed,
-       or they can inherit from existing styles. For example: */
     padding: 8px;
-    background-color: rgba(var(--epic-alabaster-rgb), 0.8); /* Example background */
+    /* Attempt to use the variable opaquely, with a fallback */
+    background-color: #f8f9fa; /* Fallback solid light color */
+    background-color: rgb(var(--epic-alabaster-rgb)); /* Try to use the variable, now opaque */
     border: 1px solid var(--epic-gold-secondary);
     border-radius: var(--global-border-radius);
+    opacity: 0.95; /* Slightly less than full opacity if alabaster is very light, to ensure visibility */
+    cursor: pointer; /* Ensure cursor indicates interactivity */
+}
+
+.fixed-vertical-toggles button:hover {
+    opacity: 1; /* Fully opaque on hover */
+    /* Consider a slight background change if possible, e.g., darken or a shadow */
+    box-shadow: 0 0 5px rgba(0,0,0,0.2); /* Example shadow for hover */
+}
+
+.fixed-vertical-toggles button:focus {
+    opacity: 1;
+    outline: 2px solid var(--epic-gold-secondary); /* Focus outline */
+    outline-offset: 1px;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,12 +2,14 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Menu Toggle Logic ---
     const menuToggle = document.getElementById('sidebar-toggle');
     const sidebar = document.getElementById('sidebar');
-    const mainContent = document.getElementById('main-content');
+    const mainContent = document.getElementById('main-content'); // This line remains to define mainContent
 
-    if (menuToggle && sidebar && mainContent) {
+    if (menuToggle && sidebar) { // Condition changed here
         menuToggle.addEventListener('click', () => {
             sidebar.classList.toggle('open');
-            mainContent.classList.toggle('pushed');
+            if (mainContent) { // Added check for mainContent here
+                mainContent.classList.toggle('pushed');
+            }
             // Update aria-expanded attribute for accessibility
             const isExpanded = sidebar.classList.contains('open');
             menuToggle.setAttribute('aria-expanded', isExpanded);


### PR DESCRIPTION
This commit addresses your feedback regarding non-functional menu elements and unnecessary buttons.

Key changes:

1.  **Button Cleanup:**
    *   Removed the `action-buttons` div (containing old `menu-toggle`, `theme-toggle`, and `ai-drawer-toggle` buttons) from `_header.html`. These buttons were redundant as their functionality was previously moved to the sidebar.

2.  **Menu Functionality Fix:**
    *   Corrected the JavaScript in `assets/js/main.js` for the main sidebar toggle (`#sidebar-toggle` - ☰ button). The event listener is now correctly attached even if an element with `id='main-content'` is not present, ensuring the sidebar opens and closes reliably. The toggling of the `pushed` class on `main-content` is now conditional.

3.  **Styling Refinement:**
    *   Adjusted the CSS in `assets/css/header/fixed-toggles.css` for the main menu toggle button (`#sidebar-toggle`). It should now appear less transparent by default and has improved hover and focus states for better perceived interactivity. This addresses concerns about it appearing as a "gray" or non-interactive button.

These changes ensure that the primary sidebar menu is functional and that superfluous buttons from a previous layout have been removed, leading to a cleaner and more intuitive user interface.