### PR TITLE
Clean up header buttons and HTML structure

### DIFF
--- a/fragments/header/toggles.html
+++ b/fragments/header/toggles.html
@@ -1,7 +1,0 @@
-<div class="fixed-vertical-toggles">
-    <button id="sidebar-toggle" class="sidebar-toggle" aria-label="Toggle Menu" aria-expanded="false">
-        <span class="bar"></span>
-        <span class="bar"></span>
-        <span class="bar"></span>
-    </button>
-</div>


### PR DESCRIPTION
I removed an unused button (`sidebar-toggle`) and its container div from `fragments/header/toggles.html` as per your feedback to only include three main buttons.

- Deleted `sidebar-toggle` button from `fragments/header/toggles.html`.
- Removed the now-empty `<div class="fixed-vertical-toggles">` from `fragments/header/toggles.html`, leaving the file empty.
- Verified that these changes do not impact the functionality of the primary menu, theme, and AI toggle buttons.