### PR TITLE
I've configured Google Translate as the primary language switcher.

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -1,10 +1,5 @@
 <div class="left-control-panel">
     <div id="fixed-header-elements">
-        <div class="language-selector">
-            <a href="#es" title="Español"><img src="assets/flags/es.svg" alt="Bandera de España"></a>
-            <a href="#gl" title="Galego"><img src="assets/flags/gl.svg" alt="Bandera de Galicia"></a>
-            <a href="#en" title="English"><img src="assets/flags/gb.svg" alt="Bandera del Reino Unido"></a>
-        </div>
 
         <button id="menu-toggle" title="Abrir menú">
             <img src="assets/icons/menu-icon.svg" alt="Menú">


### PR DESCRIPTION
Here's what I did:

- Removed the language selector with image flags from `_header.html`'s left control panel.
- Confirmed that `includes/header.php` loads `fragments/header/language-bar.html`, which contains the HTML structure for the Google Translate widget and language links.
- Verified that `_header.html` includes `js/lang-bar.js`, which handles the Google Translate functionality.
- Reviewed `js/lang-bar.js` and `fragments/header/language-bar.html` to ensure they are correctly set up to work together.

This change implements your request to use the Google Translate bar as the sole language switching mechanism.