### PR TITLE
Use env-based Gemini key

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,13 @@ y cualquier otra variable necesaria.
 
 
 Las variables definidas en `.env` se cargan de forma automática gracias a `includes/env_loader.php`.
+
+## Configuración de la clave Gemini
+
+Define la variable `GEMINI_API_KEY` en tu archivo `.env` con la clave proporcionada por el servicio Gemini:
+
+```bash
+GEMINI_API_KEY=tu_clave_personal
+```
+
+El valor se inyectará en la etiqueta `<meta name="gemini-api-key">` generada por `includes/head_common.php` y será leído por `assets/js/main.js` para realizar las peticiones.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -80,7 +80,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const prompt = aiInput.value.trim();
             if (!prompt) return; // Don't send empty prompts
 
-            const apiKey = 'A_TUA_CLAVE_DE_API_DE_GEMINI'; // Placeholder
+            const apiKeyMeta = document.querySelector('meta[name="gemini-api-key"]');
+            const apiKey = apiKeyMeta ? apiKeyMeta.getAttribute('content') : '';
             const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`;
 
             aiResponse.innerHTML = 'Procesando...';

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -1,9 +1,12 @@
 <?php
 require_once __DIR__ . '/session.php';
 ensure_session_started();
+require_once __DIR__ . '/env_loader.php';
+$geminiKey = getenv('GEMINI_API_KEY') ?: '';
 ?>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="gemini-api-key" content="<?php echo htmlspecialchars($geminiKey, ENT_QUOTES, 'UTF-8'); ?>">
 <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- inject GEMINI_API_KEY through head_common.php meta tag
- read the key from the meta tag in assets/js/main.js
- document how to configure the Gemini API key with environment variables

## Testing
- `./vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685019230b108329afe97c8d5831a58a