### PR TITLE
Implement basic Flask forum API with PHP frontend

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -1,0 +1,26 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+# In-memory message store
+messages = []
+
+@app.route('/api/foro/messages', methods=['GET', 'POST'])
+def forum_messages():
+    if request.method == 'POST':
+        data = request.get_json(force=True)
+        if not data or 'author' not in data or 'content' not in data:
+            return jsonify({'error': 'Invalid payload'}), 400
+        message = {
+            'id': len(messages) + 1,
+            'author': data['author'],
+            'content': data['content']
+        }
+        messages.append(message)
+        return jsonify(message), 201
+
+    # GET request
+    return jsonify(messages)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/foro/index.php
+++ b/foro/index.php
@@ -1,12 +1,18 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
 <body>
     <?php require_once __DIR__ . '/../_header.html'; ?>
-    <main class="container page-content-block" style="text-align: center; padding: 4em 1em;">
-        <h1>El foro estará disponible próximamente</h1>
-        <p>Estamos trabajando para habilitar este espacio de debate. Vuelve a visitarnos pronto.</p>
+    <main class="container page-content-block" style="padding: 2em 1em;">
+        <h1>Foro Comunitario</h1>
+        <form id="message-form" class="mb-4">
+            <input type="text" id="author" placeholder="Tu nombre" required class="form-control mb-2">
+            <textarea id="content" placeholder="Escribe tu mensaje" required class="form-control mb-2"></textarea>
+            <button type="submit" class="btn btn-primary">Enviar</button>
+        </form>
+        <ul id="message-list" class="list-unstyled"></ul>
         <p><a href="/index.php" class="cta-button">Volver al inicio</a></p>
     </main>
     <?php require_once __DIR__ . '/../_footer.php'; ?>
     <script src="/js/layout.js"></script>
+    <script src="/js/foro.js"></script>
 </body>
 </html>

--- a/js/foro.js
+++ b/js/foro.js
@@ -1,0 +1,33 @@
+async function loadMessages() {
+    try {
+        const response = await fetch('/api/foro/messages');
+        const data = await response.json();
+        const list = document.getElementById('message-list');
+        list.innerHTML = '';
+        data.forEach(msg => {
+            const item = document.createElement('li');
+            item.textContent = `${msg.author}: ${msg.content}`;
+            list.appendChild(item);
+        });
+    } catch (err) {
+        console.error('Error loading messages', err);
+    }
+}
+
+async function sendMessage(event) {
+    event.preventDefault();
+    const author = document.getElementById('author').value;
+    const content = document.getElementById('content').value;
+    await fetch('/api/foro/messages', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({author, content})
+    });
+    document.getElementById('content').value = '';
+    loadMessages();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadMessages();
+    document.getElementById('message-form').addEventListener('submit', sendMessage);
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4
 requests
+Flask


### PR DESCRIPTION
## Summary
- add `flask_app/app.py` with a minimal Flask API for forum messages
- create `js/foro.js` to call the API
- update `foro/index.php` with simple message form and list
- include Flask in `requirements.txt`

## Testing
- `pytest -q`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501931bad883298bb4ae8c4152514f