### PR TITLE
Add basic Flask API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ php -S localhost:8000
 
 Esto iniciará el servidor en `http://localhost:8000`.
 
+Para exponer la API Flask primero instala las dependencias de Python y lanza el servicio:
+
+```bash
+pip install -r requirements.txt
+python flask_app.py
+```
+
+Esto iniciará la API en `http://localhost:5000`, que puede ejecutarse en paralelo al servidor PHP.
+
 ## Instalación de dependencias
 
 Antes de ejecutar el sitio por primera vez descarga las librerías necesarias:

--- a/flask_app.py
+++ b/flask_app.py
@@ -1,0 +1,21 @@
+from flask import Flask, request, jsonify
+from graph_db_interface import GraphDBInterface
+
+app = Flask(__name__)
+
+db = GraphDBInterface()
+
+@app.route('/api/resource', methods=['GET', 'POST'])
+def resource_collection():
+    if request.method == 'POST':
+        data = request.get_json(silent=True) or {}
+        if not data.get('url'):
+            return jsonify({'error': "'url' field is required"}), 400
+        db.add_or_update_resource(data)
+        return jsonify({'success': True}), 201
+    else:  # GET
+        resources = db.get_all_resources()
+        return jsonify(resources)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/js/ia-tools.js
+++ b/js/ia-tools.js
@@ -150,4 +150,11 @@ function handleWebSearch(output) {
     .catch(err => {
         showOutput(output, `<p class="ia-tool-error">${err.message}</p>`);
     });
+
+// Simple demo request to the Flask API
+function demoFlaskRequest() {
+    fetch('http://localhost:5000/api/resource')
+        .then(res => res.json())
+        .then(data => console.log('API resources', data))
+        .catch(err => console.error('API error', err));
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4
 requests
+Flask


### PR DESCRIPTION
## Summary
- add a minimal Flask service exposing `/api/resource`
- demonstrate an API call from the frontend
- update requirements
- document how to run Flask alongside the PHP server

## Testing
- `python -m py_compile flask_app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6850608cd564832980665d32a998283d