### PR TITLE
Refactor CSS colors to use theme variables

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -14,38 +14,38 @@ body {
 }
 
 body {
-  background-color: #F0E9E0;
-  color: #2C1D12;
+  background-color: var(--epic-alabaster-bg);
+  color: var(--epic-text-color);
 }
 
 .hero {
-  background-color: #5B1A7D;
-  color: #FFFFFF;
+  background-color: var(--epic-purple-emperor);
+  color: var(--epic-text-light);
 }
 
 .cta-button {
-  background-color: #FFD700;
-  color: #2C1D12;
+  background-color: var(--epic-gold-main);
+  color: var(--epic-text-color);
 }
 .cta-button:hover {
-  background-color: #ccac00;
+  background-color: var(--epic-gold-secondary);
 }
 
 @media (prefers-color-scheme: dark) {
   body {
-    background-color: #252B38;
-    color: #FFFFFF;
+    background-color: var(--epic-alabaster-bg);
+    color: var(--epic-text-light);
   }
   .hero {
-    background-color: #361245;
-    color: #FFFFFF;
+    background-color: var(--epic-purple-emperor);
+    color: var(--epic-text-light);
   }
   .cta-button {
-    background-color: #9A6700;
-    color: #2C1D12;
+    background-color: var(--epic-gold-secondary);
+    color: var(--epic-text-color);
   }
   .cta-button:hover {
-    background-color: rgb(103, 68.8896103896, 0);
+    background-color: var(--epic-purple-emperor);
   }
 }
 

--- a/assets/css/demo_transparencia_movimiento.css
+++ b/assets/css/demo_transparencia_movimiento.css
@@ -1,7 +1,7 @@
 :root {
-    --morado-emperador: #4A0D67;
-    --albastro: #F9F7F4;
-    --oro-viejo: #CFB53B;
+    --morado-emperador: var(--epic-purple-emperor);
+    --albastro: var(--epic-alabaster-bg);
+    --oro-viejo: var(--epic-gold-main);
 }
 
 .demo-hero {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,14 +1,14 @@
 :root {
-    --emperador-purple: #5D3A99; /* Morado Emperador */
-    --old-gold: #CFB53B; /* Ouro Vello */
-    --light-text: #F5F5F5; /* Texto claro para fondos oscuros */
-    --dark-text: #2A2A2A; /* Texto oscuro para fondos claros */
-    --background-light: #FFFFFF;
-    --background-dark: #1E1E1E; /* Un gris oscuro casi negro */
-    --sidebar-bg-light: #F8F9FA;
-    --sidebar-bg-dark: #2C2C2C; /* Un poco más claro que el fondo principal oscuro */
-    --separator-light: #D1D1D1;
-    --separator-dark: #4A4A4A;
+    --emperador-purple: var(--epic-purple-emperor); /* Morado Emperador */
+    --old-gold: var(--epic-gold-main); /* Ouro Vello */
+    --light-text: var(--epic-text-light); /* Texto claro para fondos oscuros */
+    --dark-text: var(--epic-text-color); /* Texto oscuro para fondos claros */
+    --background-light: var(--epic-alabaster-bg);
+    --background-dark: var(--epic-alabaster-medium); /* Tono más oscuro para fondos */
+    --sidebar-bg-light: var(--epic-alabaster-bg);
+    --sidebar-bg-dark: var(--epic-alabaster-medium); /* Un poco más oscuro que el fondo principal */
+    --separator-light: var(--epic-gold-main);
+    --separator-dark: var(--epic-gold-secondary);
     --button-bg-light: var(--emperador-purple);
     --button-text-light: var(--light-text);
     --button-bg-dark: var(--old-gold);
@@ -21,8 +21,8 @@
     --current-separator: var(--separator-light);
     --current-button-bg: var(--button-bg-light);
     --current-button-text: var(--button-text-light);
-    --current-link-color: #442970;
-    --current-link-hover-color: #301C4E;
+    --current-link-color: var(--epic-purple-emperor);
+    --current-link-hover-color: var(--epic-gold-secondary);
     --current-icon-filter: none; /* Para invertir iconos en modo oscuro si son negros */
 }
 
@@ -372,7 +372,7 @@ header { /* New header for hamburger only */
 }
 
 .left-control-panel .action-buttons button:hover {
-    background-color: #fff; /* Un color de resaltado al pasar el ratón */
+    background-color: var(--epic-gold-main); /* Resalta con oro principal */
     transform: scale(1.05);
 }
 
@@ -398,7 +398,7 @@ header { /* New header for hamburger only */
 }
 
 #fixed-header-elements #menu-toggle:hover {
-    background-color: #fff; /* Un color de resaltado al pasar el ratón */
+    background-color: var(--epic-gold-main); /* Resalta con oro principal */
     transform: scale(1.05);
 }
 


### PR DESCRIPTION
## Summary
- replace hard-coded colors in `custom.css` with `epic_theme.css` variables
- map `styles.css` palette to purple and gold theme variables
- update demo transparency styles to rely on theme variables

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506095a1e4832999fc7a0e50bf05f6