### PR TITLE
Use theme variables in admin pages

### DIFF
--- a/assets/css/admin_overrides.css
+++ b/assets/css/admin_overrides.css
@@ -1,0 +1,57 @@
+/* Admin specific overrides using theme variables */
+
+:root {
+    --epic-success-green: var(--epic-success-green, #d4edda);
+}
+
+body.admin-body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+    background-color: var(--epic-alabaster-bg);
+    color: var(--epic-text-color);
+}
+
+.admin-container {
+    max-width: 900px;
+    margin: auto;
+    background-color: var(--epic-alabaster-bg);
+    padding: 20px;
+    border-radius: var(--global-border-radius);
+    box-shadow: var(--global-box-shadow-light);
+}
+
+.admin-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 20px;
+}
+
+.admin-table th, .admin-table td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+.admin-table th {
+    background-color: var(--epic-alabaster-medium);
+}
+
+.feedback {
+    padding: 10px;
+    margin-bottom: 10px;
+    border-radius: var(--global-border-radius);
+}
+
+.feedback.success {
+    background-color: var(--epic-success-green);
+}
+
+.feedback.error {
+    background-color: var(--epic-error-red);
+    color: var(--epic-alabaster-bg);
+}
+
+.delete-button {
+    background-color: var(--epic-error-red);
+    margin-left: 10px;
+}

--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -12,6 +12,8 @@
     --epic-alabaster-bg-rgb: 232, 239, 249; /* RGB for new light tone */
     --epic-alabaster-medium: #E6EEF9; /* Slightly darker celeste */
     --epic-alabaster-medium-rgb: 230, 238, 249; /* RGB for new medium tone */
+    --epic-success-green: #d4edda; /* Success notifications */
+    --epic-success-green-rgb: 212, 237, 218;
     --epic-text-color: #2c1d12;
     --epic-text-color-rgb: 44, 29, 18;
     --epic-text-light: #EAE0C8;

--- a/dashboard/create_user.php
+++ b/dashboard/create_user.php
@@ -52,40 +52,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Crear Nuevo Usuario</title>
-    <style>
-        body { font-family: Arial, sans-serif; background-color: #f4f4f4; margin: 0; padding: 0; display: flex; justify-content: center; align-items: center; min-height: 100vh; flex-direction: column; }
-        .container { background-color: #fff; padding: 20px 30px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); width: 100%; max-width: 400px; }
-        h2 { text-align: center; color: #333; margin-bottom: 20px; }
-        .message { padding: 10px; margin-bottom: 15px; border-radius: 4px; text-align: center; }
-        .error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
-        .success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
-        label { display: block; margin-bottom: 5px; color: #555; }
-        input[type="text"], input[type="password"], select {
-            width: 100%;
-            padding: 10px;
-            margin-bottom: 15px;
-            border: 1px solid #ddd;
-            border-radius: 4px;
-            box-sizing: border-box;
-        }
-        button[type="submit"] {
-            width: 100%;
-            padding: 10px;
-            background-color: #007bff;
-            color: white;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 16px;
-        }
-        button[type="submit"]:hover { background-color: #0056b3; }
-        .navigation-link { text-align: center; margin-top: 15px; }
-        .navigation-link a { color: #007bff; text-decoration: none; }
-        .navigation-link a:hover { text-decoration: underline; }
-    </style>
+    <link rel="stylesheet" href="../assets/css/epic_theme.css">
+    <link rel="stylesheet" href="../assets/css/admin_overrides.css">
 </head>
-<body>
-    <div class="container">
+<body class="admin-body">
+    <div class="admin-container">
         <h2>Crear Nuevo Usuario</h2>
 
         <?php if ($error_message): ?>

--- a/dashboard/edit_texts.php
+++ b/dashboard/edit_texts.php
@@ -44,33 +44,10 @@ $edit_id_highlight = $_GET['edit_id'] ?? null;
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Editar Textos del Sitio</title>
     <link rel="stylesheet" href="../assets/css/epic_theme.css"> <!-- Main theme -->
-    <style>
-        body { font-family: Arial, sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
-        .container { max-width: 900px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
-        h1, h2 { color: #333; }
-        .feedback { padding: 10px; margin-bottom: 15px; border-radius: 4px; }
-        .feedback.success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
-        .feedback.error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
-        .feedback.info { background-color: #e2e3e5; color: #383d41; border: 1px solid #d6d8db; }
-        .text-item { border: 1px solid #ddd; padding: 15px; margin-bottom: 15px; border-radius: 5px; background-color: #f9f9f9; }
-        .text-item.highlight { border-color: #007bff; background-color: #e7f3ff; }
-        .text-item strong { display: block; margin-bottom: 5px; color: #0056b3; }
-        textarea { width: 98%; min-height: 100px; padding: 8px; border: 1px solid #ccc; border-radius: 4px; margin-bottom: 10px; font-family: inherit; font-size: inherit; }
-        button { background-color: #007bff; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; }
-        button:hover { background-color: #0056b3; }
-        button.add-new-button { background-color: #28a745; margin-bottom:20px}
-        button.add-new-button:hover { background-color: #1e7e34; }
-        .text-meta { font-size: 0.8em; color: #666; margin-top: 5px; }
-        label { font-weight: bold; margin-bottom: 5px; display: inline-block; }
-        input[type="text"] { width: calc(98% - 100px); padding: 8px; border: 1px solid #ccc; border-radius: 4px; margin-bottom: 10px; }
-        .add-text-form { margin-bottom: 30px; padding: 15px; border: 1px solid #28a745; border-radius: 5px; background-color: #f0fff0; }
-        nav { margin-bottom: 20px; }
-        nav a { text-decoration: none; padding: 8px 15px; background-color: #6c757d; color: white; border-radius: 4px; margin-right: 10px; }
-        nav a:hover { background-color: #5a6268; }
-    </style>
+    <link rel="stylesheet" href="../assets/css/admin_overrides.css">
 </head>
-<body>
-    <div class="container">
+<body class="admin-body">
+    <div class="admin-container">
         <nav>
             <a href="../index.php">Volver al Inicio</a> <?php // TODO: Link to index.php if it becomes dynamic ?>
             <a href="logout.php">Cerrar Sesión</a>
@@ -115,7 +92,7 @@ $edit_id_highlight = $_GET['edit_id'] ?? null;
                         </div>
                         <button type="submit">Guardar Cambios</button>
                         <span class="text-meta">Última actualización: <?php echo htmlspecialchars($text['updated_at'] ? date('d/m/Y H:i:s', strtotime($text['updated_at'])) : 'N/A'); ?></span>
-                         <button type="submit" name="action" value="delete" style="background-color: #dc3545; margin-left: 10px;" onclick="return confirm('¿Está seguro de que desea eliminar este texto? Esta acción no se puede deshacer.');">Eliminar</button>
+                        <button type="submit" name="action" value="delete" class="delete-button" onclick="return confirm('¿Está seguro de que desea eliminar este texto? Esta acción no se puede deshacer.');">Eliminar</button>
                     </form>
                 </div>
             <?php endforeach; ?>

--- a/dashboard/tienda_admin.php
+++ b/dashboard/tienda_admin.php
@@ -102,18 +102,10 @@ try {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Administrar Tienda</title>
     <link rel="stylesheet" href="../assets/css/epic_theme.css">
-    <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        .container { max-width: 900px; margin: auto; }
-        table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-        th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
-        th { background-color: #f2f2f2; }
-        .feedback.success { background:#d4edda; padding:10px; margin-bottom:10px; }
-        .feedback.error { background:#f8d7da; padding:10px; margin-bottom:10px; }
-    </style>
+    <link rel="stylesheet" href="../assets/css/admin_overrides.css">
 </head>
-<body>
-<div class="container">
+<body class="admin-body">
+<div class="admin-container">
     <nav>
         <a href="../index.php">Inicio</a>
         <a href="logout.php">Cerrar sesión</a>
@@ -151,7 +143,7 @@ try {
         <button type="submit">Agregar</button>
     </form>
     <h2>Productos Existentes</h2>
-    <table>
+    <table class="admin-table">
         <tr><th>ID</th><th>Nombre</th><th>Precio</th><th>Stock</th><th>Acciones</th></tr>
         <?php foreach ($productos as $p): ?>
             <tr>

--- a/foro/index.php
+++ b/foro/index.php
@@ -85,7 +85,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo) {
         }
         .agent-profile textarea { width: 100%; margin: 0.5em 0; }
         .feedback { padding: 10px; margin: 10px 0; border-radius: 4px; }
-        .feedback.error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
+        .feedback.error { background-color: var(--epic-error-red); color: var(--epic-alabaster-bg); border: 1px solid #f5c6cb; }
         .slide-menu {
             position: fixed;
             left: -230px;

--- a/foro/manage_comments.php
+++ b/foro/manage_comments.php
@@ -48,16 +48,9 @@ if ($pdo) {
     <meta charset="UTF-8">
     <title>Administrar Comentarios</title>
     <link rel="stylesheet" href="../assets/css/epic_theme.css">
-    <style>
-        body { background-color: #f4f4f4; padding: 20px; }
-        table { width: 100%; border-collapse: collapse; }
-        th, td { padding: 8px; border: 1px solid #ccc; }
-        .feedback { padding: 10px; margin: 10px 0; border-radius: 4px; }
-        .feedback.success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
-        .feedback.error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
-    </style>
+    <link rel="stylesheet" href="../assets/css/admin_overrides.css">
 </head>
-<body>
+<body class="admin-body">
     <h1>Administrar Comentarios del Foro</h1>
     <nav>
         <a href="../index.php">Inicio</a>
@@ -70,7 +63,7 @@ if ($pdo) {
     <?php if (empty($comments)): ?>
         <p>No hay comentarios para mostrar.</p>
     <?php else: ?>
-        <table>
+        <table class="admin-table">
             <tr><th>Agente</th><th>Comentario</th><th>Fecha</th><th>Acciones</th></tr>
             <?php foreach ($comments as $c): ?>
                 <tr>

--- a/museo/editar_pieza.php
+++ b/museo/editar_pieza.php
@@ -56,16 +56,9 @@ try {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Editar Piezas del Museo</title>
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
-    <style>
-        body { font-family: Arial, sans-serif; margin:20px; }
-        table { width:100%; border-collapse: collapse; margin-bottom:20px; }
-        th, td { border:1px solid #ccc; padding:8px; text-align:left; }
-        th { background-color:#f2f2f2; }
-        .feedback.success { background:#d4edda; padding:10px; margin-bottom:10px; }
-        .feedback.error { background:#f8d7da; padding:10px; margin-bottom:10px; }
-    </style>
+    <link rel="stylesheet" href="/assets/css/admin_overrides.css">
 </head>
-<body>
+<body class="admin-body">
 <nav>
     <a href="../index.php">Inicio</a>
     <a href="../dashboard/index.php">Dashboard</a>
@@ -77,7 +70,7 @@ try {
         <?php echo htmlspecialchars($feedback_message); ?>
     </div>
 <?php endif; ?>
-<table>
+<table class="admin-table">
     <tr><th>ID</th><th>Título</th><th>Pos X</th><th>Pos Y</th><th>Pos Z</th><th>Escala</th><th>Acción</th></tr>
 <?php foreach ($piezas as $p): ?>
     <tr>


### PR DESCRIPTION
## Summary
- define success green color variable in `epic_theme.css`
- add shared admin styles in new `admin_overrides.css`
- link admin CSS and apply classes in several admin pages
- swap inline hard-coded colours for CSS variable based ones

## Testing
- `vendor/bin/phpunit -c phpunit.xml tests/ApiTest.php` *(fails: `No such file or directory`)*
- `composer install` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6850608e4c088329b7411de7578e4571