### PR TITLE
Fix link checker docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,21 @@ vendor/bin/phpunit
 
 El primer comando descargará las dependencias necesarias, incluido PHPUnit, y el
 segundo lanzará todos los tests definidos en `phpunit.xml`.
+
+## Verificación de enlaces internos
+
+El script `check_links_extended.sh` permite detectar rutas rotas en los principales archivos y en los fragmentos HTML que se cargan dinámicamente. Antes de ejecutarlo conviene asegurarse de que todos los fragmentos listados existen en `fragments/`.
+
+Para añadir un nuevo fragmento solo hay que crear el archivo correspondiente y añadir su ruta relativa al array `html_fragments` dentro del script. Por ejemplo:
+
+```bash
+html_fragments+=("fragments/header/new-widget.html")
+```
+
+A continuación se puede lanzar el script:
+
+```bash
+./check_links_extended.sh
+```
+
+Se generará un reporte llamado `broken_links_report_extended.txt` con los enlaces rotos encontrados.

--- a/check_links_extended.sh
+++ b/check_links_extended.sh
@@ -14,6 +14,11 @@ html_fragments=(
     "fragments/menus/social-menu.html"
 )
 
+# Add new fragments by appending their relative path to the array above.
+# Ensure the referenced file exists in the repository before running the script.
+# Example:
+#   html_fragments+=("fragments/header/new-widget.html")
+
 # Combine the arrays
 all_files_to_check=("${files_to_check[@]}" "${html_fragments[@]}")
 


### PR DESCRIPTION
## Summary
- clarify that all fragments listed in `check_links_extended.sh` must exist
- add a README section describing the link checker and how to add fragments

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685063aa2d908329a3dc4698a330d951