### PR TITLE
Exclude ia-chat fragment

### DIFF
--- a/broken_links_report_extended.txt
+++ b/broken_links_report_extended.txt
@@ -1,64 +1,102 @@
 Broken Link Report (Extended):
 ------------------------------
-Checked on: $(date)
+Checked on: Mon Jun 16 18:36:34 UTC 2025
 
 Checking links in: index.php
-  BROKEN (File): /historia/historia.html (should be /historia/historia.php)
-  BROKEN (File): /visitas/visitas.html (should be /visitas/visitas.php)
-  BROKEN (File): /cultura/cultura.html (should be /cultura/cultura.php)
-  SUMMARY for index.php: 3 broken link(s) out of 26 processable links.
+  OK: /historia/historia.php (resolved to historia/historia.php)
+  OK: /secciones_index/memoria_hispanidad.html (resolved to secciones_index/memoria_hispanidad.html)
+  OK: /historia/historia.php (resolved to historia/historia.php)
+  OK: /lugares/lugares.html (resolved to lugares/lugares.html)
+  OK: /visitas/visitas.php (resolved to visitas/visitas.php)
+  OK: /personajes/Militares_y_Gobernantes/conde_casio_cerasio.html (resolved to personajes/Militares_y_Gobernantes/conde_casio_cerasio.html)
+  OK: /personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html (resolved to personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html)
+  OK: /personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html (resolved to personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html)
+  OK: /personajes/indice_personajes.html (resolved to personajes/indice_personajes.html)
+  OK: /secciones_index/historia_tiempo_resumen.html (resolved to secciones_index/historia_tiempo_resumen.html)
+  OK: /cultura/cultura.php (resolved to cultura/cultura.php)
+  OK: /assets/img/escudo.jpg (resolved to assets/img/escudo.jpg)
+  OK: /assets/img/PrimerEscritoCastellano.jpg (resolved to assets/img/PrimerEscritoCastellano.jpg)
+  OK: /assets/img/RodrigoTabliegaCastillo.jpg (resolved to assets/img/RodrigoTabliegaCastillo.jpg)
+  OK: /assets/img/Yanna.jpg (resolved to assets/img/Yanna.jpg)
+  OK: /assets/img/Casio.png (resolved to assets/img/Casio.png)
+  OK: /assets/img/GonzaloTellez.png (resolved to assets/img/GonzaloTellez.png)
+  OK: /assets/img/FernandoDiaz.png (resolved to assets/img/FernandoDiaz.png)
+  OK: /js/layout.js (resolved to js/layout.js)
+  SUMMARY for index.php: All 19 processable links appear OK.
 
 Checking links in: _header.html
+  OK: /index.php (resolved to index.php)
+  OK: /js/menu-controller.js (resolved to js/menu-controller.js)
   SUMMARY for _header.html: All 2 processable links appear OK.
 
 Checking links in: _footer.php
-  BROKEN (File): /en_construccion.html (should be /en_construccion.php)
-  SUMMARY for _footer.php: 1 broken link(s) out of 3 processable links.
+  OK: /dashboard/logout.php (resolved to dashboard/logout.php)
+  OK: /dashboard/login.php (resolved to dashboard/login.php)
+  OK: /en_construccion.php (resolved to en_construccion.php)
+  OK: /en_construccion.php (resolved to en_construccion.php)
+  SUMMARY for _footer.php: All 4 processable links appear OK.
 
 Checking links in: fragments/header/language-bar.html
-  No internal page/file links found to check in fragments/header/language-bar.html.
-  SUMMARY for fragments/header/language-bar.html: All 0 processable links appear OK.
-
-Checking links in: fragments/header/toggles.html
-  No internal page/file links found to check in fragments/header/toggles.html.
-  SUMMARY for fragments/header/toggles.html: All 0 processable links appear OK.
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=es (resolved to fragments/header/?lang=es)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=en (resolved to fragments/header/?lang=en)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=fr (resolved to fragments/header/?lang=fr)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=de (resolved to fragments/header/?lang=de)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=it (resolved to fragments/header/?lang=it)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=pt (resolved to fragments/header/?lang=pt)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=ru (resolved to fragments/header/?lang=ru)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=zh-CN (resolved to fragments/header/?lang=zh-CN)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=ja (resolved to fragments/header/?lang=ja)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=ko (resolved to fragments/header/?lang=ko)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=ar (resolved to fragments/header/?lang=ar)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=hi (resolved to fragments/header/?lang=hi)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=tr (resolved to fragments/header/?lang=tr)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=id (resolved to fragments/header/?lang=id)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=vi (resolved to fragments/header/?lang=vi)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=bn (resolved to fragments/header/?lang=bn)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=ur (resolved to fragments/header/?lang=ur)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=fa (resolved to fragments/header/?lang=fa)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=nl (resolved to fragments/header/?lang=nl)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=pl (resolved to fragments/header/?lang=pl)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=uk (resolved to fragments/header/?lang=uk)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=sw (resolved to fragments/header/?lang=sw)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=sv (resolved to fragments/header/?lang=sv)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=th (resolved to fragments/header/?lang=th)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=el (resolved to fragments/header/?lang=el)
+  POTENTIALLY BROKEN (Clean URL or missing dir): ?lang=he (resolved to fragments/header/?lang=he)
+  SUMMARY for fragments/header/language-bar.html: All 26 processable links appear OK.
 
 Checking links in: fragments/header/navigation.html
+  OK: /index.php (resolved to index.php)
+  OK: /assets/img/AlfozCerasioLantaron.jpg (resolved to assets/img/AlfozCerasioLantaron.jpg)
   SUMMARY for fragments/header/navigation.html: All 2 processable links appear OK.
 
 Checking links in: fragments/menus/main-menu.html
-  BROKEN (File): /historia/historia.html (should be /historia/historia.php)
-  BROKEN (File): /historia_cerezo/index.html (should be /historia_cerezo/index.php)
-  BROKEN (File): /historia/subpaginas/obispado_auca_cerezo.html (should be /historia/subpaginas/obispado_auca_cerezo.php)
-  BROKEN (File): /alfoz/alfoz.html (should be /alfoz/alfoz.php)
-  BROKEN (File): /camino_santiago/camino_santiago.html (should be /camino_santiago/camino_santiago.php)
-  BROKEN (File): /visitas/visitas.html (should be /visitas/visitas.php)
-  BROKEN (File): /cultura/cultura.html (should be /cultura/cultura.php)
-  BROKEN (File): /foro/index.html (should be /foro/index.php)
-  BROKEN (File): /contacto/contacto.html (should be /contacto/contacto.php)
-  SUMMARY for fragments/menus/main-menu.html: 9 broken link(s) out of 18 processable links.
+  OK: /index.php (resolved to index.php)
+  OK: /historia/historia.php (resolved to historia/historia.php)
+  OK: /historia_cerezo/index.php (resolved to historia_cerezo/index.php)
+  OK: /historia/subpaginas/obispado_auca_cerezo.php (resolved to historia/subpaginas/obispado_auca_cerezo.php)
+  OK: /alfoz/alfoz.php (resolved to alfoz/alfoz.php)
+  OK: /lugares/lugares.html (resolved to lugares/lugares.html)
+  OK: /camino_santiago/camino_santiago.php (resolved to camino_santiago/camino_santiago.php)
+  OK: /museo/galeria.php (resolved to museo/galeria.php)
+  OK: /museo/museo_3d.php (resolved to museo/museo_3d.php)
+  OK: /museo/subir_pieza.php (resolved to museo/subir_pieza.php)
+  OK: /galeria/galeria_colaborativa.php (resolved to galeria/galeria_colaborativa.php)
+  OK: /tienda/index.php (resolved to tienda/index.php)
+  OK: /visitas/visitas.php (resolved to visitas/visitas.php)
+  OK: /cultura/cultura.php (resolved to cultura/cultura.php)
+  OK: /personajes/indice_personajes.html (resolved to personajes/indice_personajes.html)
+  OK: /empresa/index.php (resolved to empresa/index.php)
+  OK: /foro/index.php (resolved to foro/index.php)
+  OK: /contacto/contacto.php (resolved to contacto/contacto.php)
+  SUMMARY for fragments/menus/main-menu.html: All 18 processable links appear OK.
 
 Checking links in: fragments/menus/admin-menu.php
+  OK: /dashboard/logout.php (resolved to dashboard/logout.php)
+  OK: /dashboard/index.php (resolved to dashboard/index.php)
+  OK: /dashboard/login.php (resolved to dashboard/login.php)
   SUMMARY for fragments/menus/admin-menu.php: All 3 processable links appear OK.
 
 Checking links in: fragments/menus/social-menu.html
-  No internal page/file links found to check in fragments/menus/social-menu.html.
-  SUMMARY for fragments/menus/social-menu.html: All 0 processable links appear OK.
+  No processable internal links found in fragments/menus/social-menu.html.
 
-Checking links in: fragments/header/ia-chat.html
-  File NOT FOUND: fragments/header/ia-chat.html
-
-Extended link checking complete.
-Note: This report was generated by manually simulating the check_links_extended.sh script due to persistent errors with the run_in_bash_session tool. The $(date) placeholder would have been filled by the script. Number of processable links are estimates based on manual parsing.
-Final list of unique broken links and their suggested corrections:
-- /historia/historia.html -> /historia/historia.php
-- /visitas/visitas.html -> /visitas/visitas.php
-- /cultura/cultura.html -> /cultura/cultura.php
-- /en_construccion.html -> /en_construccion.php
-- /historia_cerezo/index.html -> /historia_cerezo/index.php
-- /historia/subpaginas/obispado_auca_cerezo.html -> /historia/subpaginas/obispado_auca_cerezo.php
-- /alfoz/alfoz.html -> /alfoz/alfoz.php
-- /camino_santiago/camino_santiago.html -> /camino_santiago/camino_santiago.php
-- /foro/index.html -> /foro/index.php
-- /contacto/contacto.html -> /contacto/contacto.php
-- Script check_links_extended.sh references a non-existent file: fragments/header/ia-chat.html

--- a/check_links_extended.sh
+++ b/check_links_extended.sh
@@ -17,6 +17,9 @@ html_fragments=(
 # Combine the arrays
 all_files_to_check=("${files_to_check[@]}" "${html_fragments[@]}")
 
+# Files that may appear in header_loader.js but no longer exist should be skipped
+skip_files=("fragments/header/ia-chat.html")
+
 # Output file for broken links
 output_file="broken_links_report_extended.txt"
 echo "Broken Link Report (Extended):" > "$output_file"
@@ -140,6 +143,16 @@ check_links_in_file() {
 
 # Check each file
 for f in "${all_files_to_check[@]}"; do
+    skip=false
+    for s in "${skip_files[@]}"; do
+        if [[ "$f" == "$s" ]]; then
+            skip=true
+            break
+        fi
+    done
+    if [ "$skip" = true ]; then
+        continue
+    fi
     check_links_in_file "$f"
 done
 


### PR DESCRIPTION
## Summary
- update check_links_extended.sh to skip the obsolete `ia-chat` fragment
- regenerate extended broken links report

## Testing
- `bash check_links_extended.sh`

------
https://chatgpt.com/codex/tasks/task_e_685063bafae4832984a7e674a200ce30