### PR TITLE
Add MenuLinksTest to validate menu links

### DIFF
--- a/tests/MenuLinksTest.php
+++ b/tests/MenuLinksTest.php
@@ -1,0 +1,49 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class MenuLinksTest extends TestCase {
+    private string $rootDir;
+
+    protected function setUp(): void {
+        $this->rootDir = realpath(__DIR__ . '/..');
+        // Include header fragments to ensure they exist
+        ob_start();
+        include $this->rootDir . '/includes/header.php';
+        ob_end_clean();
+    }
+
+    private function targetExists(string $href): bool {
+        $path = parse_url($href, PHP_URL_PATH) ?: '';
+        $full = $this->rootDir . $path;
+        if (file_exists($full)) {
+            return true;
+        }
+        if (is_dir($full)) {
+            return file_exists($full . '/index.php') || file_exists($full . '/index.html');
+        }
+        $dir = dirname($full);
+        return (
+            is_dir($dir) && (
+                file_exists($dir . '/index.php') || file_exists($dir . '/index.html')
+            )
+        );
+    }
+
+    public function testMenuLinksTargetsExist(): void {
+        $html = file_get_contents($this->rootDir . '/fragments/menus/main-menu.html');
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadHTML($html);
+        libxml_clear_errors();
+        foreach ($dom->getElementsByTagName('a') as $link) {
+            $href = $link->getAttribute('href');
+            if (preg_match('/^(https?:|mailto:)/', $href)) {
+                continue;
+            }
+            $this->assertTrue(
+                $this->targetExists($href),
+                "Missing target for href: $href"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test all menu links in `fragments/menus/main-menu.html`
- ensure `includes/header.php` loads without errors and each menu link points to an existing file or directory index

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: no such file or directory)*
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685063c07ed08329aeb7facc57d0a04e