### PR TITLE
Add main menu link test

### DIFF
--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../includes/auth.php';      // For is_admin_logged_in()
 require_once __DIR__ . '/../dashboard/db_connect.php'; // Necesario para $pdo
 /** @var PDO $pdo */
 require_once __DIR__ . '/../includes/text_manager.php'; // Necesario para editableText()
+require_once __DIR__ . '/../includes/csrf.php';
 
 $is_admin = is_admin_logged_in();
 $gallery_images_data = [];

--- a/includes/env_loader.php
+++ b/includes/env_loader.php
@@ -1,6 +1,9 @@
 <?php
 // includes/env_loader.php
 // Automatically load environment variables using vlucas/phpdotenv
-require_once __DIR__ . '/../vendor/autoload.php';
-
-Dotenv\Dotenv::createImmutable(__DIR__ . '/..')->safeLoad();
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+    if (class_exists('Dotenv\\Dotenv')) {
+        Dotenv\Dotenv::createImmutable(__DIR__ . '/..')->safeLoad();
+    }
+}

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -8,10 +8,14 @@ class ApiTest extends TestCase {
             'REQUEST_URI' => $server['REQUEST_URI'],
             'HTTP_HOST' => 'localhost',
         ];
-        $cmd = sprintf('php -d auto_prepend_file=%s %s',
-            escapeshellarg(__DIR__.'/fixtures/prepend.php'),
+        $prepend = realpath(__DIR__.'/fixtures/prepend.php');
+        $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
+            escapeshellarg($prepend),
             escapeshellarg($script)
         );
+        $env['PATH'] = getenv('PATH');
+        $env['REDIRECT_STATUS'] = '1';
+        $env['SCRIPT_FILENAME'] = $script;
         $descriptor = [1 => ['pipe','w'], 2 => ['pipe','w']];
         $proc = proc_open($cmd, $descriptor, $pipes, null, $env);
         $output = stream_get_contents($pipes[1]);

--- a/tests/LoginLogoutTest.php
+++ b/tests/LoginLogoutTest.php
@@ -3,8 +3,9 @@ use PHPUnit\Framework\TestCase;
 
 class LoginLogoutTest extends TestCase {
     private function runScript(string $script, array $env): array {
-        $cmd = sprintf('php -d auto_prepend_file=%s %s',
-            escapeshellarg(__DIR__.'/fixtures/login_prepend.php'),
+        $prepend = realpath(__DIR__.'/fixtures/login_prepend.php');
+        $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
+            escapeshellarg($prepend),
             escapeshellarg($script)
         );
         $env['PATH'] = getenv('PATH');

--- a/tests/MainMenuLinksTest.php
+++ b/tests/MainMenuLinksTest.php
@@ -1,0 +1,57 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class MainMenuLinksTest extends TestCase {
+    private function runPage(string $script): array {
+        $prepend = realpath(__DIR__.'/fixtures/page_prepend.php');
+        $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
+            escapeshellarg($prepend),
+            escapeshellarg($script)
+        );
+        $env = [
+            'PATH' => getenv('PATH'),
+            'REDIRECT_STATUS' => '1',
+            'SCRIPT_FILENAME' => $script
+        ];
+        $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        $status = proc_close($proc);
+        return [$status, $out, $err];
+    }
+
+    public static function urlProvider(): array {
+        $html = file_get_contents(__DIR__.'/../fragments/menus/main-menu.html');
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadHTML($html);
+        $urls = [];
+        foreach ($dom->getElementsByTagName('a') as $a) {
+            $href = $a->getAttribute('href');
+            if ($href !== '') {
+                $urls[] = [$href];
+            }
+        }
+        return $urls;
+    }
+
+    /**
+     * @dataProvider urlProvider
+     */
+    public function testLinkLoads(string $href): void {
+        $path = __DIR__.'/..'.$href;
+        if (is_dir($path)) {
+            $path .= '/index.php';
+        }
+        $this->assertFileExists($path, "Missing file for $href");
+        if (pathinfo($path, PATHINFO_EXTENSION) === 'php') {
+            [$status, $out, $err] = $this->runPage($path);
+            $this->assertSame(0, $status, $err);
+            $this->assertNotEmpty($out);
+        } else {
+            $content = file_get_contents($path);
+            $this->assertNotFalse($content, "Failed to read $path");
+        }
+    }
+}
+?>

--- a/tests/MuseumPagesTest.php
+++ b/tests/MuseumPagesTest.php
@@ -3,12 +3,18 @@ use PHPUnit\Framework\TestCase;
 
 class MuseumPagesTest extends TestCase {
     private function runPage(string $script): array {
-        $cmd = sprintf('php -d auto_prepend_file=%s %s',
-            escapeshellarg(__DIR__.'/fixtures/prepend.php'),
+        $prepend = realpath(__DIR__.'/fixtures/prepend.php');
+        $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
+            escapeshellarg($prepend),
             escapeshellarg($script)
         );
+        $env = [
+            'PATH' => getenv('PATH'),
+            'REDIRECT_STATUS' => '1',
+            'SCRIPT_FILENAME' => $script
+        ];
         $descriptor = [1 => ['pipe','w'], 2 => ['pipe','w']];
-        $proc = proc_open($cmd, $descriptor, $pipes);
+        $proc = proc_open($cmd, $descriptor, $pipes, null, $env);
         $output = stream_get_contents($pipes[1]);
         $err = stream_get_contents($pipes[2]);
         $status = proc_close($proc);

--- a/tests/fixtures/includes/env_loader.php
+++ b/tests/fixtures/includes/env_loader.php
@@ -1,0 +1,3 @@
+<?php
+// Stub for env_loader to bypass Dotenv loading during tests
+?>

--- a/tests/fixtures/page_prepend.php
+++ b/tests/fixtures/page_prepend.php
@@ -1,0 +1,13 @@
+<?php
+chdir(__DIR__ . '/..');
+set_include_path(__DIR__ . PATH_SEPARATOR . get_include_path());
+$_SERVER['HTTP_HOST'] = 'localhost';
+$_SERVER['HTTPS'] = 'off';
+$GLOBALS['TESTING'] = true;
+require_once __DIR__ . '/../../includes/session.php';
+ensure_session_started();
+require_once __DIR__ . '/../../includes/csrf.php';
+// Automatically log in as admin for protected pages
+$_SESSION['user_id'] = 1;
+$_SESSION['user_role'] = 'admin';
+?>


### PR DESCRIPTION
## Summary
- parse main menu to gather links and test each loads
- allow env loader without vendor
- autologin helper for new link tests
- include CSRF in collaborative gallery page

## Testing
- `phpunit --configuration phpunit.xml --testsuite "Project Test Suite"` *(fails: 4 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6850639bbbb88329bdb0617b670ba8b8