### PR TITLE
Read FLASK_DEBUG in flask_app

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ python flask_app.py
 
 Esto iniciará la API en `http://localhost:5000`, que puede ejecutarse en paralelo al servidor PHP.
 
+### Variable de entorno `FLASK_DEBUG`
+
+Establece `FLASK_DEBUG=1` para arrancar la API en modo depuración:
+
+```bash
+export FLASK_DEBUG=1
+python flask_app.py
+```
+
+Si no defines la variable, `flask_app.py` ejecutará `app.run(debug=False)` por defecto.
+
 ## Instalación de dependencias
 
 Tras clonar el repositorio instala las dependencias de PHP y descarga las

--- a/flask_app.py
+++ b/flask_app.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify
 from graph_db_interface import GraphDBInterface
+import os
 
 app = Flask(__name__)
 
@@ -18,4 +19,6 @@ def resource_collection():
         return jsonify(resources)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_env = os.getenv('FLASK_DEBUG')
+    debug_mode = str(debug_env).lower() in ('1', 'true')
+    app.run(debug=debug_mode)


### PR DESCRIPTION
## Summary
- use `FLASK_DEBUG` env variable when launching `flask_app.py`
- document `FLASK_DEBUG` in README

## Testing
- `pip install -r requirements.txt`
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685068cf80c0832985d56724dc64b39e