### PR TITLE
Implement forum rate limit config and menu enhancements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ CONDADO_DB_PASSWORD="your_password"
 GEMINI_API_KEY=your_key
 GeminiAPI=your_key
 GEMINI_API_ENDPOINT=https://api.gemini.example.com/v1/generateContent
+FORUM_COMMENT_COOLDOWN=60

--- a/assets/css/pages/foro.css
+++ b/assets/css/pages/foro.css
@@ -7,7 +7,7 @@ body { background-color: rgba(245,235,220,0.95); }
     border-left: 5px solid var(--color-primario-purpura, #4A0D67);
     backdrop-filter: blur(3px);
 }
-.agent-profile h2 {
+.gradient-title {
     background: linear-gradient(45deg, var(--color-primario-purpura, #4A0D67), var(--color-secundario-dorado, #B8860B));
     -webkit-background-clip: text;
     color: transparent;
@@ -15,19 +15,13 @@ body { background-color: rgba(245,235,220,0.95); }
 .agent-profile textarea { width: 100%; margin: 0.5em 0; }
 .feedback { padding: 10px; margin: 10px 0; border-radius: 4px; }
 .feedback.error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
-.slide-menu {
-    position: fixed;
-    left: -230px;
-    top: 0;
-    width: 220px;
-    height: 100%;
-    background-color: rgba(74,13,103,0.9);
-    transition: left 0.3s ease;
-    padding-top: 60px;
-    z-index: 1000;
+.slide-menu a {
+    display: block;
+    padding: 10px;
+    color: var(--color-secundario-dorado, #B8860B);
+    text-decoration: none;
+    font-weight: bold;
 }
-.slide-menu.open { left: 0; }
-.slide-menu a { display: block; padding: 10px; color: var(--color-secundario-dorado, #B8860B); text-decoration: none; font-weight: bold; }
 .menu-btn {
     position: fixed;
     left: 10px;

--- a/foro/index.php
+++ b/foro/index.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 require_once __DIR__ . '/../dashboard/db_connect.php';
+require_once __DIR__ . '/../includes/config.php';
 /** @var PDO $pdo */
 
 // Ensure comments table exists
@@ -48,7 +49,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo) {
     $agent = $_POST['agent'] ?? '';
     $comment = trim($_POST['comment'] ?? '');
     $maxLength = 500;
-    $rateLimit = 60; // seconds
+    $rateLimit = FORUM_COMMENT_COOLDOWN; // seconds
 
     if (strlen($comment) > $maxLength) {
         $_SESSION['forum_error'] = 'Comentario demasiado largo.';
@@ -73,10 +74,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo) {
 </head>
 <body>
 <?php require_once __DIR__ . '/../_header.php'; ?>
-<button id="menu-btn" class="menu-btn">☰ Expertos</button>
-<nav id="slide-menu" class="slide-menu">
+<button id="menu-btn" class="menu-btn" data-menu-target="agents-menu">☰ Expertos</button>
+<nav id="agents-menu" class="slide-menu left">
 <?php foreach ($agents as $id => $ag): ?>
-    <a href="#<?php echo $id; ?>"><?php echo htmlspecialchars($ag['name']); ?></a>
+    <a href="#<?php echo $id; ?>" class="gradient-title"><?php echo htmlspecialchars($ag['name']); ?></a>
 <?php endforeach; ?>
 </nav>
 <main class="container page-content-block">
@@ -86,7 +87,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo) {
     <?php endif; ?>
     <?php foreach ($agents as $id => $ag): ?>
     <section id="<?php echo $id; ?>" class="agent-profile">
-        <h2><?php echo htmlspecialchars($ag['name']); ?></h2>
+        <h2 class="gradient-title"><?php echo htmlspecialchars($ag['name']); ?></h2>
         <p><?php echo htmlspecialchars($ag['bio']); ?></p>
         <form method="post">
             <input type="hidden" name="agent" value="<?php echo $id; ?>">
@@ -111,6 +112,5 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo) {
 </main>
 <?php require_once __DIR__ . '/../_footer.php'; ?>
 <script src="/js/layout.js"></script>
-<script src="/assets/js/foro.js"></script>
 </body>
 </html>

--- a/includes/config.php
+++ b/includes/config.php
@@ -1,0 +1,7 @@
+<?php
+require_once __DIR__ . '/env_loader.php';
+
+if (!defined('FORUM_COMMENT_COOLDOWN')) {
+    $cooldown = getenv('FORUM_COMMENT_COOLDOWN');
+    define('FORUM_COMMENT_COOLDOWN', $cooldown !== false ? (int)$cooldown : 60);
+}


### PR DESCRIPTION
## Summary
- add `FORUM_COMMENT_COOLDOWN` env example and configuration
- create `includes/config.php` to load the cooldown value
- enhance forum page with slide menu component
- style agent names with `.gradient-title` and update CSS

## Testing
- `npm --version`
- *Unable to run PHP tests due to missing PHP runtime*

------
https://chatgpt.com/codex/tasks/task_e_685068d68314832984c3e885ff32a86c