### PR TITLE
Integrate Flask service with gallery API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,11 @@ Para exponer la API Flask primero instala las dependencias de Python y lanza el 
 
 ```bash
 pip install -r requirements.txt
-python flask_app.py
+./scripts/start_flask_service.sh
 ```
+
+El script deja la API ejecutándose en segundo plano y escribe los logs en `logs/flask_app.log`.
+Podrás detenerla con `kill \$(cat logs/flask_app.pid)`.
 
 Esto iniciará la API en `http://localhost:5000`, que puede ejecutarse en paralelo al servidor PHP.
 
@@ -129,3 +132,18 @@ esperadas para cada elemento del menú principal:
 
 Mantén esta lista actualizada cuando se añadan o eliminen páginas para que se
 pueda validar fácilmente el contenido del menú.
+
+## Uso de AJAX
+
+Para actualizar o recuperar recursos desde el frontend puedes emplear `fetch` y
+consumir `api_galeria.php`, que a su vez contacta con la API Flask.
+
+Ejemplo básico para obtener datos:
+
+```javascript
+fetch('/api/galeria/fotos')
+  .then(r => r.json())
+  .then(data => console.log(data));
+```
+
+Para crear una entrada se envía un formulario con `FormData` al mismo endpoint.

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -31,6 +31,12 @@ body {
   background-color: var(--epic-gold-secondary);
 }
 
+.hero h1 {
+  background: linear-gradient(90deg, var(--epic-purple-emperor), var(--epic-gold-main));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     background-color: var(--epic-alabaster-bg);

--- a/scripts/start_flask_service.sh
+++ b/scripts/start_flask_service.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Start Flask API as a background service.
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$PROJECT_ROOT/logs"
+mkdir -p "$LOG_DIR"
+nohup python3 "$PROJECT_ROOT/flask_app.py" > "$LOG_DIR/flask_app.log" 2>&1 &
+echo $! > "$LOG_DIR/flask_app.pid"
+echo "Flask service started with PID $(cat "$LOG_DIR/flask_app.pid")"


### PR DESCRIPTION
## Summary
- create `start_flask_service.sh` to run Flask API in background
- add helper to call Flask API from `api_galeria.php`
- send gallery uploads to Flask and include resources when listing
- document new script and AJAX usage in README
- add gradient text style to hero heading

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml`
- `vendor/bin/phpunit --do-not-cache-result` *(fails: missing DOM and XML extensions)*

------
https://chatgpt.com/codex/tasks/task_e_685068d730588329a70acb00142b17fb