### PR TITLE
Improve sliding menu accessibility

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -1,7 +1,10 @@
 <header id="fixed-header" role="banner">
-    <button id="menu-button" aria-label="Abrir menú" data-menu-target="slide-menu-left">☰</button>
+    <style>
+        .menu-btn:focus { outline: 3px solid var(--old-gold); outline-offset: 2px; }
+    </style>
+    <button id="menu-button" class="menu-btn" aria-label="Abrir menú" aria-controls="slide-menu-left" aria-expanded="false" data-menu-target="slide-menu-left">☰</button>
     <a href="/index.php" class="site-title">Condado de Castilla</a>
-    <button id="tools-button" aria-label="Herramientas" data-menu-target="slide-menu-right">⚙</button>
+    <button id="tools-button" class="menu-btn" aria-label="Herramientas" aria-controls="slide-menu-right" aria-expanded="false" data-menu-target="slide-menu-right">⚙</button>
 </header>
 <nav id="slide-menu-left" class="slide-menu left" role="navigation">
     <?php require __DIR__ . '/includes/header.php'; ?>
@@ -12,4 +15,4 @@
         <button id="ai-drawer-toggle" title="Asistente IA">IA</button>
     </div>
 </nav>
-<script defer src="/js/menu-controller.js"></script>
+<script defer src="/js/sliding-menu.js"></script>

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -37,6 +37,10 @@
     cursor: pointer;
     border-radius: 4px;
 }
+.menu-btn:focus {
+    outline: 3px solid var(--old-gold);
+    outline-offset: 2px;
+}
 
 .slide-menu {
     position: fixed;

--- a/js/sliding-menu.js
+++ b/js/sliding-menu.js
@@ -1,0 +1,30 @@
+(function(){
+    function toggleMenu(button){
+        const targetId = button.getAttribute('data-menu-target');
+        if(!targetId) return;
+        const menu = document.getElementById(targetId);
+        if(!menu) return;
+        const side = menu.classList.contains('left') ? 'left' : (menu.classList.contains('right') ? 'right' : '');
+        const isOpen = menu.classList.toggle('open');
+        if(side){
+            document.body.classList.toggle(`menu-open-${side}`, isOpen);
+        }
+        button.setAttribute('aria-expanded', isOpen);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('[data-menu-target]').forEach(btn => {
+            const targetId = btn.getAttribute('data-menu-target');
+            if(!targetId) return;
+            btn.setAttribute('aria-controls', targetId);
+            btn.setAttribute('aria-expanded', 'false');
+            btn.addEventListener('click', () => toggleMenu(btn));
+            btn.addEventListener('keydown', e => {
+                if(e.key === 'Enter' || e.key === ' '){
+                    e.preventDefault();
+                    toggleMenu(btn);
+                }
+            });
+        });
+    });
+})();


### PR DESCRIPTION
## Summary
- add focus styles and ARIA attributes for menu buttons
- create `sliding-menu.js` with keyboard support
- wire up new script and styles

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685068d8fd588329982e3c6c1b082bdd