### PR TITLE
Add GSAP sliding menu

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -12,4 +12,5 @@
         <button id="ai-drawer-toggle" title="Asistente IA">IA</button>
     </div>
 </nav>
-<script defer src="/js/menu-controller.js"></script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+<script defer src="/js/sliding-menu.js"></script>

--- a/js/sliding-menu.js
+++ b/js/sliding-menu.js
@@ -1,0 +1,47 @@
+(function(){
+    function toggleMenu(button){
+        var targetId = button.getAttribute('data-menu-target');
+        if(!targetId) return;
+        var menu = document.getElementById(targetId);
+        if(!menu) return;
+        var body = document.body;
+        var side = menu.classList.contains('left') ? 'left' : 'right';
+        var width = menu.offsetWidth || 260;
+        var openClass = 'menu-open-' + side;
+        var isOpen = menu.classList.contains('open');
+
+        if(!window.gsap){
+            menu.classList.toggle('open');
+            body.classList.toggle(openClass, !isOpen);
+            return;
+        }
+
+        if(isOpen){
+            gsap.to(menu, { x: side==='left' ? '-100%' : '100%', duration:0.35, ease:'power2.in', onComplete:function(){
+                menu.classList.remove('open');
+                menu.style.transform='';
+            }});
+            gsap.to(body, { x:0, duration:0.35, ease:'power2.in', onComplete:function(){
+                body.classList.remove(openClass);
+                body.style.transform='';
+            }});
+        } else {
+            menu.classList.add('open');
+            body.classList.add(openClass);
+            gsap.fromTo(menu, { x: side==='left' ? '-100%' : '100%' }, { x:'0%', duration:0.35, ease:'power2.out', clearProps:'transform' });
+            gsap.to(body, { x: side==='left' ? width : -width, duration:0.35, ease:'power2.out', clearProps:'transform' });
+        }
+    }
+
+    function init(){
+        document.querySelectorAll('[data-menu-target]').forEach(function(btn){
+            btn.addEventListener('click', function(){ toggleMenu(btn); });
+        });
+    }
+
+    if(document.readyState === 'loading'){
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/tests/js/sliding-menu.test.js
+++ b/tests/js/sliding-menu.test.js
@@ -1,0 +1,56 @@
+const {JSDOM} = require('jsdom');
+const {window} = new JSDOM(`<!DOCTYPE html><body>
+  <button id="left-btn" data-menu-target="menu-left"></button>
+  <button id="right-btn" data-menu-target="menu-right"></button>
+  <nav id="menu-left" class="slide-menu left"></nav>
+  <nav id="menu-right" class="slide-menu right"></nav>
+</body>`, {url: 'http://localhost'});
+
+global.window = window;
+global.document = window.document;
+const body = window.document.body;
+
+// Mock getComputedStyle width for menus
+Object.defineProperty(window.HTMLElement.prototype, 'offsetWidth', {get(){return 260;}});
+
+require('../../js/sliding-menu.js');
+window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+function click(el){
+  const evt = new window.Event('click', {bubbles:true});
+  el.dispatchEvent(evt);
+}
+
+function check(condition, msg){
+  if(!condition){
+    console.error('Test failed:', msg);
+    process.exit(1);
+  }
+}
+
+const leftBtn = document.getElementById('left-btn');
+const rightBtn = document.getElementById('right-btn');
+const leftMenu = document.getElementById('menu-left');
+const rightMenu = document.getElementById('menu-right');
+
+// Open left
+click(leftBtn);
+check(leftMenu.classList.contains('open'), 'Left menu should open');
+check(body.classList.contains('menu-open-left'), 'Body shifted left');
+
+// Close left
+click(leftBtn);
+check(!leftMenu.classList.contains('open'), 'Left menu should close');
+check(!body.classList.contains('menu-open-left'), 'Body reset after closing left');
+
+// Open right
+click(rightBtn);
+check(rightMenu.classList.contains('open'), 'Right menu should open');
+check(body.classList.contains('menu-open-right'), 'Body shifted right');
+
+// Close right
+click(rightBtn);
+check(!rightMenu.classList.contains('open'), 'Right menu should close');
+check(!body.classList.contains('menu-open-right'), 'Body reset after closing right');
+
+console.log('sliding-menu tests passed');


### PR DESCRIPTION
## Summary
- add JS to animate sliding menu panels and body with GSAP
- load GSAP and new script from the header
- create Node-based test verifying menu open/close behaviour

## Testing
- `node tests/js/sliding-menu.test.js`
- `composer install` *(fails: requires ext-dom)*
- `vendor/bin/phpunit` *(fails: php-cgi not found)*

------
https://chatgpt.com/codex/tasks/task_e_685068dbfaf88329840e8b213c6f5eea