### PR TITLE
Fix Spanish labels for theme toggle

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -28,7 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else { // Light theme
             document.documentElement.setAttribute('data-theme', 'light');
             if (themeIcon) themeIcon.src = 'assets/icons/moon-icon.svg';
-            if (themeSpan) themeSpan.textContent = 'Modo Escuro';
+            if (themeSpan) themeSpan.textContent = 'Modo Oscuro';
             localStorage.setItem('theme', 'light');
         }
     }


### PR DESCRIPTION
## Summary
- improve Spanish text for light mode label in theme toggle

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506933843c8329882ed28f014a5dcd