### PR TITLE
Remove leftover debug comment

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -148,4 +148,3 @@ document.addEventListener('DOMContentLoaded', () => {
         AOS.init();
     }
 });
-// Re-submitting to ensure branch is pushed.


### PR DESCRIPTION
## Summary
- remove leftover debug comment from `assets/js/main.js`

## Testing
- `grep -n -e "debug" -e "console.log" -e "Re-submitting" -e "console.dir" -e "\btest\b" -e "placeholder" assets/js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_6850693467f48329bea7adef54920125