### PR TITLE
Remove unused Tailwind CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ y cualquier otra variable necesaria.
 
 Las variables definidas en `.env` se cargan de forma automática gracias a `includes/env_loader.php`.
 
+### Dependencia opcional: Tailwind CSS
+
+El sitio no utiliza clases propias de Tailwind CSS y el script que cargaba la librería
+se ha eliminado de `includes/head_common.php`. Actualmente no es necesario descargar
+ni servir Tailwind en local.
+
 ## Configuración de la clave Gemini
 
 Define la variable `GEMINI_API_KEY` en tu archivo `.env` con la clave proporcionada por el servicio Gemini:

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -18,7 +18,6 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <link rel="stylesheet" href="/assets/vendor/css/bootstrap.min.css">
 <link rel="stylesheet" href="/assets/css/custom.css">
 <link rel="stylesheet" href="/assets/css/lighting.css">
-<script src="https://cdn.tailwindcss.com"></script>
 <script defer src="/assets/vendor/js/bootstrap.bundle.min.js"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" />
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>


### PR DESCRIPTION
## Summary
- prune Tailwind CDN script from `includes/head_common.php`
- document that Tailwind is not used in the README

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml`
- `vendor/bin/phpunit` *(fails: requires dom, xml, xmlwriter PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_e_685069368cbc832988df36e7eb48868a