### PR TITLE
docs: document frontend setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwrit
 ./scripts/setup_frontend_libs.sh
 ```
 
+El script `scripts/setup_frontend_libs.sh` descarga o actualiza las dependencias de
+JavaScript y CSS (por ejemplo jQuery y Bootstrap) en `assets/vendor`. Ejecuta este
+comando siempre tras clonar el repositorio o cuando necesites actualizar estas
+bibliotecas a versiones más recientes, como ocurriría al lanzar una nueva versión
+de `three.js` u otra librería.
+
 A continuación copia el archivo de ejemplo `.env.example` a `.env`
 y sustituye sus valores por tus credenciales reales para
 `CONDADO_DB_PASSWORD`, `GEMINI_API_KEY`


### PR DESCRIPTION
## Summary
- explain what `scripts/setup_frontend_libs.sh` does
- mention running it after cloning or when frontend libraries are updated

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml --no-interaction --no-progress`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: php-cgi not found)*
- `./scripts/setup_frontend_libs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6850694482408329a99e16a717560d1f