### PR TITLE
Remove obsolete chat fragment from link checker

### DIFF
--- a/check_links_extended.sh
+++ b/check_links_extended.sh
@@ -18,7 +18,7 @@ html_fragments=(
 all_files_to_check=("${files_to_check[@]}" "${html_fragments[@]}")
 
 # Files that were previously loaded dynamically but no longer exist should be skipped
-skip_files=("fragments/header/ia-chat.html")
+skip_files=()
 
 # Output file for broken links
 output_file="broken_links_report_extended.txt"


### PR DESCRIPTION
## Summary
- remove `fragments/header/ia-chat.html` from the skip list in `check_links_extended.sh`

## Testing
- `./check_links_extended.sh > /tmp/script.log && tail -n 20 /tmp/script.log`


------
https://chatgpt.com/codex/tasks/task_e_6850711256748329bb8f48d2aa0cb023