### PR TITLE
Add right-side tools menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ esperadas para cada elemento del menú principal:
 Mantén esta lista actualizada cuando se añadan o eliminen páginas para que se
 pueda validar fácilmente el contenido del menú.
 
+El menú lateral derecho se genera a partir de `fragments/menus/tools-menu.html` y
+ofrece accesos rápidos a páginas clave. Se incluye dentro del elemento
+`<nav id="slide-menu-right">` en `_header.html` y comparte la misma temática de
+colores morado y oro viejo que el resto de la cabecera.
+
 ## Cambios recientes
 
 - Eliminado `js/header_loader.js` y referencias a dicho script, ya que la cabecera se carga ahora de forma estática.

--- a/_header.html
+++ b/_header.html
@@ -14,5 +14,6 @@
         <button id="theme-toggle" title="Cambiar tema" style="margin-bottom:1rem;">Tema</button>
         <button id="ai-drawer-toggle" title="Asistente IA">IA</button>
     </div>
+    <?php echo file_get_contents(__DIR__ . '/fragments/menus/tools-menu.html'); ?>
 </nav>
 <script defer src="/js/sliding-menu.js"></script>

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -67,3 +67,22 @@ body.menu-open-left {
 body.menu-open-right {
     transform: translateX(-260px);
 }
+
+#slide-menu-right ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+#slide-menu-right a {
+    display: block;
+    padding: 0.5rem 1rem;
+    color: var(--primary-purple);
+    text-decoration: none;
+}
+
+#slide-menu-right a:hover,
+#slide-menu-right a:focus-visible {
+    background: var(--old-gold);
+    color: var(--primary-purple);
+}

--- a/fragments/menus/tools-menu.html
+++ b/fragments/menus/tools-menu.html
@@ -1,0 +1,7 @@
+<ul id="tools-menu" class="nav-links">
+    <li><a href="/index.php">Inicio</a></li>
+    <li><a href="/museo/galeria.php">Museo Colaborativo</a></li>
+    <li><a href="/tienda/index.php">Tienda</a></li>
+    <li><a href="/foro/index.php">Foro</a></li>
+    <li><a href="/contacto/contacto.php">Contacto</a></li>
+</ul>

--- a/tests/ToolsMenuLinksTest.php
+++ b/tests/ToolsMenuLinksTest.php
@@ -1,0 +1,57 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ToolsMenuLinksTest extends TestCase {
+    private function runPage(string $script): array {
+        $prepend = realpath(__DIR__.'/fixtures/page_prepend.php');
+        $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
+            escapeshellarg($prepend),
+            escapeshellarg($script)
+        );
+        $env = [
+            'PATH' => getenv('PATH'),
+            'REDIRECT_STATUS' => '1',
+            'SCRIPT_FILENAME' => $script
+        ];
+        $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        $status = proc_close($proc);
+        return [$status, $out, $err];
+    }
+
+    public static function urlProvider(): array {
+        $html = file_get_contents(__DIR__.'/../fragments/menus/tools-menu.html');
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadHTML($html);
+        $urls = [];
+        foreach ($dom->getElementsByTagName('a') as $a) {
+            $href = $a->getAttribute('href');
+            if ($href !== '') {
+                $urls[] = [$href];
+            }
+        }
+        return $urls;
+    }
+
+    /**
+     * @dataProvider urlProvider
+     */
+    public function testLinkLoads(string $href): void {
+        $path = __DIR__.'/..'.$href;
+        if (is_dir($path)) {
+            $path .= '/index.php';
+        }
+        $this->assertFileExists($path, "Missing file for $href");
+        if (pathinfo($path, PATHINFO_EXTENSION) === 'php') {
+            [$status, $out, $err] = $this->runPage($path);
+            $this->assertSame(0, $status, $err);
+            $this->assertNotEmpty($out);
+        } else {
+            $content = file_get_contents($path);
+            $this->assertNotFalse($content, "Failed to read $path");
+        }
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- add sliding menu on the right with quick links
- load the menu in `_header.html`
- style right menu links
- add PHPUnit tests for the tools menu links
- document the new menu in the README

## Testing
- `npm --version`
- `vendor/bin/phpunit` *(fails: command not found)*
- `composer install` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685070f00b0c8329a0ce78531eb4c2cd