### PR TITLE
Add tools slide menu and tests

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -10,9 +10,6 @@
     <?php require __DIR__ . '/includes/header.php'; ?>
 </nav>
 <nav id="slide-menu-right" class="slide-menu right" aria-label="Herramientas">
-    <div style="padding:1rem;">
-        <button id="theme-toggle" title="Cambiar tema" style="margin-bottom:1rem;">Tema</button>
-        <button id="ai-drawer-toggle" title="Asistente IA">IA</button>
-    </div>
+    <?php require __DIR__ . '/includes/right_menu.php'; ?>
 </nav>
 <script defer src="/js/sliding-menu.js"></script>

--- a/fragments/menus/tools-menu.html
+++ b/fragments/menus/tools-menu.html
@@ -1,0 +1,7 @@
+<ul id="tools-menu" class="nav-links">
+    <li><a href="/museo/subir_pieza.php">Subir Pieza</a></li>
+    <li><a href="/galeria/galeria_colaborativa.php">Galería Colaborativa</a></li>
+    <li><a href="/tienda/index.php">Tienda</a></li>
+    <li><a href="/foro/index.php">Foro</a></li>
+    <li><a href="/contacto/contacto.php">Contacto</a></li>
+</ul>

--- a/includes/right_menu.php
+++ b/includes/right_menu.php
@@ -1,0 +1,9 @@
+<?php
+$baseDir = dirname(__DIR__);
+// Output tools menu
+echo file_get_contents($baseDir . '/fragments/menus/tools-menu.html');
+?>
+<div style="padding:1rem;">
+    <button id="theme-toggle" title="Cambiar tema" style="margin-bottom:1rem;">Tema</button>
+    <button id="ai-drawer-toggle" title="Asistente IA">IA</button>
+</div>

--- a/tests/RightMenuLinksTest.php
+++ b/tests/RightMenuLinksTest.php
@@ -1,0 +1,29 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class RightMenuLinksTest extends TestCase {
+    public function testToolsMenuLinksExist(): void {
+        $menuPath = __DIR__ . '/../fragments/menus/tools-menu.html';
+        $html = file_get_contents($menuPath);
+        $dom = new DOMDocument();
+        @$dom->loadHTML($html);
+        $xpath = new DOMXPath($dom);
+        $links = [];
+        foreach ($xpath->query('//a[@href]') as $node) {
+            $links[] = $node->getAttribute('href');
+        }
+        foreach ($links as $href) {
+            if (str_starts_with($href, 'http://') ||
+                str_starts_with($href, 'https://') ||
+                str_starts_with($href, 'mailto:') ||
+                str_starts_with($href, 'javascript:') ||
+                str_starts_with($href, '#')) {
+                continue;
+            }
+            $path = ltrim($href, '/');
+            $path = strtok($path, '#?');
+            $fullPath = __DIR__ . '/../' . $path;
+            $this->assertFileExists($fullPath, "Link target $href does not exist");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `tools-menu.html` with shortcuts
- include new menu through `right_menu.php`
- update `_header.html` to load right-side menu
- add PHPUnit test for tools menu links

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685070f34a9c8329acf23ebc1e1ba344