### PR TITLE
Remove outdated IA chat CSS import

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -1,6 +1,5 @@
 @import url('header/layout.css');
 @import url('header/nav.css');
-@import url('header/ia-chat.css');
 @import url('header/topbar.css');
 @import url('menus/main-menu.css');
 @import url('menus/admin-menu.css');


### PR DESCRIPTION
## Summary
- clean up `header.css` to avoid missing CSS reference

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685070fda72c83298165c137a9475f35