### PR TITLE
Add IA chat sidebar markup and style

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -5,6 +5,9 @@
     <button id="menu-button" class="menu-btn" aria-label="Abrir menú" aria-controls="slide-menu-left" aria-expanded="false" data-menu-target="slide-menu-left">☰</button>
     <a href="/index.php" class="site-title">Condado de Castilla</a>
     <button id="tools-button" class="menu-btn" aria-label="Herramientas" aria-controls="slide-menu-right" aria-expanded="false" data-menu-target="slide-menu-right">⚙</button>
+    <button id="ia-chat-toggle" class="menu-btn" aria-label="Chat IA" aria-controls="ia-chat-sidebar" aria-expanded="false" data-menu-target="ia-chat-sidebar">
+        <i class="fas fa-comments"></i>
+    </button>
 </header>
 <nav id="slide-menu-left" class="slide-menu left" role="navigation">
     <?php require __DIR__ . '/includes/header.php'; ?>
@@ -13,6 +16,14 @@
     <div style="padding:1rem;">
         <button id="theme-toggle" title="Cambiar tema" style="margin-bottom:1rem;">Tema</button>
         <button id="ai-drawer-toggle" title="Asistente IA">IA</button>
+    </div>
+</nav>
+<nav id="ia-chat-sidebar" class="slide-menu right" aria-label="Chat IA">
+    <div id="ia-tools-menu">
+        <button id="ia-summary-btn">Resumen</button>
+        <button id="ia-translate-btn">Traducir</button>
+        <button id="ia-research-btn">Investigar</button>
+        <button id="ia-websearch-btn">Buscar</button>
     </div>
 </nav>
 <script defer src="/js/sliding-menu.js"></script>

--- a/assets/css/header/ia-chat.css
+++ b/assets/css/header/ia-chat.css
@@ -1,0 +1,25 @@
+# Minimal styles for IA chat sidebar and toggle
+#ia-chat-sidebar {
+    position: fixed;
+    top: 0;
+    right: -320px;
+    width: clamp(280px, 70vw, 320px);
+    height: 100vh;
+    background-color: var(--epic-alabaster-bg);
+    border-left: 2px solid var(--epic-gold-secondary);
+    box-shadow: -3px 0 15px rgba(var(--epic-text-color-rgb), 0.25);
+    padding: 1rem;
+    overflow-y: auto;
+    transition: right var(--global-transition-speed) ease-in-out;
+    z-index: 3000;
+}
+
+body.menu-open-right #ia-chat-sidebar  {
+    right: 0;
+}
+
+#ia-chat-toggle {
+    position: fixed;
+    top: 88px;
+    right: 15px;
+}


### PR DESCRIPTION
## Summary
- include IA chat toggle button and sidebar in `_header.html`
- add minimal `ia-chat.css` for sidebar positioning

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml`
- `vendor/bin/phpunit --colors=never` *(fails: required PHP extensions not available)*

------
https://chatgpt.com/codex/tasks/task_e_685070ff463c8329bc60fd95a5053edb