### PR TITLE
Reposition theme toggle UI

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -5,14 +5,15 @@
     <button id="menu-button" class="menu-btn" aria-label="Abrir menú" aria-controls="slide-menu-left" aria-expanded="false" data-menu-target="slide-menu-left">☰</button>
     <a href="/index.php" class="site-title">Condado de Castilla</a>
     <button id="tools-button" class="menu-btn" aria-label="Herramientas" aria-controls="slide-menu-right" aria-expanded="false" data-menu-target="slide-menu-right">⚙</button>
+    <div class="tools-group">
+        <button id="theme-toggle" title="Cambiar tema">Tema</button>
+        <button id="ai-drawer-toggle" title="Asistente IA">IA</button>
+    </div>
 </header>
 <nav id="slide-menu-left" class="slide-menu left" role="navigation">
     <?php require __DIR__ . '/includes/header.php'; ?>
 </nav>
 <nav id="slide-menu-right" class="slide-menu right" aria-label="Herramientas">
-    <div style="padding:1rem;">
-        <button id="theme-toggle" title="Cambiar tema" style="margin-bottom:1rem;">Tema</button>
-        <button id="ai-drawer-toggle" title="Asistente IA">IA</button>
-    </div>
+    
 </nav>
 <script defer src="/js/sliding-menu.js"></script>

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -25,10 +25,6 @@
 
 /* Theme Toggle Button - Original Position (will be adjusted for mobile) */
 #theme-toggle {
-    position: fixed;
-    top: 88px; /* lowered position */
-    left: 50%;
-    transform: translateX(-50%);
     background-color: var(--epic-transparent-overlay-medium);
     border: 2px solid var(--epic-gold-secondary);
     border-radius: var(--global-border-radius);

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -37,6 +37,15 @@
     cursor: pointer;
     border-radius: 4px;
 }
+.tools-group {
+    position: absolute;
+    right: 0;
+    top: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding-top: 0.5rem;
+}
 .menu-btn:focus {
     outline: 3px solid var(--old-gold);
     outline-offset: 2px;

--- a/js/layout.js
+++ b/js/layout.js
@@ -34,8 +34,6 @@ document.addEventListener("DOMContentLoaded", function() {
     //     })
     //     .catch(error => console.error('Error fetching _footer.php:', error));
 
-    // Theme toggle initialization
-    initializeThemeToggle();
     initializeLinterna();
 });
 
@@ -107,29 +105,6 @@ function initializeSidebarNavigation() {
     } else {
         console.error("Sidebar toggle, sidebar element, or body not found.");
     }
-}
-
-// Initialize theme toggle button
-function initializeThemeToggle() {
-    const toggleButton = document.getElementById('theme-toggle');
-    const body = document.body;
-    if (!toggleButton) return;
-
-    const icon = toggleButton.querySelector('i');
-    const storedTheme = localStorage.getItem('theme');
-    if (storedTheme === 'dark') {
-        body.classList.add('dark-mode');
-        icon.classList.remove('fa-moon');
-        icon.classList.add('fa-sun');
-    }
-
-    toggleButton.addEventListener('click', () => {
-        body.classList.toggle('dark-mode');
-        const isDark = body.classList.contains('dark-mode');
-        icon.classList.toggle('fa-moon', !isDark);
-        icon.classList.toggle('fa-sun', isDark);
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    });
 }
 
 function initializeLinterna() {


### PR DESCRIPTION
## Summary
- move theme & AI buttons to a new `.tools-group` under the tools button
- style `.tools-group` with flexbox below the tools button
- drop fixed positioning from the theme toggle style
- remove duplicate theme toggle logic from layout.js

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850712e6b8083299942ac141ade8b2c