### PR TITLE
Add chat API route and integrate with frontend

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -80,9 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const prompt = aiInput.value.trim();
             if (!prompt) return; // Don't send empty prompts
 
-            const apiKeyMeta = document.querySelector('meta[name="gemini-api-key"]');
-            const apiKey = apiKeyMeta ? apiKeyMeta.getAttribute('content') : '';
-            const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`;
+            const url = '/api/chat';
 
             aiResponse.innerHTML = 'Procesando...';
 
@@ -90,9 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const response = await fetch(url, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        "contents": [{ "parts": [{ "text": prompt }] }]
-                    })
+                    body: JSON.stringify({ prompt })
                 });
 
                 if (!response.ok) {
@@ -105,27 +101,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
 
                 const data = await response.json();
-                if (data.candidates && data.candidates.length > 0 &&
-                    data.candidates[0].content && data.candidates[0].content.parts &&
-                    data.candidates[0].content.parts.length > 0) {
-                    aiResponse.innerHTML = data.candidates[0].content.parts[0].text.replace(/\n/g, '<br>');
-                } else if (data.promptFeedback && data.promptFeedback.blockReason) {
-                    let feedbackMsg = `Pregunta bloqueada: ${data.promptFeedback.blockReason}`;
-                    if (data.promptFeedback.safetyRatings) {
-                        data.promptFeedback.safetyRatings.forEach(rating => {
-                            if (rating.blocked) {
-                                feedbackMsg += `<br>- Categoría: ${rating.category}, Probabilidad: ${rating.probability}`;
-                            }
-                        });
-                    }
-                    aiResponse.innerHTML = feedbackMsg;
+                if (data.response) {
+                    aiResponse.innerHTML = data.response;
+                } else if (data.error) {
+                    aiResponse.innerHTML = data.error;
                 } else {
-                    // Check for other possible valid responses or more detailed error messages
-                    if (data.candidates && data.candidates.length > 0 && data.candidates[0].finishReason === "SAFETY") {
-                         aiResponse.innerHTML = 'La respuesta fue bloqueada por motivos de seguridad. Intenta reformular tu pregunta.';
-                    } else {
-                         aiResponse.innerHTML = 'No se recibió una respuesta válida o el contenido fue bloqueado.';
-                    }
+                    aiResponse.innerHTML = 'No se recibió respuesta válida.';
                 }
             } catch (error) {
                 console.error('Error llamando a la API de Gemini:', error);

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -405,6 +405,30 @@ function get_history_chat_response(string $question): string {
     return nl2br(htmlspecialchars($parsed_text));
 }
 
+/**
+ * Genera una respuesta genérica para el chat utilizando Gemini.
+ *
+ * @param string $prompt Texto introducido por el usuario.
+ * @return string Respuesta generada o mensaje de error.
+ */
+function get_ai_chat_response(string $prompt): string {
+    if (empty(trim($prompt))) {
+        return "Error: No se proporcionó prompt.";
+    }
+
+    $payload = _build_gemini_payload($prompt);
+
+    $error = null;
+    $api_response = _call_gemini_api($payload, $error);
+    $parsed_text = _parse_gemini_response($api_response, $error);
+
+    if (strpos($parsed_text, "Error:") === 0) {
+        return $parsed_text; // It's an error message, return as is.
+    }
+    // It's successful, non-empty text
+    return nl2br(htmlspecialchars($parsed_text));
+}
+
 
 
 /**

--- a/scripts/chat_cli.php
+++ b/scripts/chat_cli.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/../includes/ai_utils.php';
+
+$prompt = $argv[1] ?? '';
+$prompt = is_string($prompt) ? $prompt : '';
+$prompt = trim($prompt);
+if ($prompt === '') {
+    fwrite(STDERR, "No prompt provided\n");
+    exit(1);
+}
+$response = get_ai_chat_response($prompt);
+// Output plain text; errors are returned as text starting with 'Error:'
+// We do not JSON encode to keep usage simple.
+// Convert newlines to \n to preserve formatting when read from Python.
+$response = str_replace(["\r", "\n"], ["", "\n"], $response);
+echo $response;
+


### PR DESCRIPTION
## Summary
- add generic AI chat helper in `ai_utils.php`
- expose new `/api/chat` POST route in `flask_app.py`
- provide CLI helper `scripts/chat_cli.php` for Flask to call
- update frontend JS to send prompts to `/api/chat`

## Testing
- `python -m pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6850710eb0d483299707375d68415173