### PR TITLE
Fix: Remove redundant AI drawer include from index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -157,7 +157,6 @@ require_once __DIR__ . '/_header.php';
     </main>
 
     <?php require_once __DIR__ . '/_footer.php'; ?>
-    <?php include __DIR__ . '/fragments/ai-drawer.html'; ?>
     <script src="/assets/js/main.js"></script>
     <script src="/js/layout.js"></script>
 


### PR DESCRIPTION
The file `index.php` was including `fragments/ai-drawer.html` directly, while `_header.php` (included in `index.php`) already loads `fragments/header/ai-drawer.html`.

This change removes the duplicate include from `index.php` to prevent potential UI conflicts and unnecessary code loading, ensuring the AI drawer is loaded only once via the header mechanism.