### PR TITLE
Fix: Make Google Translate widget visible and functional

### DIFF
--- a/fragments/header/language-bar.html
+++ b/fragments/header/language-bar.html
@@ -26,4 +26,4 @@
     <a href="?lang=el" class="lang-flag" title="Ελληνικά">🇬🇷</a>
     <a href="?lang=he" class="lang-flag" title="עברית">🇮🇱</a>
 </div>
-<div id="google_translate_element" style="display:none;"></div>
+<div id="google_translate_element"></div>


### PR DESCRIPTION
The Google Translate widget (google_translate_element) was previously hidden with `display:none;`. This change removes the inline style, making the widget visible to you.

The existing JavaScript in `js/lang-bar.js` handles the loading of the Google Translate Element and sets its language based on the `lang` URL parameter, which is controlled by clicking language flags in `fragments/header/language-bar.html`.

With the widget visible, you can now:
- See the current translation status.
- Use the Google Translate widget's native controls to change languages or revert to the original.
- Have the language automatically set based on the language flag you click.

This addresses the issue of the translation functionality not being perceivably functional due to the hidden widget.