### PR TITLE
Standardize GEMINI_API_KEY variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,5 @@ DB_NAME="condado_castilla_db"
 DB_USER="condado_user"
 CONDADO_DB_PASSWORD="your_password"
 GEMINI_API_KEY=your_key
-GeminiAPI=your_key
 GEMINI_API_ENDPOINT=https://api.gemini.example.com/v1/generateContent
 FORUM_COMMENT_COOLDOWN=60

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Define la variable `GEMINI_API_KEY` en tu archivo `.env` con la clave proporcion
 ```bash
 GEMINI_API_KEY=tu_clave_personal
 ```
+Solo se admite la variable `GEMINI_API_KEY`; otros nombres anteriores han sido eliminados.
 
 El valor se inyectará en la etiqueta `<meta name="gemini-api-key">` generada por `includes/head_common.php` y será leído por `assets/js/main.js` para realizar las peticiones.
 

--- a/ajax_actions/get_gemini_chat_response.php
+++ b/ajax_actions/get_gemini_chat_response.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/ai_utils.php'; // For GOOGLE_API_KEY and Gemini functions
+require_once __DIR__ . '/../includes/ai_utils.php'; // For GEMINI_API_KEY and Gemini functions
 require_once __DIR__ . '/../includes/env_loader.php'; // Ensure environment variables are loaded
 
 header('Content-Type: application/json');
@@ -14,7 +14,7 @@ if (empty(trim($prompt))) {
 }
 
 // Call the function from ai_utils.php that interacts with Gemini for chat
-// (This function should already be set up to use GOOGLE_API_KEY)
+// (This function should already be set up to use GEMINI_API_KEY)
 $ai_response_text = get_ai_chat_response($prompt); // Assumes get_ai_chat_response handles errors internally and prefixes with "Error:"
 
 $response = [];

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -6,9 +6,9 @@ require_once __DIR__ . '/env_loader.php';
 
 // Read Gemini API settings from environment variables when available
 if (!defined('GEMINI_API_KEY')) {
-    $envKey = getenv('GOOGLE_API_KEY');
-    // Fallback to 'GeminiAPI' removed to keep it specific to GOOGLE_API_KEY
-    define('GEMINI_API_KEY', $envKey !== false ? $envKey : 'YOUR_GOOGLE_API_KEY_NOT_SET');
+    $envKey = getenv('GEMINI_API_KEY');
+    // Reads GEMINI_API_KEY only
+    define('GEMINI_API_KEY', $envKey !== false ? $envKey : 'YOUR_GEMINI_API_KEY_NOT_SET');
 }
 if (!defined('GEMINI_API_ENDPOINT')) {
     $envEndpoint = getenv('GEMINI_API_ENDPOINT');
@@ -180,7 +180,7 @@ function _parse_gemini_response(?array $api_response, ?string $call_error): stri
 function _call_gemini_api(array $payload, ?string &$error = null): ?array {
     // Use simulator only if the API key is the placeholder "not set" value.
     // If a key is provided, attempt a real call, regardless of the endpoint value.
-    if (GEMINI_API_KEY === 'YOUR_GOOGLE_API_KEY_NOT_SET') {
+    if (GEMINI_API_KEY === 'YOUR_GEMINI_API_KEY_NOT_SET') {
         return _call_gemini_api_simulator($payload);
     }
 


### PR DESCRIPTION
## Summary
- read only `GEMINI_API_KEY` in AI utilities
- remove alternate env var from `.env.example`
- document that `GEMINI_API_KEY` is the single supported name
- adjust API chat script comments

## Testing
- `composer install --no-interaction --no-progress --prefer-dist` *(fails: ext-dom missing)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d5b5b8cc8329a75f92f5da79dc68