### PR TITLE
Add Flask API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ vendor/bin/phpunit
 El primer comando descargará las dependencias necesarias, incluido PHPUnit, y el
 segundo lanzará todos los tests definidos en `phpunit.xml`.
 
+### Pruebas de la API Flask
+
+Para ejecutar las pruebas escritas en Python que validan la API Flask utiliza:
+
+```bash
+python -m unittest tests/test_flask_api.py
+```
+
 ## Elementos del menú principal
 
 El archivo `fragments/menus/main-menu.html` define los enlaces de navegación que

--- a/tests/test_flask_api.py
+++ b/tests/test_flask_api.py
@@ -1,0 +1,55 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+import flask_app
+
+class FakeDB:
+    def __init__(self):
+        self.resources = []
+    def add_or_update_resource(self, data):
+        self.resources.append(data)
+    def get_all_resources(self):
+        return self.resources
+
+class FlaskApiTestCase(unittest.TestCase):
+    def setUp(self):
+        flask_app.db = FakeDB()
+        self.client = flask_app.app.test_client()
+
+    def test_resource_post_and_get(self):
+        res = self.client.post('/api/resource', json={'url': 'http://example.com'})
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(res.get_json(), {'success': True})
+
+        res = self.client.get('/api/resource')
+        self.assertEqual(res.status_code, 200)
+        data = res.get_json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(data[0]['url'], 'http://example.com')
+
+    def test_resource_post_missing_url(self):
+        res = self.client.post('/api/resource', json={'foo': 'bar'})
+        self.assertEqual(res.status_code, 400)
+        self.assertIn('error', res.get_json())
+
+    @patch('flask_app.subprocess.run')
+    def test_chat_success(self, mock_run):
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout='Hola', stderr='')
+        res = self.client.post('/api/chat', json={'prompt': 'hola'})
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.get_json(), {'response': 'Hola'})
+
+    def test_chat_missing_prompt(self):
+        res = self.client.post('/api/chat', json={})
+        self.assertEqual(res.status_code, 400)
+        self.assertIn('error', res.get_json())
+
+    @patch('flask_app.subprocess.run')
+    def test_chat_php_error(self, mock_run):
+        mock_run.return_value = SimpleNamespace(returncode=1, stdout='', stderr='fail')
+        res = self.client.post('/api/chat', json={'prompt': 'hola'})
+        self.assertEqual(res.status_code, 500)
+        self.assertIn('error', res.get_json())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- test flask API endpoints
- document running the new python tests

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6851f7ffc36c83299c97a779d9a426e5