### PR TITLE
Add APP_DEBUG control for dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ CONDADO_DB_PASSWORD="your_password"
 GEMINI_API_KEY=your_key
 GEMINI_API_ENDPOINT=https://api.gemini.example.com/v1/generateContent
 FORUM_COMMENT_COOLDOWN=60
+# Controla la visualización de errores y avisos en PHP. Usar 'true' para
+# entornos de desarrollo y 'false' en producción.
+APP_DEBUG=false

--- a/dashboard/db_connect.php
+++ b/dashboard/db_connect.php
@@ -6,13 +6,16 @@
 // Cargar variables de entorno desde .env
 require_once __DIR__ . '/../includes/env_loader.php';
 
-// --- IMPORTANTE PARA PRODUCCIÓN ---
-// Las siguientes líneas habilitan la visualización de errores para desarrollo.
-// DEBEN SER COMENTADAS O ELIMINADAS en un entorno de producción para no exponer información sensible.
-// ini_set('display_errors', 1);
-// ini_set('display_startup_errors', 1);
-// error_reporting(E_ALL);
-// --- FIN DE SECCIÓN IMPORTANTE PARA PRODUCCIÓN ---
+// --- Manejo de modo debug ---
+// Activa la visualización de errores solo cuando la variable de entorno
+// APP_DEBUG esté establecida a 'true'. Por defecto esta variable es falsa.
+$app_debug = filter_var($_ENV['APP_DEBUG'] ?? false, FILTER_VALIDATE_BOOLEAN);
+if ($app_debug) {
+    ini_set('display_errors', '1');
+    ini_set('display_startup_errors', '1');
+    error_reporting(E_ALL);
+}
+// --- Fin de manejo de modo debug ---
 
 // Configuración de la base de datos PostgreSQL
 $db_host = "localhost";         // Host de la base de datos (PostgreSQL está en el mismo servidor)


### PR DESCRIPTION
## Summary
- activate debugging output in `dashboard/db_connect.php` only when `APP_DEBUG` is enabled
- document `APP_DEBUG` in `.env.example`

## Testing
- `vendor/bin/phpunit --version` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6851f800e5d083299b3d6d79ff75940e