### PR TITLE
Scale content when sliding menus open

### DIFF
--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -62,10 +62,10 @@ body.menu-open-right {
     transition: transform 0.3s ease;
 }
 body.menu-open-left {
-    transform: translateX(260px);
+    transform: translateX(260px) scale(0.97);
 }
 body.menu-open-right {
-    transform: translateX(-260px);
+    transform: translateX(-260px) scale(0.97);
 }
 
 #slide-menu-right ul {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const open = menu.classList.toggle('active');
         btn.setAttribute('aria-expanded', open);
         if (side) document.body.classList.toggle(`menu-open-${side}`, open);
+        document.body.classList.toggle('menu-compressed', open);
     };
 
     document.querySelectorAll('[data-menu-target]').forEach(btn => {
@@ -26,6 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const side = menu.classList.contains('left-panel') ? 'left'
                             : (menu.classList.contains('right-panel') ? 'right' : '');
                 if (side) document.body.classList.remove(`menu-open-${side}`);
+                document.body.classList.remove('menu-compressed');
             }
         });
     });
@@ -39,6 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const side = menu.classList.contains('left-panel') ? 'left'
                             : (menu.classList.contains('right-panel') ? 'right' : '');
                 if (side) document.body.classList.remove(`menu-open-${side}`);
+                document.body.classList.remove('menu-compressed');
             });
         }
     });
@@ -50,6 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (panel) {
                 panel.classList.remove('active');
                 document.body.classList.remove('menu-open-left');
+                document.body.classList.remove('menu-compressed');
             }
             const btn = document.querySelector('[data-menu-target="ai-chat-panel"]');
             if (btn) btn.setAttribute('aria-expanded', 'false');


### PR DESCRIPTION
## Summary
- shrink the body when sliding menus open
- mark the body as `menu-compressed` via JS

## Testing
- `phpunit` *(fails: php-cgi not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f803040c8329ad6c4838e8de0035