### PR TITLE
Update demo with sliding panel

### DIFF
--- a/assets/css/demo_transparencia_movimiento.css
+++ b/assets/css/demo_transparencia_movimiento.css
@@ -33,10 +33,12 @@
     color: var(--morado-emperador);
     opacity: 0;
     animation: fade-up 1s ease forwards 0.5s;
+    text-align: right; /* move inner content to the right */
 }
 
 .demo-button {
-    display: inline-block;
+    display: block; /* allow margin auto */
+    margin-left: auto; /* align button to right */
     padding: 0.75rem 1.5rem;
     background: var(--oro-viejo);
     color: var(--morado-emperador);
@@ -47,6 +49,17 @@
     position: relative;
     overflow: hidden;
     transition: color 0.3s;
+}
+
+.demo-button span {
+    display: block;
+    background: linear-gradient(45deg, var(--morado-emperador), var(--oro-viejo));
+    -webkit-background-clip: text;
+    color: transparent;
+}
+
+.demo-button:hover span {
+    background: linear-gradient(45deg, var(--oro-viejo), var(--morado-emperador));
 }
 
 .demo-button::after {

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -57,6 +57,12 @@
 .slide-menu.right { right: 0; transform: translateX(100%); }
 .slide-menu.open { transform: translateX(0); }
 
+/* When any sliding menu is open, compress content slightly */
+body.menu-compressed {
+    transform: scale(0.97);
+    transition: transform 0.3s ease;
+}
+
 body.menu-open-left,
 body.menu-open-right {
     transition: transform 0.3s ease;

--- a/demo_transparencia_movimiento.php
+++ b/demo_transparencia_movimiento.php
@@ -5,9 +5,12 @@
         <h1>Efectos Visuales</h1>
         <div class="demo-card">
             <p>Esta tarjeta emplea un sutil efecto de vidrio esmerilado con movimiento de aparición.</p>
-            <button class="demo-button">Acción</button>
+            <button class="demo-button" data-menu-target="demo-info-panel"><span>Acción</span></button>
         </div>
     </section>
+    <div id="demo-info-panel" class="menu-panel right-panel">
+        <p>Demo interactiva del patrimonio de Cerezo de Río Tirón.</p>
+    </div>
     <?php require_once __DIR__ . '/_footer.php'; ?>
     <script src="/assets/js/main.js"></script>
     <script src="/js/layout.js"></script>


### PR DESCRIPTION
## Summary
- add compression style for sliding menus
- make demo button open a new info panel

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6851f9ad82608329a336f4b17282a578