### PR TITLE
Implement accessible demo info panel

### DIFF
--- a/assets/css/demo_transparencia_movimiento.css
+++ b/assets/css/demo_transparencia_movimiento.css
@@ -84,3 +84,22 @@
     from { opacity: 0; transform: translateY(40px); }
     to { opacity: 1; transform: translateY(0); }
 }
+
+#demo-info-panel {
+    padding-top: 2rem;
+}
+
+#demo-info-panel #close-demo-info {
+    background: none;
+    border: none;
+    font-size: 1.4em;
+    color: var(--morado-emperador);
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    cursor: pointer;
+}
+
+#demo-info-panel #close-demo-info:hover {
+    color: var(--oro-viejo);
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -60,6 +60,20 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    const closeDemoInfo = document.getElementById('close-demo-info');
+    if (closeDemoInfo) {
+        closeDemoInfo.addEventListener('click', () => {
+            const panel = document.getElementById('demo-info-panel');
+            if (panel) {
+                panel.classList.remove('active');
+                document.body.classList.remove('menu-open-right');
+                document.body.classList.remove('menu-compressed');
+            }
+            const btn = document.querySelector('[data-menu-target="demo-info-panel"]');
+            if (btn) btn.setAttribute('aria-expanded', 'false');
+        });
+    }
+
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
         const icon = themeToggle.querySelector('i');

--- a/demo_transparencia_movimiento.php
+++ b/demo_transparencia_movimiento.php
@@ -5,9 +5,17 @@
         <h1>Efectos Visuales</h1>
         <div class="demo-card">
             <p>Esta tarjeta emplea un sutil efecto de vidrio esmerilado con movimiento de aparición.</p>
-            <button class="demo-button"><span>Acción</span></button>
+            <button class="demo-button" id="demo-info-trigger" data-menu-target="demo-info-panel" aria-controls="demo-info-panel" aria-expanded="false"><span>Información</span></button>
         </div>
     </section>
+
+    <div id="demo-info-panel" class="menu-panel right-panel" role="dialog">
+        <button id="close-demo-info" aria-label="Cerrar">×</button>
+        <div class="menu-section">
+            <h4 class="gradient-text">Detalles del efecto</h4>
+            <p>Este panel demuestra la integración de transparencias y movimiento con colores morados y oro viejo.</p>
+        </div>
+    </div>
     <?php require_once __DIR__ . '/_footer.php'; ?>
     <script src="/assets/js/main.js"></script>
     <script src="/js/layout.js"></script>


### PR DESCRIPTION
## Summary
- add opening button and new info panel markup
- style close button and panel
- support closing demo info panel in JS

## Testing
- `composer install` *(fails: ext-dom missing, then installed php-xml; success)*
- `vendor/bin/phpunit --do-not-cache-result` *(fails: many errors)
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6852003eb14c8329895a0354f2379f48