### PR TITLE
Add accessible language labels and styling

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -64,9 +64,23 @@ body {
     display: none !important;
 }
 
+/* Ocultar visualmente pero mantener accesible */
+.visually-hidden {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* Estilos para la bandera del idioma activo */
 .language-bar .lang-flag.active-lang {
-    border: 2px solid #007bff; /* Un borde azul distintivo */
+    border: 2px solid var(--epic-gold-main); /* Resalta con color del tema */
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.15);
     opacity: 1 !important; /* Asegurar que sea completamente opaco */
     transform: scale(1.1); /* Un ligero aumento de tamaño */
     border-radius: 3px; /* Bordes redondeados para el borde */

--- a/fragments/header/language-bar.html
+++ b/fragments/header/language-bar.html
@@ -1,29 +1,29 @@
 <div class="language-bar">
-    <a href="?lang=es" class="lang-flag" title="Español">🇪🇸</a>
-    <a href="?lang=en" class="lang-flag" title="English">🇬🇧</a>
-    <a href="?lang=fr" class="lang-flag" title="Français">🇫🇷</a>
-    <a href="?lang=de" class="lang-flag" title="Deutsch">🇩🇪</a>
-    <a href="?lang=it" class="lang-flag" title="Italiano">🇮🇹</a>
-    <a href="?lang=pt" class="lang-flag" title="Português">🇵🇹</a>
-    <a href="?lang=ru" class="lang-flag" title="Русский">🇷🇺</a>
-    <a href="?lang=zh-CN" class="lang-flag" title="中文">🇨🇳</a>
-    <a href="?lang=ja" class="lang-flag" title="日本語">🇯🇵</a>
-    <a href="?lang=ko" class="lang-flag" title="한국어">🇰🇷</a>
-    <a href="?lang=ar" class="lang-flag" title="العربية">🇸🇦</a>
-    <a href="?lang=hi" class="lang-flag" title="हिन्दी">🇮🇳</a>
-    <a href="?lang=tr" class="lang-flag" title="Türkçe">🇹🇷</a>
-    <a href="?lang=id" class="lang-flag" title="Bahasa Indonesia">🇮🇩</a>
-    <a href="?lang=vi" class="lang-flag" title="Tiếng Việt">🇻🇳</a>
-    <a href="?lang=bn" class="lang-flag" title="বাংলা">🇧🇩</a>
-    <a href="?lang=ur" class="lang-flag" title="اردو">🇵🇰</a>
-    <a href="?lang=fa" class="lang-flag" title="فارسی">🇮🇷</a>
-    <a href="?lang=nl" class="lang-flag" title="Nederlands">🇳🇱</a>
-    <a href="?lang=pl" class="lang-flag" title="Polski">🇵🇱</a>
-    <a href="?lang=uk" class="lang-flag" title="Українська">🇺🇦</a>
-    <a href="?lang=sw" class="lang-flag" title="Kiswahili">🇰🇪</a>
-    <a href="?lang=sv" class="lang-flag" title="Svenska">🇸🇪</a>
-    <a href="?lang=th" class="lang-flag" title="ไทย">🇹🇭</a>
-    <a href="?lang=el" class="lang-flag" title="Ελληνικά">🇬🇷</a>
-    <a href="?lang=he" class="lang-flag" title="עברית">🇮🇱</a>
+    <a href="?lang=es" class="lang-flag" title="Español">🇪🇸<span class="visually-hidden">Español</span></a>
+    <a href="?lang=en" class="lang-flag" title="English">🇬🇧<span class="visually-hidden">English</span></a>
+    <a href="?lang=fr" class="lang-flag" title="Français">🇫🇷<span class="visually-hidden">Français</span></a>
+    <a href="?lang=de" class="lang-flag" title="Deutsch">🇩🇪<span class="visually-hidden">Deutsch</span></a>
+    <a href="?lang=it" class="lang-flag" title="Italiano">🇮🇹<span class="visually-hidden">Italiano</span></a>
+    <a href="?lang=pt" class="lang-flag" title="Português">🇵🇹<span class="visually-hidden">Português</span></a>
+    <a href="?lang=ru" class="lang-flag" title="Русский">🇷🇺<span class="visually-hidden">Русский</span></a>
+    <a href="?lang=zh-CN" class="lang-flag" title="中文">🇨🇳<span class="visually-hidden">中文</span></a>
+    <a href="?lang=ja" class="lang-flag" title="日本語">🇯🇵<span class="visually-hidden">日本語</span></a>
+    <a href="?lang=ko" class="lang-flag" title="한국어">🇰🇷<span class="visually-hidden">한국어</span></a>
+    <a href="?lang=ar" class="lang-flag" title="العربية">🇸🇦<span class="visually-hidden">العربية</span></a>
+    <a href="?lang=hi" class="lang-flag" title="हिन्दी">🇮🇳<span class="visually-hidden">हिन्दी</span></a>
+    <a href="?lang=tr" class="lang-flag" title="Türkçe">🇹🇷<span class="visually-hidden">Türkçe</span></a>
+    <a href="?lang=id" class="lang-flag" title="Bahasa Indonesia">🇮🇩<span class="visually-hidden">Bahasa Indonesia</span></a>
+    <a href="?lang=vi" class="lang-flag" title="Tiếng Việt">🇻🇳<span class="visually-hidden">Tiếng Việt</span></a>
+    <a href="?lang=bn" class="lang-flag" title="বাংলা">🇧🇩<span class="visually-hidden">বাংলা</span></a>
+    <a href="?lang=ur" class="lang-flag" title="اردو">🇵🇰<span class="visually-hidden">اردو</span></a>
+    <a href="?lang=fa" class="lang-flag" title="فارسی">🇮🇷<span class="visually-hidden">فارسی</span></a>
+    <a href="?lang=nl" class="lang-flag" title="Nederlands">🇳🇱<span class="visually-hidden">Nederlands</span></a>
+    <a href="?lang=pl" class="lang-flag" title="Polski">🇵🇱<span class="visually-hidden">Polski</span></a>
+    <a href="?lang=uk" class="lang-flag" title="Українська">🇺🇦<span class="visually-hidden">Українська</span></a>
+    <a href="?lang=sw" class="lang-flag" title="Kiswahili">🇰🇪<span class="visually-hidden">Kiswahili</span></a>
+    <a href="?lang=sv" class="lang-flag" title="Svenska">🇸🇪<span class="visually-hidden">Svenska</span></a>
+    <a href="?lang=th" class="lang-flag" title="ไทย">🇹🇭<span class="visually-hidden">ไทย</span></a>
+    <a href="?lang=el" class="lang-flag" title="Ελληνικά">🇬🇷<span class="visually-hidden">Ελληνικά</span></a>
+    <a href="?lang=he" class="lang-flag" title="עברית">🇮🇱<span class="visually-hidden">עברית</span></a>
 </div>
 <div id="google_translate_element"></div>

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -7,6 +7,7 @@ function setupLanguageBar() {
 
         flagLinks.forEach(link => {
             link.classList.remove('active-lang');
+            link.removeAttribute('aria-current');
         });
 
         flagLinks.forEach(link => {
@@ -24,6 +25,7 @@ function setupLanguageBar() {
             flagLinks.forEach(link => {
                 if (link.getAttribute('href').includes(`lang=${lang}`)) {
                     link.classList.add('active-lang');
+                    link.setAttribute('aria-current', 'true');
                 }
             });
             console.log(`setupLanguageBar: Determined language for translation: ${lang}`);
@@ -33,6 +35,7 @@ function setupLanguageBar() {
             flagLinks.forEach(link => {
                 if (link.getAttribute('href').includes('lang=es')) {
                     link.classList.add('active-lang');
+                    link.setAttribute('aria-current', 'true');
                 }
             });
             console.log("setupLanguageBar: No language parameter in URL, or default language selected.");


### PR DESCRIPTION
## Summary
- improve language bar accessibility with visually hidden text and aria-current
- highlight active language using theme colors
- add `.visually-hidden` CSS class

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_app')*

------
https://chatgpt.com/codex/tasks/task_e_685204e0bda48329befbeba10c66d410