### PR TITLE
Skip ?lang= links in link checker

### DIFF
--- a/check_links_extended.sh
+++ b/check_links_extended.sh
@@ -84,6 +84,11 @@ check_links_in_file() {
         # Clean up ./ if any
         normalized_link=$(echo "$normalized_link" | sed 's#\./##g')
 
+        # Skip language selector links like ?lang=es
+        if [[ "$original_link_for_reporting" == \?lang=* ]]; then
+            continue
+        fi
+
         # Handle cases where normalized_link might be empty after stripping leading /
         if [ -z "$normalized_link" ]; then
             if [ "$original_link_for_reporting" == "/" ]; then


### PR DESCRIPTION
## Summary
- avoid checking language selector links that start with `?lang=`

## Testing
- `composer install` *(fails: ext-dom missing earlier, then succeeded after installing php-xml)*
- `vendor/bin/phpunit` *(fails: 4 failures)*
- `python -m unittest tests/test_flask_api.py`


------
https://chatgpt.com/codex/tasks/task_e_685204e2c8008329bb935c7798387d0f