### PR TITLE
Add forum comment integration tests

### DIFF
--- a/dashboard/db_connect.php
+++ b/dashboard/db_connect.php
@@ -6,6 +6,13 @@
 // Cargar variables de entorno desde .env
 require_once __DIR__ . '/../includes/env_loader.php';
 
+// Allow tests to inject an SQLite database via TEST_SQLITE_PATH
+if (!empty($GLOBALS['TESTING']) && getenv('TEST_SQLITE_PATH')) {
+    $pdo = new PDO('sqlite:' . getenv('TEST_SQLITE_PATH'));
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return;
+}
+
 // --- Manejo de modo debug ---
 // Activa la visualización de errores solo cuando la variable de entorno
 // APP_DEBUG esté establecida a 'true'. Por defecto esta variable es falsa.

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -2,6 +2,18 @@
 use PHPUnit\Framework\TestCase;
 
 class ApiTest extends TestCase {
+    private string $dbFile;
+
+    protected function setUp(): void {
+        $this->dbFile = tempnam(sys_get_temp_dir(), 'api');
+    }
+
+    protected function tearDown(): void {
+        if (file_exists($this->dbFile)) {
+            unlink($this->dbFile);
+        }
+    }
+
     private function runScript(string $script, array $server): array {
         $env = [
             'REQUEST_METHOD' => $server['REQUEST_METHOD'],
@@ -16,6 +28,7 @@ class ApiTest extends TestCase {
         $env['PATH'] = getenv('PATH');
         $env['REDIRECT_STATUS'] = '1';
         $env['SCRIPT_FILENAME'] = $script;
+        $env['TEST_SQLITE_PATH'] = $this->dbFile;
         $descriptor = [1 => ['pipe','w'], 2 => ['pipe','w']];
         $proc = proc_open($cmd, $descriptor, $pipes, null, $env);
         $output = stream_get_contents($pipes[1]);

--- a/tests/ForumCommentsTest.php
+++ b/tests/ForumCommentsTest.php
@@ -1,0 +1,102 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ForumCommentsTest extends TestCase {
+    private string $dbFile;
+
+    protected function setUp(): void {
+        $this->dbFile = tempnam(sys_get_temp_dir(), 'forum');
+    }
+
+    protected function tearDown(): void {
+        if (file_exists($this->dbFile)) {
+            unlink($this->dbFile);
+        }
+    }
+
+    private function runForum(array $env = []): array {
+        $script = realpath(__DIR__.'/../foro/index.php');
+        $prepend = realpath(__DIR__.'/fixtures/forum_prepend.php');
+        $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
+            escapeshellarg($prepend),
+            escapeshellarg($script)
+        );
+        $env = array_merge([
+            'PATH' => getenv('PATH'),
+            'REDIRECT_STATUS' => '1',
+            'SCRIPT_FILENAME' => $script,
+            'TEST_SQLITE_PATH' => $this->dbFile,
+            'FORUM_COMMENT_COOLDOWN' => '2',
+        ], $env);
+        $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        $status = proc_close($proc);
+        return [$status, $out, $err];
+    }
+
+    private function parseHeaders(string $out): array {
+        $headers = [];
+        foreach (explode("\n", trim($out)) as $line) {
+            if ($line === '' || str_starts_with($line, 'Status:')) {
+                continue;
+            }
+            if (strpos($line, ':') !== false) {
+                [$k, $v] = array_map('trim', explode(':', $line, 2));
+                $headers[$k][] = $v;
+            }
+        }
+        return $headers;
+    }
+
+    public function testValidCommentInserted(): void {
+        [$status, $out, $err] = $this->runForum([
+            'REQUEST_METHOD' => 'POST',
+            'FORUM_AGENT' => 'historian',
+            'FORUM_COMMENT' => 'Hola',
+        ]);
+        $this->assertSame(0, $status, $err);
+        $pdo = new PDO('sqlite:' . $this->dbFile);
+        $count = $pdo->query('SELECT COUNT(*) FROM forum_comments')->fetchColumn();
+        $this->assertSame(1, (int)$count);
+    }
+
+    public function testInvalidCsrfRejected(): void {
+        [$status, $out, $err] = $this->runForum([
+            'REQUEST_METHOD' => 'POST',
+            'FORUM_AGENT' => 'guide',
+            'FORUM_COMMENT' => 'fail',
+            'FORUM_TOKEN' => 'bad',
+        ]);
+        $this->assertSame(0, $status, $err);
+        $pdo = new PDO('sqlite:' . $this->dbFile);
+        $count = $pdo->query('SELECT COUNT(*) FROM forum_comments')->fetchColumn();
+        $this->assertSame(0, (int)$count);
+    }
+
+    public function testRateLimiting(): void {
+        [$status1, $out1, $err1] = $this->runForum([
+            'REQUEST_METHOD' => 'POST',
+            'FORUM_AGENT' => 'guide',
+            'FORUM_COMMENT' => 'first',
+        ]);
+        $this->assertSame(0, $status1, $err1);
+        $headers = $this->parseHeaders($out1);
+        preg_match('/PHPSESSID=([^;]+)/', $headers['Set-Cookie'][0] ?? '', $m);
+        $sid = $m[1] ?? '';
+        $this->assertNotEmpty($sid);
+
+        [$status2, $out2, $err2] = $this->runForum([
+            'REQUEST_METHOD' => 'POST',
+            'FORUM_AGENT' => 'guide',
+            'FORUM_COMMENT' => 'second',
+            'PHP_SESSION_ID' => $sid,
+        ]);
+        $this->assertSame(0, $status2, $err2);
+
+        $pdo = new PDO('sqlite:' . $this->dbFile);
+        $count = $pdo->query('SELECT COUNT(*) FROM forum_comments')->fetchColumn();
+        $this->assertSame(1, (int)$count);
+    }
+}
+?>

--- a/tests/LoginLogoutTest.php
+++ b/tests/LoginLogoutTest.php
@@ -2,6 +2,18 @@
 use PHPUnit\Framework\TestCase;
 
 class LoginLogoutTest extends TestCase {
+    private string $dbFile;
+
+    protected function setUp(): void {
+        $this->dbFile = tempnam(sys_get_temp_dir(), 'login');
+    }
+
+    protected function tearDown(): void {
+        if (file_exists($this->dbFile)) {
+            unlink($this->dbFile);
+        }
+    }
+
     private function runScript(string $script, array $env): array {
         $prepend = realpath(__DIR__.'/fixtures/login_prepend.php');
         $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
@@ -9,6 +21,7 @@ class LoginLogoutTest extends TestCase {
             escapeshellarg($script)
         );
         $env['PATH'] = getenv('PATH');
+        $env['TEST_SQLITE_PATH'] = $this->dbFile;
         $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
         $out = stream_get_contents($pipes[1]);
         $err = stream_get_contents($pipes[2]);

--- a/tests/fixtures/forum_prepend.php
+++ b/tests/fixtures/forum_prepend.php
@@ -1,0 +1,25 @@
+<?php
+chdir(__DIR__ . '/..');
+set_include_path(__DIR__ . PATH_SEPARATOR . get_include_path());
+$_SERVER['HTTP_HOST'] = 'localhost';
+$_SERVER['HTTPS'] = 'off';
+$GLOBALS['TESTING'] = true;
+require_once __DIR__ . '/../../includes/session.php';
+$sid = getenv('PHP_SESSION_ID');
+if ($sid) {
+    session_id($sid);
+}
+ensure_session_started();
+require_once __DIR__ . '/../../includes/csrf.php';
+$_SERVER['REQUEST_METHOD'] = getenv('REQUEST_METHOD') ?: 'GET';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $_POST['agent'] = getenv('FORUM_AGENT') ?: '';
+    $_POST['comment'] = getenv('FORUM_COMMENT') ?: '';
+    $token = getenv('FORUM_TOKEN');
+    if ($token !== false) {
+        $_POST['csrf_token'] = $token;
+    } else {
+        $_POST['csrf_token'] = get_csrf_token();
+    }
+}
+?>

--- a/tests/fixtures/prepend.php
+++ b/tests/fixtures/prepend.php
@@ -3,4 +3,8 @@ chdir(__DIR__ . '/..');
 set_include_path(__DIR__ . PATH_SEPARATOR . get_include_path());
 $_SERVER['HTTP_HOST'] = 'localhost';
 $_SERVER['HTTPS'] = 'off';
+$GLOBALS['TESTING'] = true;
+require_once __DIR__ . '/../../includes/session.php';
+ensure_session_started();
+require_once __DIR__ . '/../../includes/csrf.php';
 ?>


### PR DESCRIPTION
## Summary
- enable SQLite for tests when `TEST_SQLITE_PATH` is set
- extend fixtures to start sessions for tests
- allow API and login tests to use temporary SQLite databases
- add dedicated forum fixtures and tests for posting comments

## Testing
- `phpunit --filter ForumCommentsTest tests/ForumCommentsTest.php`
- `phpunit --configuration phpunit.xml` *(fails: ApiTest, LoginLogoutTest)*

------
https://chatgpt.com/codex/tasks/task_e_685204df5b248329a7c4baec8ec1880c