### PR TITLE
Add index.php overview docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@ Este directorio contiene una división del antiguo `nuevo4.md` en varios documen
 - [Historia](historia.md)
 - [Arqueología](arqueologia.md)
 - [Tradición](tradicion.md)
+- [Guía de index.php y menús](index-guide.md)

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -1,0 +1,41 @@
+# Guía de index.php y el menú deslizante
+
+## Secciones principales de `index.php`
+El archivo `index.php` actúa como portada del sitio y se organiza en varias secciones. Asignarles un identificador facilita enlazarlas desde el menú o desde otras páginas.
+
+| Sección (clase)                         | Contenido                                  | ID sugerido |
+|-----------------------------------------|---------------------------------------------|-------------|
+| `<header class="hero">`                | Escudo, texto editable y botón de historia | `hero`      |
+| `<section class="video-section">`      | Vídeo promocional de la zona                | `video`     |
+| `<section class="detailed-intro-section">` | Introducción a la memoria de la Hispanidad | `memoria`   |
+| `<section class="alternate-bg">`       | Tarjetas "Explora Nuestro Legado"           | `legado`    |
+| `<section>` (Personajes)                | Tarjetas de personajes históricos           | `personajes`|
+| `<section class="timeline-section-summary">` | Resumen cronológico                         | `timeline`  |
+| `<section class="immersion-section">`  | Invitación final a profundizar en la cultura| `cultura`   |
+
+Para usar anclas basta con añadir `id="..."` a cada elemento. Por ejemplo:
+```html
+<section id="video" class="video-section section spotlight-active">...
+```
+
+## Cómo `_header.php` carga los menús
+El archivo `_header.php` genera el panel deslizante derecho e inserta las diferentes secciones de menú leyendo los archivos de `fragments/menus/`:
+```php
+<?php
+if (file_exists(__DIR__ . '/fragments/menus/main-menu.html')) {
+    echo file_get_contents(__DIR__ . '/fragments/menus/main-menu.html');
+}
+?>
+```
+De igual manera se incluyen `tools-menu.html`, `admin-menu.php` y `social-menu.html` dentro de bloques `<div class="menu-section">`.
+
+## Personalización del menú deslizante y nuevas páginas
+* **Estilos**: modifica `assets/css/menus/consolidated-menu.css` para cambiar colores morado y oro viejo, anchura u otros efectos del panel `.menu-panel`.
+* **Comportamiento**: `js/menu-controller.js` gestiona la apertura y cierre con el atributo `data-menu-target`.
+* **Añadir páginas**: edita `fragments/menus/main-menu.html` para crear nuevos enlaces y añade el archivo correspondiente en el directorio del proyecto.
+
+Tras cualquier modificación ejecuta las pruebas de PHP y Python si las dependencias están instaladas:
+```bash
+vendor/bin/phpunit
+python -m unittest tests/test_flask_api.py
+```


### PR DESCRIPTION
## Summary
- add `docs/index-guide.md` explaining index.php sections, anchors, and the sliding menu
- link the new guide from `docs/README.md`

## Testing
- `python -m unittest tests/test_flask_api.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6852977b67108329b5b8e65c9945aef9