### PR TITLE
Remove redundant main.js inclusions

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -59,7 +59,6 @@ $post_slug = isset($_GET['post']) ? $_GET['post'] : null;
 <?php endif; ?>
 </main>
 <?php include __DIR__.'/_footer.php'; ?>
-<script src="/assets/js/main.js"></script>
 <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/demo_transparencia_movimiento.php
+++ b/demo_transparencia_movimiento.php
@@ -12,7 +12,6 @@
         </div>
     </section>
     <?php require_once __DIR__ . '/_footer.php'; ?>
-    <script src="/assets/js/main.js"></script>
     <script src="/js/layout.js"></script>
     <script>
     document.addEventListener('DOMContentLoaded', function() {

--- a/en_construccion.php
+++ b/en_construccion.php
@@ -7,7 +7,6 @@
         <p><a href="/index.php" class="cta-button">Volver al inicio</a></p>
     </main>
     <?php require_once __DIR__ . '/_footer.php'; ?>
-    <script src="/assets/js/main.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/homonexus.php
+++ b/homonexus.php
@@ -15,7 +15,6 @@
         <p>Utiliza el botón ∞ para activar o desactivar la metamorfosis de los menús y sentir el flujo telepático de la información.</p>
     </main>
     <?php require_once __DIR__ . '/_footer.php'; ?>
-    <script src="/assets/js/main.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -153,7 +153,6 @@ require_once __DIR__ . '/_header.php';
     </main>
 
     <?php require_once __DIR__ . '/_footer.php'; ?>
-    <script src="/assets/js/main.js"></script>
     <script src="/js/layout.js"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- remove duplicate main.js script tags from several PHP templates
- keep single inclusion in `_footer.php`

## Testing
- `composer install` *(fails: ext-dom missing)*
- `vendor/bin/phpunit` *(fails: php-cgi missing and DB/links issues)*
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6852977e4ea083298773c63bba352f31