### PR TITLE
Add image alt checker script

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,15 @@ colores morado y oro viejo que el resto de la cabecera.
 - Eliminado `js/header_loader.js` y referencias a dicho script, ya que la cabecera se carga ahora de forma estática.
 
 
+
+## Scripts de utilidad
+
+### Comprobación de etiquetas `<img>`
+
+Ejecuta el script `check_alt_texts.sh` para detectar imágenes sin atributo `alt` en los archivos PHP y HTML:
+
+```bash
+./scripts/check_alt_texts.sh
+```
+
+Puedes indicar una ruta concreta como argumento si solo quieres escanear una carpeta determinada. El comando mostrará las líneas problemáticas y devolverá un código de salida distinto de cero si encuentra imágenes sin descripción.

--- a/scripts/check_alt_texts.sh
+++ b/scripts/check_alt_texts.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# Scan HTML and PHP files for <img> tags without an alt attribute.
+# Usage: ./scripts/check_alt_texts.sh [directory]
+
+SEARCH_DIR="${1:-.}"
+
+# Find lines with <img> tags and filter those lacking the alt attribute.
+output=$(grep -rHn --exclude-dir=vendor --include='*.php' --include='*.html' '<img[^>]*>' "$SEARCH_DIR" | grep -v 'alt=' || true)
+
+if [[ -n "$output" ]]; then
+    echo "The following <img> tags are missing alt attributes:"
+    echo "$output"
+    exit 1
+else
+    echo "All <img> tags contain alt attributes."
+fi


### PR DESCRIPTION
## Summary
- scan for `<img>` tags without `alt` attribute via `check_alt_texts.sh`
- document script usage in README

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml`
- `vendor/bin/phpunit` *(fails: missing PHP extensions)*
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `./scripts/check_alt_texts.sh`

------
https://chatgpt.com/codex/tasks/task_e_68529a43d8888329b50eca38034790aa