### PR TITLE
Handle missing PDO connections gracefully

### DIFF
--- a/alfoz/alfoz.php
+++ b/alfoz/alfoz.php
@@ -4,6 +4,9 @@ ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';      // For is_admin_logged_in()
 require_once __DIR__ . '/../dashboard/db_connect.php'; // Provides $pdo
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+}
 require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 ?>
 <!DOCTYPE html>

--- a/contacto/contacto.php
+++ b/contacto/contacto.php
@@ -4,6 +4,9 @@ ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';      // For is_admin_logged_in()
 require_once __DIR__ . '/../dashboard/db_connect.php'; // Provides $pdo
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+}
 require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 ?>
 <!DOCTYPE html>

--- a/cultura/cultura.php
+++ b/cultura/cultura.php
@@ -4,6 +4,9 @@ ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';      // For is_admin_logged_in()
 require_once __DIR__ . '/../dashboard/db_connect.php'; // Provides $pdo
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+}
 require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 ?>
 <!DOCTYPE html>

--- a/dashboard/edit_texts.php
+++ b/dashboard/edit_texts.php
@@ -5,6 +5,10 @@ ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';
 require_once 'db_connect.php'; // Use include_path to allow test override
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+    return;
+}
 require_once __DIR__ . '/../includes/text_manager.php'; // For getText, though not directly used for display here
 require_once __DIR__ . '/../includes/csrf.php';
 

--- a/dashboard/login.php
+++ b/dashboard/login.php
@@ -7,6 +7,10 @@ require_once __DIR__ . '/../includes/auth.php';
 require_once __DIR__ . '/../includes/csrf.php';
 require_once 'dashboard/db_connect.php'; // Use include_path to allow test override
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+    return;
+}
 
 $error_message = '';
 $login_success = false;

--- a/dashboard/save_text.php
+++ b/dashboard/save_text.php
@@ -5,6 +5,10 @@ ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';
 require_once 'db_connect.php'; // Use include_path to allow test override
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+    return;
+}
 require_once __DIR__ . '/../includes/csrf.php';
 
 // Ensure user is admin and request is POST

--- a/dashboard/tienda_admin.php
+++ b/dashboard/tienda_admin.php
@@ -4,6 +4,10 @@ ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';
 require_once 'db_connect.php'; // Use include_path to allow test override
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+    return;
+}
 require_once __DIR__ . '/../includes/csrf.php';
 
 require_admin_login();

--- a/foro/index.php
+++ b/foro/index.php
@@ -6,6 +6,9 @@ require_once __DIR__ . '/../includes/config.php';
 require_once __DIR__ . '/../includes/csrf.php';
 $agents = require __DIR__ . '/../config/forum_agents.php';
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El foro est\xc3\xa1 en modo solo lectura.</p>";
+}
 
 // Ensure comments table exists
 if ($pdo) {

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -5,6 +5,9 @@ require_once __DIR__ . '/../includes/auth.php';      // For is_admin_logged_in()
 // dashboard/db_connect.php ya podría estar comentado, asegurarse que se incluye para $pdo
 require_once __DIR__ . '/../dashboard/db_connect.php'; // Necesario para $pdo
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+}
 require_once __DIR__ . '/../includes/text_manager.php'; // Necesario para editableText()
 require_once __DIR__ . '/../includes/csrf.php';
 

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -9,6 +9,9 @@ if (session_status() == PHP_SESSION_NONE) {
 // Asumimos que db_connect.php establece $pdo
 require_once __DIR__ . '/../dashboard/db_connect.php';
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+}
 // text_manager.php incluye auth.php, así que $is_admin estará disponible indirectamente.
 require_once __DIR__ . '/../includes/text_manager.php';
 require_once __DIR__ . '/../includes/ai_utils.php';

--- a/historia/subpaginas/auca_patricia_ubicacion.php
+++ b/historia/subpaginas/auca_patricia_ubicacion.php
@@ -66,6 +66,9 @@ $titulo_pagina_actual = $breadcrumb_tema_actual_texto; // Usar el título del te
 // Asumiendo que $pdo no está disponible aún, o para asegurar que sí lo esté.
 require_once __DIR__ . '/../../../dashboard/db_connect.php'; // Ajustar ruta si es necesario
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+}
 require_once __DIR__ . '/../../../includes/text_manager.php';
 ?>
 <!DOCTYPE html>

--- a/index.php
+++ b/index.php
@@ -4,6 +4,9 @@ ensure_session_started();
 require_once 'includes/auth.php';      // For is_admin_logged_in()
 require_once 'dashboard/db_connect.php'; // Provides $pdo
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+}
 require_once 'includes/text_manager.php';// For editableText()
 require_once 'includes/ai_utils.php';
 ?>

--- a/museo/editar_pieza.php
+++ b/museo/editar_pieza.php
@@ -4,6 +4,10 @@ ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';
 require_once __DIR__ . '/../dashboard/db_connect.php';
 /** @var PDO $pdo */
+if (!$pdo) {
+    echo "<p class='db-warning'>El sitio est\xc3\xa1 en modo solo lectura.</p>";
+    return;
+}
 require_once __DIR__ . '/../includes/csrf.php';
 
 require_admin_login();

--- a/tests/ReadOnlyModeTest.php
+++ b/tests/ReadOnlyModeTest.php
@@ -1,0 +1,29 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ReadOnlyModeTest extends TestCase {
+    private function runPage(string $script): array {
+        $prepend = realpath(__DIR__.'/fixtures/page_prepend_nodb.php');
+        $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
+            escapeshellarg($prepend),
+            escapeshellarg($script)
+        );
+        $env = [
+            'PATH' => getenv('PATH'),
+            'REDIRECT_STATUS' => '1',
+            'SCRIPT_FILENAME' => $script
+        ];
+        $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        $status = proc_close($proc);
+        return [$status, $out, $err];
+    }
+
+    public function testIndexShowsReadOnlyNotice(): void {
+        [$status, $out, $err] = $this->runPage(__DIR__.'/../index.php');
+        $this->assertSame(0, $status, $err);
+        $this->assertStringContainsString('modo solo lectura', $out);
+    }
+}
+?>

--- a/tests/fixtures/page_prepend_nodb.php
+++ b/tests/fixtures/page_prepend_nodb.php
@@ -1,0 +1,10 @@
+<?php
+chdir(__DIR__ . '/..');
+$_SERVER['HTTP_HOST'] = 'localhost';
+$_SERVER['HTTPS'] = 'off';
+$GLOBALS['TESTING'] = true;
+require_once __DIR__ . '/../../includes/session.php';
+ensure_session_started();
+require_once __DIR__ . '/../../includes/csrf.php';
+// Do not modify include_path so scripts use real files
+?>


### PR DESCRIPTION
## Summary
- check for missing PDO connections across PHP pages
- show a read-only notice if `$pdo` is not available
- add fixture and test for read-only mode

## Testing
- `phpunit tests` *(fails: Link target /lugares/lugares.html does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68529a45962c8329bd395b46368f61ad