### PR TITLE
Refactor history pages styles

### DIFF
--- a/assets/css/pages/historia_cerezo_index.css
+++ b/assets/css/pages/historia_cerezo_index.css
@@ -1,0 +1,4 @@
+        body { font-family: sans-serif; margin: 20px; }
+        nav ul { list-style-type: none; padding: 0; }
+        nav ul li { margin-bottom: 10px; }
+        nav h2 { margin-top: 30px; }

--- a/assets/css/pages/historia_galeria_historica_index.css
+++ b/assets/css/pages/historia_galeria_historica_index.css
@@ -1,0 +1,61 @@
+        /* Basic gallery styling */
+        .gallery-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 20px; /* Space between items */
+            justify-content: center;
+            padding: 20px;
+        }
+        .gallery-item {
+            background-color: #fdfaf6; /* Fondo alabastro claro */
+            border: 1px solid #ddd; /* Light grey border */
+            border-radius: 8px; /* Rounded corners */
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1); /* Subtle shadow */
+            width: calc(33.333% - 40px); /* Adjust for 3 items per row, considering gap */
+            margin-bottom: 20px;
+            overflow: hidden; /* Ensures content fits rounded corners */
+            text-align: center;
+        }
+        .gallery-item img, .gallery-item .file-placeholder {
+            width: 100%;
+            height: 200px; /* Fixed height for image/placeholder area */
+            object-fit: cover; /* Cover ensures image fills space, might crop */
+            border-bottom: 1px solid #ddd;
+        }
+        .gallery-item .file-placeholder {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: #f0f0f0; /* Light background for placeholder */
+            font-size: 3em; /* Larger icon */
+            color: #aaa; /* Grey icon color */
+        }
+        .gallery-item-description {
+            padding: 15px;
+            text-align: left;
+        }
+        .gallery-item-description h3 {
+            margin-top: 0;
+            color: var(--color-primario-purpura);
+        }
+        .gallery-item-description p {
+            font-size: 0.9em;
+            color: #333; /* Darker grey for text */
+            margin-bottom: 10px;
+        }
+        .gallery-item-description a {
+            font-size: 0.9em;
+            color: var(--color-secundario-dorado);
+        }
+
+        /* Responsive adjustments */
+        @media (max-width: 992px) {
+            .gallery-item {
+                width: calc(50% - 30px); /* 2 items per row */
+            }
+        }
+        @media (max-width: 768px) {
+            .gallery-item {
+                width: calc(100% - 20px); /* 1 item per row */
+            }
+        }

--- a/assets/css/pages/historia_subpaginas_alcazar_de_cerasio.css
+++ b/assets/css/pages/historia_subpaginas_alcazar_de_cerasio.css
@@ -1,0 +1,39 @@
+        .article-content p {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        .article-content h3 {
+            font-family: 'Cinzel', serif;
+            color: var(--color-secundario-dorado);
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        .article-content h4 {
+            font-family: 'Lora', serif;
+            font-style: italic;
+            color: var(--color-primario-purpura);
+            margin-top: 1em;
+            margin-bottom: 0.3em;
+        }
+        .article-content a {
+            color: var(--epic-gold-main);
+            text-decoration: underline;
+        }
+        .article-content a:hover {
+            color: var(--color-secundario-dorado);
+        }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 2em;
+            font-size: 0.9em;
+            color: var(--color-primario-purpura);
+            text-decoration: none;
+            border: 1px solid var(--color-primario-purpura);
+            padding: 0.5em 1em;
+            border-radius: 5px;
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .back-link:hover {
+            background-color: var(--color-primario-purpura);
+            color: var(--color-blanco-fondo);
+        }

--- a/assets/css/pages/historia_subpaginas_alfoz_cerezo_lantaron.css
+++ b/assets/css/pages/historia_subpaginas_alfoz_cerezo_lantaron.css
@@ -1,0 +1,39 @@
+        .article-content p {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        .article-content h3 {
+            font-family: 'Cinzel', serif;
+            color: var(--color-secundario-dorado);
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        .article-content h4 {
+            font-family: 'Lora', serif;
+            font-style: italic;
+            color: var(--color-primario-purpura);
+            margin-top: 1em;
+            margin-bottom: 0.3em;
+        }
+        .article-content a {
+            color: var(--epic-gold-main);
+            text-decoration: underline;
+        }
+        .article-content a:hover {
+            color: var(--color-secundario-dorado);
+        }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 2em;
+            font-size: 0.9em;
+            color: var(--color-primario-purpura);
+            text-decoration: none;
+            border: 1px solid var(--color-primario-purpura);
+            padding: 0.5em 1em;
+            border-radius: 5px;
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .back-link:hover {
+            background-color: var(--color-primario-purpura);
+            color: var(--color-blanco-fondo);
+        }

--- a/assets/css/pages/historia_subpaginas_auca_patricia_ubicacion.css
+++ b/assets/css/pages/historia_subpaginas_auca_patricia_ubicacion.css
@@ -1,0 +1,78 @@
+        .article-content p {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        .article-content h3 {
+            font-family: 'Cinzel', serif;
+            color: var(--color-secundario-dorado);
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        .article-content h4 {
+            font-family: 'Lora', serif;
+            font-style: italic;
+            color: var(--color-primario-purpura);
+            margin-top: 1em;
+            margin-bottom: 0.3em;
+        }
+        .article-content a {
+            color: var(--epic-gold-main);
+            text-decoration: underline;
+        }
+        .article-content a:hover {
+            color: var(--color-secundario-dorado);
+        }
+        .back-link {
+            display: inline-block;
+            margin-top: 1em; /* Adjusted from margin-bottom to be after breadcrumbs */
+            margin-bottom: 1em;
+            font-size: 0.9em;
+            color: var(--color-primario-purpura);
+            text-decoration: none;
+            border: 1px solid var(--color-primario-purpura);
+            padding: 0.5em 1em;
+            border-radius: 5px;
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .back-link:hover {
+            background-color: var(--color-primario-purpura);
+            color: var(--color-blanco-fondo);
+        }
+
+        /* Breadcrumb Styles */
+        .breadcrumb-container {
+            padding: 0.75em 0;
+            margin-bottom: 1em; /* Add some space below breadcrumbs */
+        }
+        .breadcrumb {
+            display: flex;
+            flex-wrap: wrap; /* Allow wrapping on small screens */
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            font-family: 'Lora', serif;
+            font-size: 0.9em;
+        }
+        .breadcrumb li {
+            padding: 0 0.3em;
+        }
+        .breadcrumb li a {
+            color: var(--color-primario-purpura);
+            text-decoration: none;
+        }
+        .breadcrumb li a:hover {
+            text-decoration: underline;
+        }
+        .breadcrumb li + li::before {
+            content: ">"; /* Separador */
+            padding-right: 0.5em;
+            color: var(--color-texto-secundario);
+        }
+        .breadcrumb li.active {
+            color: var(--color-texto-principal);
+            font-weight: bold;
+        }
+        .breadcrumb-error {
+            color: red;
+            font-size: 0.8em;
+        }

--- a/assets/css/pages/historia_subpaginas_becerro_galicano_origen_castilla.css
+++ b/assets/css/pages/historia_subpaginas_becerro_galicano_origen_castilla.css
@@ -1,0 +1,46 @@
+        .article-content p {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        .article-content h3 {
+            font-family: 'Cinzel', serif;
+            color: var(--color-secundario-dorado);
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        .article-content h4 {
+            font-family: 'Lora', serif;
+            font-style: italic;
+            color: var(--color-primario-purpura);
+            margin-top: 1em;
+            margin-bottom: 0.3em;
+        }
+        .article-content a {
+            color: var(--epic-gold-main);
+            text-decoration: underline;
+        }
+        .article-content a:hover {
+            color: var(--color-secundario-dorado);
+        }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 2em;
+            font-size: 0.9em;
+            color: var(--color-primario-purpura);
+            text-decoration: none;
+            border: 1px solid var(--color-primario-purpura);
+            padding: 0.5em 1em;
+            border-radius: 5px;
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .back-link:hover {
+            background-color: var(--color-primario-purpura);
+            color: var(--color-blanco-fondo);
+        }
+        .quote {
+            border-left: 3px solid var(--color-secundario-dorado);
+            padding-left: 1em;
+            margin-left: 1em;
+            font-style: italic;
+            color: #555;
+        }

--- a/assets/css/pages/historia_subpaginas_condes_castilla_alava_cerasio.css
+++ b/assets/css/pages/historia_subpaginas_condes_castilla_alava_cerasio.css
@@ -1,0 +1,45 @@
+        .article-content p {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        .article-content h3 {
+            font-family: 'Cinzel', serif;
+            color: var(--color-secundario-dorado);
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        .article-content h4 {
+            font-family: 'Lora', serif;
+            font-style: italic;
+            color: var(--color-primario-purpura);
+            margin-top: 1em;
+            margin-bottom: 0.3em;
+        }
+        .article-content a {
+            color: var(--epic-gold-main);
+            text-decoration: underline;
+        }
+        .article-content a:hover {
+            color: var(--color-secundario-dorado);
+        }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 2em;
+            font-size: 0.9em;
+            color: var(--color-primario-purpura);
+            text-decoration: none;
+            border: 1px solid var(--color-primario-purpura);
+            padding: 0.5em 1em;
+            border-radius: 5px;
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .back-link:hover {
+            background-color: var(--color-primario-purpura);
+            color: var(--color-blanco-fondo);
+        }
+        .highlight {
+            background-color: rgba(var(--color-secundario-dorado-rgb), 0.1);
+            padding: 0.2em 0.4em;
+            border-radius: 3px;
+            font-weight: bold;
+        }

--- a/assets/css/pages/historia_subpaginas_evidencia_arqueologica_cerezo.css
+++ b/assets/css/pages/historia_subpaginas_evidencia_arqueologica_cerezo.css
@@ -1,0 +1,52 @@
+        .article-content p {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        .article-content h3 {
+            font-family: 'Cinzel', serif;
+            color: var(--color-secundario-dorado);
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        .article-content h4 {
+            font-family: 'Lora', serif;
+            font-style: italic;
+            color: var(--color-primario-purpura);
+            margin-top: 1em;
+            margin-bottom: 0.3em;
+        }
+        .article-content a {
+            color: var(--epic-gold-main);
+            text-decoration: underline;
+        }
+        .article-content a:hover {
+            color: var(--color-secundario-dorado);
+        }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 2em;
+            font-size: 0.9em;
+            color: var(--color-primario-purpura);
+            text-decoration: none;
+            border: 1px solid var(--color-primario-purpura);
+            padding: 0.5em 1em;
+            border-radius: 5px;
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .back-link:hover {
+            background-color: var(--color-primario-purpura);
+            color: var(--color-blanco-fondo);
+        }
+        .image-gallery {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            justify-content: center;
+            margin-top: 1em;
+        }
+        .image-gallery img {
+            max-width: 200px;
+            max-height: 150px;
+            border-radius: 5px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }

--- a/assets/css/pages/historia_subpaginas_indice.css
+++ b/assets/css/pages/historia_subpaginas_indice.css
@@ -1,0 +1,49 @@
+        .subpage-index-list {
+            list-style-type: none;
+            padding: 0;
+        }
+        .subpage-index-item {
+            background-color: rgba(var(--color-primario-purpura-rgb), 0.05);
+            border: 1px solid rgba(var(--color-primario-purpura-rgb), 0.2);
+            padding: 1.5em;
+            margin-bottom: 1.5em;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.05);
+        }
+        .subpage-index-item h3 {
+            font-family: 'Cinzel', serif;
+            color: var(--color-primario-purpura);
+            margin-top: 0;
+            margin-bottom: 0.5em;
+        }
+        .subpage-index-item p {
+            font-family: 'Lora', serif;
+            line-height: 1.6;
+            color: var(--color-texto-principal);
+            margin-bottom: 1em;
+        }
+        .read-more {
+            display: inline-block;
+            padding: 0.6em 1.2em;
+            background-color: var(--epic-gold-main);
+            color: var(--color-blanco-fondo);
+            text-decoration: none;
+            border-radius: 5px;
+            font-weight: bold;
+            transition: background-color 0.3s ease;
+        }
+        .read-more:hover {
+            background-color: var(--color-secundario-dorado);
+            color: var(--color-negro-contraste);
+        }
+        .page-header.hero {
+            min-height: 30vh; /* Reduced height for index page */
+        }
+        .error-message {
+            background-color: #ffdddd;
+            border: 1px solid #ff0000;
+            color: #d8000c;
+            padding: 1em;
+            margin: 1em 0;
+            border-radius: 5px;
+        }

--- a/assets/css/pages/historia_subpaginas_legado_romano_emperadores_estructuras.css
+++ b/assets/css/pages/historia_subpaginas_legado_romano_emperadores_estructuras.css
@@ -1,0 +1,39 @@
+        .article-content p {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        .article-content h3 {
+            font-family: 'Cinzel', serif;
+            color: var(--color-secundario-dorado);
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        .article-content h4 {
+            font-family: 'Lora', serif;
+            font-style: italic;
+            color: var(--color-primario-purpura);
+            margin-top: 1em;
+            margin-bottom: 0.3em;
+        }
+        .article-content a {
+            color: var(--epic-gold-main);
+            text-decoration: underline;
+        }
+        .article-content a:hover {
+            color: var(--color-secundario-dorado);
+        }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 2em;
+            font-size: 0.9em;
+            color: var(--color-primario-purpura);
+            text-decoration: none;
+            border: 1px solid var(--color-primario-purpura);
+            padding: 0.5em 1em;
+            border-radius: 5px;
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .back-link:hover {
+            background-color: var(--color-primario-purpura);
+            color: var(--color-blanco-fondo);
+        }

--- a/assets/css/pages/historia_subpaginas_obispado_auca_cerezo.css
+++ b/assets/css/pages/historia_subpaginas_obispado_auca_cerezo.css
@@ -1,0 +1,5 @@
+        .article-content p { margin-bottom: 1em; line-height: 1.6; }
+        .article-content h3 { font-family: 'Cinzel', serif; color: var(--color-secundario-dorado); margin-top: 1.5em; margin-bottom: 0.5em; }
+        .article-content h4 { font-family: 'Lora', serif; font-style: italic; color: var(--color-primario-purpura); margin-top: 1em; margin-bottom: 0.3em; }
+        .back-link { display:inline-block; margin-bottom:2em; font-size:0.9em; color:var(--color-primario-purpura); text-decoration:none; border:1px solid var(--color-primario-purpura); padding:0.5em 1em; border-radius:5px; transition:background-color 0.3s, color 0.3s; }
+        .back-link:hover { background-color:var(--color-primario-purpura); color:var(--color-blanco-fondo); }

--- a/assets/css/pages/historia_subpaginas_obispado_oca_auca.css
+++ b/assets/css/pages/historia_subpaginas_obispado_oca_auca.css
@@ -1,0 +1,39 @@
+        .article-content p {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        .article-content h3 {
+            font-family: 'Cinzel', serif;
+            color: var(--color-secundario-dorado);
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        .article-content h4 {
+            font-family: 'Lora', serif;
+            font-style: italic;
+            color: var(--color-primario-purpura);
+            margin-top: 1em;
+            margin-bottom: 0.3em;
+        }
+        .article-content a {
+            color: var(--epic-gold-main);
+            text-decoration: underline;
+        }
+        .article-content a:hover {
+            color: var(--color-secundario-dorado);
+        }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 2em;
+            font-size: 0.9em;
+            color: var(--color-primario-purpura);
+            text-decoration: none;
+            border: 1px solid var(--color-primario-purpura);
+            padding: 0.5em 1em;
+            border-radius: 5px;
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .back-link:hover {
+            background-color: var(--color-primario-purpura);
+            color: var(--color-blanco-fondo);
+        }

--- a/assets/css/pages/historia_subpaginas_origenes_castellano_vulgar.css
+++ b/assets/css/pages/historia_subpaginas_origenes_castellano_vulgar.css
@@ -1,0 +1,39 @@
+        .article-content p {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        .article-content h3 {
+            font-family: 'Cinzel', serif;
+            color: var(--color-secundario-dorado);
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        .article-content h4 {
+            font-family: 'Lora', serif;
+            font-style: italic;
+            color: var(--color-primario-purpura);
+            margin-top: 1em;
+            margin-bottom: 0.3em;
+        }
+        .article-content a {
+            color: var(--epic-gold-main);
+            text-decoration: underline;
+        }
+        .article-content a:hover {
+            color: var(--color-secundario-dorado);
+        }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 2em;
+            font-size: 0.9em;
+            color: var(--color-primario-purpura);
+            text-decoration: none;
+            border: 1px solid var(--color-primario-purpura);
+            padding: 0.5em 1em;
+            border-radius: 5px;
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .back-link:hover {
+            background-color: var(--color-primario-purpura);
+            color: var(--color-blanco-fondo);
+        }

--- a/assets/css/pages/historia_subpaginas_san_vitores_san_formerio.css
+++ b/assets/css/pages/historia_subpaginas_san_vitores_san_formerio.css
@@ -1,0 +1,39 @@
+        .article-content p {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        .article-content h3 {
+            font-family: 'Cinzel', serif;
+            color: var(--color-secundario-dorado);
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        .article-content h4 {
+            font-family: 'Lora', serif;
+            font-style: italic;
+            color: var(--color-primario-purpura);
+            margin-top: 1em;
+            margin-bottom: 0.3em;
+        }
+        .article-content a {
+            color: var(--epic-gold-main);
+            text-decoration: underline;
+        }
+        .article-content a:hover {
+            color: var(--color-secundario-dorado);
+        }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 2em;
+            font-size: 0.9em;
+            color: var(--color-primario-purpura);
+            text-decoration: none;
+            border: 1px solid var(--color-primario-purpura);
+            padding: 0.5em 1em;
+            border-radius: 5px;
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .back-link:hover {
+            background-color: var(--color-primario-purpura);
+            color: var(--color-blanco-fondo);
+        }

--- a/historia/galeria_historica/index.php
+++ b/historia/galeria_historica/index.php
@@ -1,86 +1,21 @@
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
 <head>
-    <style>
-        /* Basic gallery styling */
-        .gallery-container {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 20px; /* Space between items */
-            justify-content: center;
-            padding: 20px;
-        }
-        .gallery-item {
-            background-color: #fdfaf6; /* Fondo alabastro claro */
-            border: 1px solid #ddd; /* Light grey border */
-            border-radius: 8px; /* Rounded corners */
-            box-shadow: 0 4px 8px rgba(0,0,0,0.1); /* Subtle shadow */
-            width: calc(33.333% - 40px); /* Adjust for 3 items per row, considering gap */
-            margin-bottom: 20px;
-            overflow: hidden; /* Ensures content fits rounded corners */
-            text-align: center;
-        }
-        .gallery-item img, .gallery-item .file-placeholder {
-            width: 100%;
-            height: 200px; /* Fixed height for image/placeholder area */
-            object-fit: cover; /* Cover ensures image fills space, might crop */
-            border-bottom: 1px solid #ddd;
-        }
-        .gallery-item .file-placeholder {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background-color: #f0f0f0; /* Light background for placeholder */
-            font-size: 3em; /* Larger icon */
-            color: #aaa; /* Grey icon color */
-        }
-        .gallery-item-description {
-            padding: 15px;
-            text-align: left;
-        }
-        .gallery-item-description h3 {
-            margin-top: 0;
-            color: var(--color-primario-purpura);
-        }
-        .gallery-item-description p {
-            font-size: 0.9em;
-            color: #333; /* Darker grey for text */
-            margin-bottom: 10px;
-        }
-        .gallery-item-description a {
-            font-size: 0.9em;
-            color: var(--color-secundario-dorado);
-        }
-
-        /* Responsive adjustments */
-        @media (max-width: 992px) {
-            .gallery-item {
-                width: calc(50% - 30px); /* 2 items per row */
-            }
-        }
-        @media (max-width: 768px) {
-            .gallery-item {
-                width: calc(100% - 20px); /* 1 item per row */
-            }
-        }
-    </style>
 </head>
 <body>
 
     <?php require_once __DIR__ . '/../../_header.php'; ?>
-
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_historia_background.jpg');">
         <div class="hero-content">
             <h1>Galería Histórica</h1>
             <p>Imágenes, documentos y artefactos visuales que narran la rica historia del Condado de Castilla y sus gentes.</p>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container">
                 <h2 class="section-title">Tesoros Visuales de Nuestra Historia</h2>
                 <p>Explora nuestra colección de imágenes históricas, fotografías de artefactos, mapas antiguos y representaciones de momentos clave. Cada elemento cuenta con una descripción para contextualizar su importancia.</p>
-
                 <div class="gallery-container">
                     <!-- Example Gallery Item 1: Image -->
                     <div class="gallery-item">
@@ -90,27 +25,18 @@
                             <p>Una vista evocadora del Alcázar de Cerasio al atardecer. Esta fortaleza fue crucial en la defensa y consolidación temprana de Castilla.</p>
                         </div>
                     </div>
-
                      <div class="gallery-item">
                         <img src="/assets/img/Llana.jpg" alt="Iglesia de la Llana">
-                        <div class="gallery-item-description">
                             <h3>Iglesia de la Llana</h3>
                             <p>Fotografía de la Iglesia de la Llana, un importante hito arquitectónico y espiritual en la región, con posibles orígenes en una mezquita.</p>
-                        </div>
-                    </div>
-                     <div class="gallery-item">
                         <img src="/assets/img/Muralla.jpg" alt="Restos de Muralla">
-                        <div class="gallery-item-description">
                             <h3>Restos de Muralla</h3>
                             <p>Vestigios de las antiguas murallas que protegían asentamientos clave en el Condado de Castilla, testigos de un pasado defensivo.</p>
-                        </div>
-                    </div>
                 </div>
                 <p class="text-center" style="margin-top: 30px;"><em>Esta galería se irá enriqueciendo con más elementos visuales y documentales. Se recomienda usar Font Awesome para los iconos de archivo (PDF, TXT, DOC), por lo que el CSS de la página principal o _header.php debería incluir la biblioteca.</em></p>
             </div>
         </section>
     </main>
-
     <?php require_once __DIR__ . '/../../_footer.php'; ?>
     <script src="/js/layout.js"></script>
     <!-- Consider adding a link to Font Awesome if not already included globally, e.g., in _header.php or main CSS -->

--- a/historia/subpaginas/alcazar_de_cerasio.php
+++ b/historia/subpaginas/alcazar_de_cerasio.php
@@ -1,62 +1,19 @@
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
 <head>
-    <style>
-        .article-content p {
-            margin-bottom: 1em;
-            line-height: 1.6;
-        }
-        .article-content h3 {
-            font-family: 'Cinzel', serif;
-            color: var(--color-secundario-dorado);
-            margin-top: 1.5em;
-            margin-bottom: 0.5em;
-        }
-        .article-content h4 {
-            font-family: 'Lora', serif;
-            font-style: italic;
-            color: var(--color-primario-purpura);
-            margin-top: 1em;
-            margin-bottom: 0.3em;
-        }
-        .article-content a {
-            color: var(--epic-gold-main);
-            text-decoration: underline;
-        }
-        .article-content a:hover {
-            color: var(--color-secundario-dorado);
-        }
-        .back-link {
-            display: inline-block;
-            margin-bottom: 2em;
-            font-size: 0.9em;
-            color: var(--color-primario-purpura);
-            text-decoration: none;
-            border: 1px solid var(--color-primario-purpura);
-            padding: 0.5em 1em;
-            border-radius: 5px;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .back-link:hover {
-            background-color: var(--color-primario-purpura);
-            color: var(--color-blanco-fondo);
-        }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
-
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/alcazar_detalle.jpg'); min-height: 40vh;">
         <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
             <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">El Alcázar de Cerasio: Fortaleza de Castilla</h1>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
-
                 <h3>Construcción y Materiales</h3>
                 <p>Y ver cómo Pancorvo del Alfoz de cerezo, Valpuesta del Alfoz de cerezo, y Auca se vinculan al origen de Castilla que es el Alcázar de Alabastro puro de Cerasio con sus documentados condes de Castilla y Alava y sus 1200 metros de largo con capacidad para albergar el Palacio o Alcázar su corte condal de funcionarios y sus soldados.</p>
                 <p>La Mezquita de Yanna, el hijo del Conde Conde Casio, en el Alcázar de Cerasio.</p>
@@ -65,23 +22,17 @@
                 <p>Medimos el Alcázar Árabe en forma de media luna y construido con los escombros de Auka Patricia y yeso. No hay Alcázar sin Alfoz ni Alfoz sin Alcazar hasta la expansión del Condado de Castilla.</p>
                 <p>El Alcázar de Cerasio, el Alcázar de Conde Casio en Cerezo de río Tirón, aún se puede ver el gajo de naranja de su Alcazaba, el Alcázar estaba donde hoy está la Iglesia de Villalba, con su pueblo amurallado debajo...</p>
                 <p>Cuando digo que cerezo es el Alcázar del conde Casio, pues es Árabe y en el 840 pasa a manos cristianas, ¿Quién ha construido un fabulo Alcázar en Cerezo que se puede comparar, aunque perdiendo, lógico, con la Alhambra de Granada? Hay que tener en cuenta que el de cerezo se construyó sobre el año 700 y la Alhambra en 1300... Por cierto nuestro Alcázar estaba en la iglesia de Villalba, lo que veis con forma de gajo de naranja es la Alcazaba del Alcázar.</p>
-
                 <h4>Importancia Estratégica y Gubernamental</h4>
                 <p>Desde Cerezo se gobernaba las Bardulias, dese la cuidad de Auka Patricia (patriniani) con nuestra episcopi de San Martín con 116 metros de largo, toda la provincia Cantábrica en tiempos visigodos (los montes de Cantabria en la Rioja). Somos el Origen de Castilla y del Idioma Castellano y la ciudad de Auka Patricia. Con los restos de la ciudad construyeron el Alcázar con el el Alfoz de Castilla, y sus Condes de Castilla y Álava gobernando desde su Alcazar en la Alcazaba.</p>
                 <p>En la Ciudad de Auca Patricia capital visigoda de la Cantabrica, desde donde se gobiernan las bardulias, desde la civittate Patricia o patriciani, desde la episcopi de San Martín, desde el Monumental Alcázar con su alfoz que se construyo con los restos de una civita Romana de oca, capital de la cantábrica pues cesar desembarco en segisamaclo sus legiones para su conquista. En Cerezo de Río Tirón origen de Castilla de su Cultura y de su Idioma con Valuesta en su Alfoz.</p>
                 <p>Alcazar de Cerasio 1200 metros de puro Alabastro, desde donde gobernaron los primeros Condes de Castilla y sin ninguna duda que es cuna e Origen de Castilla su Cultura e Idioma Castellano, hecho con las ruinas de Civitate Auca Patricia capital de Cantabria y las Bardulias.</p>
-
                 <h4>El Conde Casio y el Alcázar</h4>
                 <p>Un Conde Visigodo por obligación debe tener una ciudad romana que gobierna. Los primeros escritos sobre Castilla hablan de Auka Patriciani. Y la episcopi de San Martín que adjunto foto de sombra de una monumental ruina de más de 114 metros de largo enterrada en trigo y olvido y lugar de descanso de los primeros condes de Castilla, haciendo la episcopi el origen olvidado de nuestra cultura.</p>
                 <p>El Conde Casio cuna de los Banucasi siendo un Conde Visigodo por obligación debe gobernar una ciudad Patricia Romana y Auca Patricia es la correcta, capital de la cantábrica, ya el nombre de nuestra ciudadela con rango de Alcázar con capacidad para albergar un Conde sus funcionarios y soldados con sus familias da pie a confundir, Cerasio y Casio, en la civitate de Auca Patriciani, El Alcázar del Conde Casio.</p>
                 <p>El origen de Castilla es Cerasio u su Alcázar de Alabastro de 1200 metros de largo con capacidad para albergar el Alcázar del Conde de Castilla y Alava a su corte de funcionarios sus soldados y familias, documentado que los primeros condes de Castilla gobernaron desde el Alcázar de Cerasio en Cerezo de Río Tirón. Con su extenso alfoz que cuenta con Valpuesta y Pancorvo dentro. El Alcázar fue construido en el siglo VIII por el Conde Casio, el Alcázar de Cerasio, con los restos de la ciudad romana de Auca Patriciani capital de la Cantabrica desde donde se gobernaban las Vardulias. La antigua segisamam donde César Augusto puso su cuartel general en las guerras Cantabras.</p>
-
             </div>
         </section>
     </main>
-
-
-
     <?php require_once __DIR__ . '/../../_footer.php'; ?>
     <script src="/js/layout.js"></script>
 </body>

--- a/historia/subpaginas/alfoz_cerezo_lantaron.php
+++ b/historia/subpaginas/alfoz_cerezo_lantaron.php
@@ -1,84 +1,35 @@
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
 <head>
-    <style>
-        .article-content p {
-            margin-bottom: 1em;
-            line-height: 1.6;
-        }
-        .article-content h3 {
-            font-family: 'Cinzel', serif;
-            color: var(--color-secundario-dorado);
-            margin-top: 1.5em;
-            margin-bottom: 0.5em;
-        }
-        .article-content h4 {
-            font-family: 'Lora', serif;
-            font-style: italic;
-            color: var(--color-primario-purpura);
-            margin-top: 1em;
-            margin-bottom: 0.3em;
-        }
-        .article-content a {
-            color: var(--epic-gold-main);
-            text-decoration: underline;
-        }
-        .article-content a:hover {
-            color: var(--color-secundario-dorado);
-        }
-        .back-link {
-            display: inline-block;
-            margin-bottom: 2em;
-            font-size: 0.9em;
-            color: var(--color-primario-purpura);
-            text-decoration: none;
-            border: 1px solid var(--color-primario-purpura);
-            padding: 0.5em 1em;
-            border-radius: 5px;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .back-link:hover {
-            background-color: var(--color-primario-purpura);
-            color: var(--color-blanco-fondo);
-        }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
-
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/alfoz_panoramica.jpg'); min-height: 40vh;">
         <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
             <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">El Alfoz de Cerezo y Lantarón: Territorio Histórico</h1>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
-
                 <h3>Definición y Extensión del Alfoz</h3>
                 <p>Y ver cómo Pancorvo del Alfoz de cerezo, Valpuesta del Alfoz de cerezo, y Auca se vinculan al origen de Castilla que es el Alcázar de Alabastro puro de Cerasio con sus documentados condes de Castilla y Alava...</p>
                 <p>Obispos de Auca, sabiendo que el valle de asur esta encima de Quintanilleja y la iglesia de San Millan en el Circo de Setefenestras, no leyendo ninguna antigua referencia a Villafranca como Auca ni como ciudad y sin tener esta restos que la abalen como ciudad Patricia capital de la Cantabrica. Cerezo que si tiene restos de una ciudad romana con un decumanus de 1200 metros ademas es nombrada como ciudad en varios contextos, una episcopi de mas 116 metros de largo en San Martin, podemos decir que Cerasio es la antigua Auca Patricia y san Felix de Oca un suburbio de Cerezo al igual que Pedroso o Belorado o Oxmilla, da fe el grandioso Alfoz de Cerezo.</p>
                 <p>El Alfoz de Cerezo Y Lantarón - Pegado a Álava frontera con el Imperio Musulmán, con Castella Romana, un Alcázar de Alabastro, tres castillos mas, el Gurugú, el Culebrón y segisamunculum, con tres probados Condes de Castilla, la batalla de la Morcuera del primer conde de Castilla Rodrigo en su Alfoz, con Diego Rodríguez Porcelos en su Alfoz, en quintanilleja la iglesia de san Millán (Auca), con el valle de assur entre Recilla y Quintanilla de las dueñas (Auca), con el Pedroso en su Alfoz, con Valpuesta en su Alfoz, cerca del Pedroso (Auca), con Jueces de Casilla, con Merinos Mayores de Castilla, con mercado, 16 hazañas en el fuero viejo de Castilla, Con un obispado en San Martín (Auca).</p>
-
                 <h4>El Alfoz en la Batalla de la Morcuera y los Primeros Condes</h4>
                 <p>Rodrigo Primer Conde de Castilla. Que si se lee la batalla de la Morcuera podemos ver donde estaban todos sus Castillos y curiosamente estaban dentro del Alfoz de Cerezo Y Lantarón como dicen el Fuero de Cerezo y montes de Oca en su mismo centro del Alfoz, la hoz de la Morcuera, seria interesante comparar los castillos de Rodrigo con el Alfoz de Cerezo para ver que todos menos uno que esta en Álava están en Alfoz de Cerezo y Lantaron (y el de Álava tambien lo era de Lantarón).</p>
                 <p>También seria interesante estudiar los Castillos del Alfoz de Cerezo y Lantaron con Cellorigo, Pancorbo, Ibrillos, Grañón, la hoz de la Morcuera de cuya batalla de la Morcuera que describen los castillos que le destruyen a Rodrigo primer Conde de Castilla puede presumir el Alfoz de tener todos los castillos dentro de sus fronteras.</p>
                 <p>El Condado de Castilla nace en Alcazar de cerasio, en los Obispados de Oca y Valpuesta, en el Alfoz de Cerasio y Lantarón.</p>
-
                 <h4>Importancia en el Origen de Castilla</h4>
                 <p>Si Lara y Burgos son conquistados por Castilla, ¿Cual es el Alcázar y el Alfoz de Castilla? Por cierto quita la aberración de foto del sarcófago de Cobarrubias… haber si voy a saber paleográfica y soy capaz de leer tan burda falsificación… Que tengo fe en que Fernán González esta enterrado en San Pedro de Arlanza fundado por Gonzalo Téllez Conde de Cerezo y Lantarón – Conde de Castilla y Álava.</p>
                 <p>En el Origen de Castilla, aquí tenemos Castellano vulgar y el origen tapado y protegido por metro y medio de polvo de miles de años. En el mismo Alfoz que Valpuesta, el origen del idioma Castellano. Si te atreves a subir...</p>
                 <p>Y un Conde necesita un Alcázar o Palacio donde reside la corte condal, sus jueces, sus administrativos, sus soldados... Así en el Alcázar de Cerasio el Alcázar del Conde Casio, tiene mas de 800 metros de largo, mas la ciudad a sus pies y un grandioso Alfoz que gobernar, veamos si la Batalla de la Morcuera se sale del Alfoz de Cerezo y Lantarón. Que Rodrigo, Ruderik el primer conde de Castilla tambien lo era de Álava ¿con cuatro castillos juntos?</p>
                 <p>Pensar que Cerezo y Lantarón junto con Álava hacen una Linea fronteriza con el Impero Musulmán, ya las merindades quedan después de estas zonas así que un conde en la frontera es en Cerezo y Lantarón con Álava.</p>
-
             </div>
         </section>
     </main>
-
-
-
     <?php require_once __DIR__ . '/../../_footer.php'; ?>
     <script src="/js/layout.js"></script>
 </body>

--- a/historia/subpaginas/auca_patricia_ubicacion.php
+++ b/historia/subpaginas/auca_patricia_ubicacion.php
@@ -4,28 +4,21 @@ $id_tema_actual = "auca_patricia_ubicacion"; // ID de esta página específica
 // Variables para los breadcrumbs
 $breadcrumb_inicio_url = "/index.php"; // O la URL correcta de tu página de inicio
 $breadcrumb_inicio_texto = "Inicio";
-
 $breadcrumb_historia_url = "/historia/historia.html"; // Enlace a la página principal de historia
 $breadcrumb_historia_texto = "Nuestra Historia"; // Texto por defecto
-
 $breadcrumb_indice_url = "/historia/subpaginas_indice.php";
 $breadcrumb_indice_texto = "Índice Detallado"; // Texto por defecto
-
 $breadcrumb_tema_actual_texto = "Tema Actual"; // Texto por defecto
-
 // Cargar JSON de índice detallado
 $json_indice_detallado_path = __DIR__ . '/../../../data/historia/indice_detallado.json';
 $indice_detallado_data = null;
 $error_message_breadcrumb = '';
-
 if (file_exists($json_indice_detallado_path)) {
     $json_content = file_get_contents($json_indice_detallado_path);
     $decoded_data = json_decode($json_content, true);
-
     if (json_last_error() === JSON_ERROR_NONE) {
         $indice_detallado_data = $decoded_data;
         $breadcrumb_indice_texto = $indice_detallado_data['titulo_pagina'] ?? $breadcrumb_indice_texto;
-
         // Encontrar el título del tema actual
         if (isset($indice_detallado_data['temas_detallados']) && is_array($indice_detallado_data['temas_detallados'])) {
             foreach ($indice_detallado_data['temas_detallados'] as $tema) {
@@ -41,28 +34,20 @@ if (file_exists($json_indice_detallado_path)) {
 } else {
     $error_message_breadcrumb .= 'No se pudo encontrar indice_detallado.json. ';
 }
-
 // Cargar JSON de historia_indice (para el título de "Nuestra Historia", si aplica)
 $json_historia_indice_path = __DIR__ . '/../../../data/historia/historia_indice.json';
 if (file_exists($json_historia_indice_path)) {
     $json_content_hist = file_get_contents($json_historia_indice_path);
     $decoded_data_hist = json_decode($json_content_hist, true);
-
     if (json_last_error() === JSON_ERROR_NONE && isset($decoded_data_hist['titulo_general'])) {
         // Podrías buscar una sección específica si la estructura lo permitiera mejor.
         // Por ahora, si queremos ser más específicos, podríamos tomar el título de una sección si coincide con "historia.html"
         // o simplemente usar el $breadcrumb_historia_texto = $decoded_data_hist['titulo_general']; si es apropiado.
         // Para este ejemplo, mantendré el "Nuestra Historia" fijo ya que la estructura de historia_indice.json no está diseñada para esto.
-    } else {
         $error_message_breadcrumb .= 'Error al decodificar historia_indice.json o título no encontrado. ';
-    }
-} else {
     $error_message_breadcrumb .= 'No se pudo encontrar historia_indice.json. ';
-}
-
 // Título de la página actual (podría venir del JSON si esta página también fuera generada por el script)
 $titulo_pagina_actual = $breadcrumb_tema_actual_texto; // Usar el título del tema para el <title>
-
 // Asumiendo que $pdo no está disponible aún, o para asegurar que sí lo esté.
 require_once __DIR__ . '/../../../dashboard/db_connect.php'; // Ajustar ruta si es necesario
 /** @var PDO $pdo */
@@ -71,103 +56,21 @@ require_once __DIR__ . '/../../../includes/text_manager.php';
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../../includes/load_page_css.php'; ?>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo htmlspecialchars($titulo_pagina_actual); ?> - Cerezo de Río Tirón</title>
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
-
     <!-- Google Fonts, FontAwesome, and epic_theme.css are now in head_common.php -->
-    <style>
-        .article-content p {
-            margin-bottom: 1em;
-            line-height: 1.6;
-        }
-        .article-content h3 {
-            font-family: 'Cinzel', serif;
-            color: var(--color-secundario-dorado);
-            margin-top: 1.5em;
-            margin-bottom: 0.5em;
-        }
-        .article-content h4 {
-            font-family: 'Lora', serif;
-            font-style: italic;
-            color: var(--color-primario-purpura);
-            margin-top: 1em;
-            margin-bottom: 0.3em;
-        }
-        .article-content a {
-            color: var(--epic-gold-main);
-            text-decoration: underline;
-        }
-        .article-content a:hover {
-            color: var(--color-secundario-dorado);
-        }
-        .back-link {
-            display: inline-block;
-            margin-top: 1em; /* Adjusted from margin-bottom to be after breadcrumbs */
-            margin-bottom: 1em;
-            font-size: 0.9em;
-            color: var(--color-primario-purpura);
-            text-decoration: none;
-            border: 1px solid var(--color-primario-purpura);
-            padding: 0.5em 1em;
-            border-radius: 5px;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .back-link:hover {
-            background-color: var(--color-primario-purpura);
-            color: var(--color-blanco-fondo);
-        }
-
-        /* Breadcrumb Styles */
-        .breadcrumb-container {
-            padding: 0.75em 0;
-            margin-bottom: 1em; /* Add some space below breadcrumbs */
-        }
-        .breadcrumb {
-            display: flex;
-            flex-wrap: wrap; /* Allow wrapping on small screens */
-            list-style: none;
-            padding: 0;
-            margin: 0;
-            font-family: 'Lora', serif;
-            font-size: 0.9em;
-        }
-        .breadcrumb li {
-            padding: 0 0.3em;
-        }
-        .breadcrumb li a {
-            color: var(--color-primario-purpura);
-            text-decoration: none;
-        }
-        .breadcrumb li a:hover {
-            text-decoration: underline;
-        }
-        .breadcrumb li + li::before {
-            content: ">"; /* Separador */
-            padding-right: 0.5em;
-            color: var(--color-texto-secundario);
-        }
-        .breadcrumb li.active {
-            color: var(--color-texto-principal);
-            font-weight: bold;
-        }
-        .breadcrumb-error {
-            color: red;
-            font-size: 0.8em;
-        }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../../../_header.php'; ?>
-
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/paisaje_cerezo.jpg'); min-height: 40vh;">
         <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
             <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);"><?php echo htmlspecialchars($titulo_pagina_actual); ?></h1>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container">
@@ -184,58 +87,46 @@ require_once __DIR__ . '/../../../includes/text_manager.php';
                         <p class="breadcrumb-error">Error en datos para breadcrumbs: <?php echo htmlspecialchars(trim($error_message_breadcrumb)); ?></p>
                     <?php endif; ?>
                 </div>
-
                 <div class="article-content">
                     <p><a href="/historia/subpaginas_indice.php" class="back-link">&laquo; Volver al Índice Detallado</a></p>
-
                     <h3>La Identificación de Auca Patricia</h3>
                     <?php editableText('auca_identificacion_p1', $pdo, 'Y hay muchas, muchas referencias a Auca como ciudad Patricia Romana antes de ser ser Patricia Visigoda. Capital de la provincia Cantabrica y Vardulias... Que luego no digan que Castilla y Vardulias y auka paterniani no están relacionadas con Cerasio y el origen de Castilla.', 'p', ''); ?>
                     <?php editableText('auca_identificacion_p2', $pdo, 'Aquí se evidencia la indefinición de la localización de la civitate, de la ciudad de Auca. Pues si sabemos dónde hay una ciudad Romana con 1200 metros de decumanus y 1200 metros de cardo... En Cerezo de Río Tirón. ciudad de Auca.', 'p', ''); ?>
-
                     <h4>Dimensiones y Estructura Urbana Romana</h4>
                     <?php editableText('auca_dimensiones_p1', $pdo, 'Y la ciudad de Oca, Auca Patricia, Civitate Auki Patriciani, Civita de Aucam, fue fundada por Cesar Augusto en Segisamam donde puso su cuartel General en las guerras cántabras, convirtiéndola en la Capital de la Cantábrica. Donde estaba el ultimo puerto Fluvial navegable del Río Ebro, en el Gurugu de Segisamam. Aun se puede ver el puerto romano en el termino de Glera de los Celox (barcos de legionarios romanos en ríos).', 'p', ''); ?>
                     <p>Y medir las puertas de la ciudad que encajan en tamaño posición y orientación con la decumanus de Auca Patricia.</p>
                     <p>En Cerezo de Río Tirón que actualmente y siempre es Oca, hay una civita Romana de 144 hectáreas rodeada de murallas romanas de hormigón romano de 6 metros de ancho, mas sus segunda murallas y fosos... una capital Patricia con Obispado.</p>
                     <p>Las calzadas romanas y el ultimo puerto fluvial romano sobre el rio Ebro esta en la Glera de los Celox (embarcación romana de legion en Rios). En Cerezo de Rio tirón aun puedes ver miles de ruinas enfrente de su Alcázar, puedes medir la carretera que va desde la caseta(cruce entre Tormmantos y Belorado) hasta el Túnel 1200 metros de Cardo (Norte-Sur) y 1200 metros de Decumanus (Este-Oeste) aun se puede apreciar los cimientos de la puerta decumanus siniestra. En esos 1200 km veras a ambos lados de la carreta las ruinas de la civita de Auca Patricia la capital de Cantabria pues Cesar Augusto puso su cuartel general en las Guerras Cántabras en territorio Berón, enfrente de Segisamam en el ultimo puerto navegable del río Ebro, en la calzada de Tarraco a Astorga, al irse Augusto, la provincia recién conquistada siguió gobernándose desde la silla de Cesar Augusto hasta su destrucción en el 714 por Muza Ibn Nuhasir.</p>
                     <p>Aun si dudas puedes ver que la civita esta rodeada por el paseo de la cárcava(foso romano) pues no hay cárcava vista, y si escabas un poco podrás ver la murallas de hormigón de 6 metros rodeando 144 hectáreas de ciudad con obispado. Pero un paseo por la civita Berona en los palacios de Cerezo te dejara ver miles de restos romanos.</p>
-
                     <h4>Relevancia como Capital</h4>
                     <p>Desde Cerezo se gobernaba las Bardulias, dese la cuidad de Auka Patricia (patriniani) con nuestra episcopi de San Martín con 116 metros de largo, toda la provincia Cantábrica en tiempos visigodos (los montes de Cantabria en la Rioja). Somos el Origen de Castilla y del Idioma Castellano y la ciudad de Auka Patricia. Con los restos de la ciudad construyeron el Alcázar con el el Alfoz de Castilla, y sus Condes de Castilla y Álava gobernando desde su Alcazar en la Alcazaba.</p>
                     <p>En la Ciudad de Auca Patricia capital visigoda de la Cantabrica, desde donde se gobiernan las bardulias, desde la civittate Patricia o patriciani, desde la episcopi de San Martín, desde el Monumental Alcázar con su alfoz que se construyo con los restos de una civita Romana de oca, capital de la cantábrica pues cesar desembarco en segisamaclo sus legiones para su conquista. En Cerezo de Río Tirón origen de Castilla de su Cultura y de su Idioma con Valuesta en su Alfoz.</p>
                     <p>Auca con titulo de patricia, capital de una provincia, Civitate Auca Patricia capital de Cantabria y las Bardulias. <a href="https://books.google.com/books?id=KVpRAAAAcAAJ&pg=RA3-PA291">Historia de los reyes de Castilla y de León, Don Fernando el Magno ... - Prudencio de SANDOVAL - Google</a></p>
                     <p>La Civitate Auca Patricia es la capital de Cantabria, dice San Braulio en la Vida de San Millan que Leovigildo conquista y destruye las murallas y torres de la civita Romana, solo deja tres torres descubiertas. Por eso tarda en entrar en los Concilios Visigodos, pues hasta el 574 que se conquista el ultimo reducto del imperio romano de occidente por Leovigildo, no puede entrar en los concilios visigodos.</p>
-
                     <h4>Interpretaciones y Evidencia Arqueológica</h4>
                     <p>Y por si a alguien del público no le queda claro cuánto mide una Civitate Patriciani, pues ahí van unas medias disuasorias para otras disparadas teorías sobre la localización de Auka Patricia capital de la Cantabrica Visigoda con las medidas de su Episcopi San Martín pues Auka Patricia es sede episcopal Así que quiero ver algo parecido a una Catedral. Esperando me tienen sus comparaciones. Me temo que insultos si, pero pruebas científicamente cuantificables.... Les faltan tegulas y les sobras letras.</p>
                     <p>Matizar que la ciudad fue Abandonada en el siglo VIII y no se construyo nada hasta finales del siglo XX, bueno, nada no es correcto, se edifico un ermita, la de San Martín, aun puedes ver su retablo en la iglesia de San Nicolas de Barí, en Cerezo de Rio Tirón.</p>
-
                 </div> <!-- Cierre de .article-content -->
             </div> <!-- Cierre de .container (para la sección) -->
         </section>
     </main>
-
     <?php require_once __DIR__ . '/../../../_footer.php'; ?>
-
     <script>
         // Script para el menú de navegación móvil
         const navToggle = document.querySelector('.nav-toggle');
         const navLinks = document.querySelector('.nav-links');
-
         navToggle.addEventListener('click', () => {
             const isExpanded = navToggle.getAttribute('aria-expanded') === 'true' || false;
             navToggle.setAttribute('aria-expanded', !isExpanded);
             navLinks.classList.toggle('active');
         });
-
         // Opcional: Cerrar menú al hacer clic en un enlace
         navLinks.querySelectorAll('a').forEach(link => {
             link.addEventListener('click', () => {
                 if (navLinks.classList.contains('active')) {
                     navToggle.setAttribute('aria-expanded', 'false');
                     navLinks.classList.remove('active');
-                }
             });
-        });
     </script>
     <!-- Removed navbar script, as navbar is replaced by _header.php -->
 </body>

--- a/historia/subpaginas/becerro_galicano_origen_castilla.php
+++ b/historia/subpaginas/becerro_galicano_origen_castilla.php
@@ -1,73 +1,22 @@
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
 <head>
-    <style>
-        .article-content p {
-            margin-bottom: 1em;
-            line-height: 1.6;
-        }
-        .article-content h3 {
-            font-family: 'Cinzel', serif;
-            color: var(--color-secundario-dorado);
-            margin-top: 1.5em;
-            margin-bottom: 0.5em;
-        }
-        .article-content h4 {
-            font-family: 'Lora', serif;
-            font-style: italic;
-            color: var(--color-primario-purpura);
-            margin-top: 1em;
-            margin-bottom: 0.3em;
-        }
-        .article-content a {
-            color: var(--epic-gold-main);
-            text-decoration: underline;
-        }
-        .article-content a:hover {
-            color: var(--color-secundario-dorado);
-        }
-        .back-link {
-            display: inline-block;
-            margin-bottom: 2em;
-            font-size: 0.9em;
-            color: var(--color-primario-purpura);
-            text-decoration: none;
-            border: 1px solid var(--color-primario-purpura);
-            padding: 0.5em 1em;
-            border-radius: 5px;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .back-link:hover {
-            background-color: var(--color-primario-purpura);
-            color: var(--color-blanco-fondo);
-        }
-        .quote {
-            border-left: 3px solid var(--color-secundario-dorado);
-            padding-left: 1em;
-            margin-left: 1em;
-            font-style: italic;
-            color: #555;
-        }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
-
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/becerro_galicano.jpg'); min-height: 40vh;">
         <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
             <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">El Becerro Galicano y el Origen de Castilla en Auca</h1>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
-
                 <h3>Interpretación del Becerro Galicano</h3>
                 <p>Queda decir que la localización de la Civita de Auca patricia nos indica donde nace el Condado de Castilla su Cultura e Idioma, porque Castilla que según la interpretación que hace Prudencio de Sandoval en la Historia de cinco obispos: Idacio, Isidoro, Sebastiano, Sampiro y Pelagio (Pamplona, 1615); del Becerro galiciano de San Millán de la Cogolla donde esta la primera mención a Castilla, dice que Castilla nace dentro de las murallas donde todo es ruina y desolación en la Civitate Auca Patricia.</p>
                 <p>Es todo ir al becerro en su versión Facsímil y a ver si leemos lo mismo que Fray Prudencio de Sandoval en la Historia de los cinco obispos. Matizar que en los Palacios de Cerezo de Río Tirón hay una Civitate romana con unos muros de hormigón romano de 6 metros de espesor circundado una Civitate romana de 144 hectáreas abandonada en el 716 y con la ermita de San Martin donde todo es ruina y desolación.</p>
-
                 <h4>Auki Patriciani vs. Area Paterniani</h4>
                 <p>Hay múltiples autores incluido a Fray Prudencio de Sandoval que fue monje de becerro galicano de San Millán de la cogolla, que sitúa la Civitate de Auca Patricia en el origen de Castilla, sabrá un monje de San Millán de la cogolla leer su becerro.</p>
                 <p>En el primer texto que nombra la palabra Castilla en el becerro galicano de San Millán de la cogolla: </p>
@@ -77,29 +26,20 @@
                 </blockquote>
                 <p>Y DE SAN MARTÍN, A QUIEN FUNDAMOS CON NUESTRAS PROPIAS MANOS, LA BASÍLICA MISMA EN LA CIUDAD DE AREA PATRINIAN, EN TERRITORIO DE CASTILLA; Denotar como dice Civitate o Ciudad Patricia, así que para ser Castilla debe tener una Civitate o Ciudad Romana con titulo de Patricia (capital de Provincia) y con la Basílica de San Martin encima, como en el termino de los Palacios de Cerezo de Río Tirón con 144 hectáreas, 20 hectáreas el termino de los Palacios y 144 hectáreas de Civitate Patricia Amurallada.</p>
                 <p>Y tenemos el otro texto que dice:</p>
-                <blockquote class="quote">
                     <p>Et in Aiki Patriciani ad Sancti Martini invenimus ipsa civitate ex ruina desolata, et fabricavimus ipsa ecclesia Sancti Martini, et fecimus culturas et laborem, et cum illa omnia hereditate quem cludit muro in circuitu de ipsa civitate;</p>
-                </blockquote>
                 <p>Y EN AIKI PATRICIANI EN SAN MARTÍN, ENCONTRAMOS LA CIUDAD MISMA DESOLADA DE RUINAS, Y CONSTRUIMOS LA IGLESIA DE SAN MARTÍN, E HICIMOS CULTIVOS Y TRABAJO, Y CON TODO ESE PATRIMONIO QUE ESTÁ ENCERRADO POR UN MURO ALREDEDOR DE LA CIUDAD MISMA; Aquí nos dice que la ciudad Patricia la encuentra en ruinas y desolada y estaba amurallada toda la Civitate con titulo de Patricia.</p>
-
                 <h4>La Basílica de San Martín y el Territorio de Castilla</h4>
                 <p>Lo único que queda escrito sobre la Cuna e Origen de Castilla esta en el Becerro Galiciano de San Millan de la Cogolla y dice: , Y fundamos con nuestras propias manos la basílica de San Martín en Civitate Auca Patricia en territorio de Castilla, et Luego dice: Construimos la basílica de San Martín dentro de las murallas de Civitate Auca Patricia donde todo era ruina y desolación en territorio de Castilla.</p>
                 <p>Si dice que fue en Territorio de Mena eso excluye por completo que sea Mena territorio de Castilla pues la linea anterior diferencia del Territorio de Mena del Territorio de Castilla, de todas las teorías posibles esta es la mas loca, pues deja en el párrafo la una exclusión de todos los territorios del mundo “Mena” que nombra con territorio propio diferenciado del Territorio de Castilla. Sin meternos en que en Mena no existe una civita romana patricia.</p>
                 <p>Leer vosotros de la única fuente y más antigua en el Becerro Galicano de San Millán de la cogolla, de la que surgen los demás textos, sacar vuestras propias conclusiones, si dice Auca Patriniani o Área Paterniani, a sabiendas que después los condes de castilla tienen su corte en Auca y gobiernan desde el Alcázar de Cerasio. [...] Saber tambien en el término de San Martín en, a pie de la parte de fuera del pasaje de la Cárcava que hace de foso a nuestra monumental ciudad romana de 1200 metros de decumanus, tenemos una Episcopi de San Martín con más de 116 metros de largo que se pueden medir sin interpretación posible.</p>
                 <p>El Texto solo dice esto con buenos signos de puntuación y con poca interpretación:</p>
-                <blockquote class="quote">
                 <p>", cuius baselica extirpe manibus nostris construximus, ego Vitulus abba, et frater meus Erbigius, in loco qui dicitur Taranco, in territorio Mene,</p>
                 <p>ET Sancti Martini, quem sub dicionem manibus nostris fundavimus ipsam baselicam in civitate de Auka Patriniani, in territorio Castelle;</p>
                 <p>ET Sancti Stephani, cuius basilicam manibus nostris fundavimus in loco qui dicitur Burcenia, in territorio mainense,"</p>
-                </blockquote>
                 <p>Leer bien como habla la fundación de tres Basílicas en tres lugares diferentes. Y dice muy claramente Civitate de Auki Patriciani, las separa con una coma y un Et. Remarcar lo de civitate pues no es lo mismo en territorio de Auka patriciani que en la ciudad de Auca Patriciani.</p>
-
             </div>
         </section>
     </main>
-
-
-
     <?php require_once __DIR__ . '/../../_footer.php'; ?>
     <script src="/js/layout.js"></script>
 </body>

--- a/historia/subpaginas/condes_castilla_alava_cerasio.php
+++ b/historia/subpaginas/condes_castilla_alava_cerasio.php
@@ -1,91 +1,36 @@
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
 <head>
-    <style>
-        .article-content p {
-            margin-bottom: 1em;
-            line-height: 1.6;
-        }
-        .article-content h3 {
-            font-family: 'Cinzel', serif;
-            color: var(--color-secundario-dorado);
-            margin-top: 1.5em;
-            margin-bottom: 0.5em;
-        }
-        .article-content h4 {
-            font-family: 'Lora', serif;
-            font-style: italic;
-            color: var(--color-primario-purpura);
-            margin-top: 1em;
-            margin-bottom: 0.3em;
-        }
-        .article-content a {
-            color: var(--epic-gold-main);
-            text-decoration: underline;
-        }
-        .article-content a:hover {
-            color: var(--color-secundario-dorado);
-        }
-        .back-link {
-            display: inline-block;
-            margin-bottom: 2em;
-            font-size: 0.9em;
-            color: var(--color-primario-purpura);
-            text-decoration: none;
-            border: 1px solid var(--color-primario-purpura);
-            padding: 0.5em 1em;
-            border-radius: 5px;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .back-link:hover {
-            background-color: var(--color-primario-purpura);
-            color: var(--color-blanco-fondo);
-        }
-        .highlight {
-            background-color: rgba(var(--color-secundario-dorado-rgb), 0.1);
-            padding: 0.2em 0.4em;
-            border-radius: 3px;
-            font-weight: bold;
-        }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
-
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/condes_hero.jpg'); min-height: 40vh;">
         <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
             <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">Condes de Castilla y Álava en el Alcázar de Cerasio</h1>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
-
                 <h3>El Gobierno desde Cerasio</h3>
                 <p>Y ver cómo Pancorvo del Alfoz de cerezo, Valpuesta del Alfoz de cerezo, y Auca se vinculan al origen de Castilla que es el Alcázar de Alabastro puro de Cerasio con sus <span class="highlight">documentados condes de Castilla y Alava</span> y sus 1200 metros de largo con capacidad para albergar el Palacio o Alcázar su corte condal de funcionarios y sus soldados.</p>
                 <p>Desde Cerezo se gobernaba las Bardulias, dese la cuidad de Auka Patricia (patriniani) con nuestra episcopi de San Martín con 116 metros de largo, toda la provincia Cantábrica en tiempos visigodos (los montes de Cantabria en la Rioja). Somos el Origen de Castilla y del Idioma Castellano y la ciudad de Auka Patricia. Con los restos de la ciudad construyeron el Alcázar con el el Alfoz de Castilla, y sus <span class="highlight">Condes de Castilla y Álava gobernando desde su Alcazar en la Alcazaba</span>.</p>
                 <p>En Cerezo de Río Tirón existen y se pueden tocar aún hoy unas monumentales ruinas que recogen la historia y las tumbas de los <span class="highlight">5 primeros condes de Castilla y Álava anteriores a Fernán González</span>, el cual regenta los títulos de Cerezo y Lantaron que hereda de su mujer Doña Sancha viuda del Conde de Castilla Álvaro Herramelluriz (conde de Cerezo y Lantaron por lo tanto Conde de Castilla y Álava)...</p>
-
                 <h4>Linaje de los Condes</h4>
                 <p>Fernán González es Conde de Lara y Burgos por parte de su padre <span class="highlight">Gonzalo Fernández</span> hijo de <span class="highlight">Fernando Díaz</span> Conde de Cerezo y Lantarón – Conde de Castilla y Álava que a su vez es hijo de <span class="highlight">Diego Rodríguez Porcelos</span> – Conde de Cerezo y Lantarón – Conde de Castilla (Esta vez no esta claro que lo sea de Álava por haber perdido la Batalla de la Morcuera desarrollada toda ella en el Alfoz de Cerezo y Lantarón), Hijo de <span class="highlight">Rodrigo</span> Primer Conde de Cerezo y Lantarón – Conde de Castilla y Álava.</p>
                 <p>El Hijo de Diego Rodríguez Porcelos, <span class="highlight">Fernando Díaz</span> Conde de Cerezo y Lantarón – Conde de Castilla y de Álava ya se le situó con la corte Condal Gobernando desde el Alcázar de Cerasio como a los Condes <span class="highlight">Gonzalo Téllez</span> y <span class="highlight">Álvaro Herramelliz</span>.</p>
                 <p>La condesa de Castilla <span class="highlight">Doña Sancha</span> que hereda los títulos de Cerezo y Lantarón – Castilla y Álava de su marido muerto <span class="highlight">Álvaro Herramelliz</span> se casa con el Conde Fernán González Conde de Lara y Burgos y a partir de ahí Frenan González se hace con los títulos de Conde de Lara, Burgos, Cerezo y Lantarón – Conde de Castilla y de Álava.</p>
-
                 <h4>Documentación y Testimonios</h4>
                 <p>El Conde de Castilla y Álava <span class="highlight">Gonzalo Téllez</span>.</p>
                 <p>El conde de Castilla y Álava <span class="highlight">Fernando Diaz</span>.</p>
                 <p>Y el Conde de Castilla y Álava <span class="highlight">Álvaro herarméliz</span> que a su muerte su viuda Doña Sancha se casa con Fernán González y desde entonces Fernán González regenta los títulos que hereda su mujer de Conde de Castilla y Álava, llevando este Conde la capitalidad del Alcázar de Cerasio al Castillo de Burgos.</p>
                 <p>Los condes de Cerezo y Lantarón fueron los primeros condes de Castilla y Álava. Cerezo de río Tirón y Miranda de Ebro son el auténtico origen de Castilla y del Idioma Castellano.</p>
                 <p>En la episcopi de San Martín en Auca están enterrados todos los condes y condesas de Castilla hasta Fernán González incluido el padre de Fernán González que dice Fray Luis Perez Urbiel que fue enterrado en Cerezo por su mujer Munaidona.</p>
-
             </div>
         </section>
     </main>
-
-
-
     <?php require_once __DIR__ . '/../../_footer.php'; ?>
     <script src="/js/layout.js"></script>
 </body>

--- a/historia/subpaginas/evidencia_arqueologica_cerezo.php
+++ b/historia/subpaginas/evidencia_arqueologica_cerezo.php
@@ -1,110 +1,46 @@
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
 <head>
-    <style>
-        .article-content p {
-            margin-bottom: 1em;
-            line-height: 1.6;
-        }
-        .article-content h3 {
-            font-family: 'Cinzel', serif;
-            color: var(--color-secundario-dorado);
-            margin-top: 1.5em;
-            margin-bottom: 0.5em;
-        }
-        .article-content h4 {
-            font-family: 'Lora', serif;
-            font-style: italic;
-            color: var(--color-primario-purpura);
-            margin-top: 1em;
-            margin-bottom: 0.3em;
-        }
-        .article-content a {
-            color: var(--epic-gold-main);
-            text-decoration: underline;
-        }
-        .article-content a:hover {
-            color: var(--color-secundario-dorado);
-        }
-        .back-link {
-            display: inline-block;
-            margin-bottom: 2em;
-            font-size: 0.9em;
-            color: var(--color-primario-purpura);
-            text-decoration: none;
-            border: 1px solid var(--color-primario-purpura);
-            padding: 0.5em 1em;
-            border-radius: 5px;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .back-link:hover {
-            background-color: var(--color-primario-purpura);
-            color: var(--color-blanco-fondo);
-        }
-        .image-gallery {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 10px;
-            justify-content: center;
-            margin-top: 1em;
-        }
-        .image-gallery img {
-            max-width: 200px;
-            max-height: 150px;
-            border-radius: 5px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-        }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
-
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/arqueologia_cerezo.jpg'); min-height: 40vh;">
         <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
             <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">Evidencia Arqueológica en Cerezo de Río Tirón</h1>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
-
                 <h3>Murallas y Estructuras Urbanas</h3>
                 <p>En Cerezo de Río Tirón que actualmente y siempre es Oca, hay una civita Romana de 144 hectáreas rodeada de murallas romanas de hormigón romano de 6 metros de ancho, mas sus segunda murallas y fosos... una capital Patricia con Obispado.</p>
                 <p>Aun si dudas puedes ver que la civita esta rodeada por el paseo de la cárcava(foso romano) pues no hay cárcava vista, y si escabas un poco podrás ver la murallas de hormigón de 6 metros rodeando 144 hectáreas de ciudad con obispado. Pero un paseo por la civita Berona en los palacios de Cerezo te dejara ver miles de restos romanos.</p>
                 <p>En Cerezo tenemos las murallas de hormigón debajo de la casa de Mogollon por ejemplo, hay km de ellas, solo es mirar bien, tenemos unas murallas que circundan 144 hectáreas de ruinas de una Civita Romana.</p>
                 <p>Paredes de opus romana.</p>
-
                 <h4>Glera de los Celox y Puerto Fluvial</h4>
                 <p>Donde estaba el ultimo puerto Fluvial navegable del Río Ebro, en el Gurugu de Segisamam. Aun se puede ver el puerto romano en el termino de Glera de los Celox (barcos de legionarios romanos en ríos).</p>
                 <p>Las calzadas romanas y el ultimo puerto fluvial romano sobre el rio Ebro esta en la Glera de los Celox (embarcación romana de legion en Rios).</p>
                 <p>Puerto Romano en Cerezo de río Tirón, último puerto de mar del río Ebro.</p>
                 <p>Nuestro Glera de los Cellos o Celox o celoces como argumento del cuartel General de Cesar Augusto en la Guerras Cántabras y como prueba de nuestro Ultimo puerto fluvial del Río Ebro. Celes (Celox) Embarcación o bote de remos rápido y ligero utilizado como mensajero en la flota de guerra romana.</p>
-
                 <h4>Monedas e Inscripciones</h4>
                 <p>Algo curioso muy curioso del escudo de Cerezo es su estrella, fijaros como las monedas romanas que tienen una puerta romana de campamento romano llevan una estrella arriba, algunas se han visto por los campos de Cerezo con la cabeza de Constantino. Pero lo curioso es que las monedas de los emperadores Máximo y su hijo Flavio Victor tienen una puerta de ciudad o campamento romano que parece una torre de un castillo con su estrella arriba...</p>
                 <p>Monedas Cerezo puerta estrella 8 puntas.</p>
                 <p>Moneda de Flavio Victor (decapitado el 26 de Agosto del 388 en el circo de Oca, Auca Patricia) , con reverso de puerta romana como la del Pendon de Castilla.</p>
                 <p>Estela de Cerezo de Rió Tirón.</p>
                 <p>Después de revisar todos las monedas celtíberas de Segisamam que se han encontrado en Cerezo de Río Tirón el 90 por ciento son con el nombre de Secobririces que se pronuncia Segisamam en plural con la M. no segisama sin M. El símbolo de nuestro Labaro o Pendón es unos cuernos de toro o media luna hacia arriba. Esta tanto en nuestra moneda como en nuestras estelas funerarias del Tirón.</p>
-
                 <h4>Alabastro y Otros Materiales</h4>
                 <p>Cerezo es precioso pueblo alba, hecho con alabastro puro. Me da que los de cerezo no se han dado cuenta aun que viven en un pueblo de Alabastro puro. [...] La tumba de Santo Domingo esta echa con Alabastro de Cerezo. [...] La prueba es que es traslucido asi sabreis si es alabastro.</p>
                 <p>Cuando veo en mi imaginación Auca Patricia revestido de alabastro del que quedan aún toneladas de ello en el Alcázar y las casas de Cerezo de Río Tirón, veo no el Alabastro que tenemos ahora meteorizado durante 2000 años, me imagino Alabastro bien pulido como el del museo del teatro de Zaragoza.</p>
-
                 <div class="image-gallery">
                     <img src="/imagenes/moneda_maximo_detalle.jpg" alt="Moneda del emperador Máximo">
                     <img src="/imagenes/moneda_constantino_detalle.jpg" alt="Moneda de Constantino">
                     <img src="/imagenes/estela_cerezo_detalle.jpg" alt="Estela de Cerezo">
                 </div>
-
             </div>
         </section>
     </main>
-
-
-
     <?php require_once __DIR__ . '/../../_footer.php'; ?>
     <script src="/js/layout.js"></script>
 </body>

--- a/historia/subpaginas/legado_romano_emperadores_estructuras.php
+++ b/historia/subpaginas/legado_romano_emperadores_estructuras.php
@@ -1,99 +1,46 @@
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
 <head>
-    <style>
-        .article-content p {
-            margin-bottom: 1em;
-            line-height: 1.6;
-        }
-        .article-content h3 {
-            font-family: 'Cinzel', serif;
-            color: var(--color-secundario-dorado);
-            margin-top: 1.5em;
-            margin-bottom: 0.5em;
-        }
-        .article-content h4 {
-            font-family: 'Lora', serif;
-            font-style: italic;
-            color: var(--color-primario-purpura);
-            margin-top: 1em;
-            margin-bottom: 0.3em;
-        }
-        .article-content a {
-            color: var(--epic-gold-main);
-            text-decoration: underline;
-        }
-        .article-content a:hover {
-            color: var(--color-secundario-dorado);
-        }
-        .back-link {
-            display: inline-block;
-            margin-bottom: 2em;
-            font-size: 0.9em;
-            color: var(--color-primario-purpura);
-            text-decoration: none;
-            border: 1px solid var(--color-primario-purpura);
-            padding: 0.5em 1em;
-            border-radius: 5px;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .back-link:hover {
-            background-color: var(--color-primario-purpura);
-            color: var(--color-blanco-fondo);
-        }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
-
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/romano_detalle.jpg'); min-height: 40vh;">
         <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
             <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">Legado Romano en Cerezo: Emperadores y Estructuras</h1>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
-
                 <h3>Emperadores Romanos y Auca Patricia</h3>
                 <p>Ya toca hablar de la cuna de tres emperadores Romanos perdidas en el tiempo, Flavio Teodosio I el grande, su primo Magno Clemente Máximo y su hijo Flavio Victor, los tres emperadores romanos de cuna Hispana familia entre ellos. De Flavio Teodosio dice que nació en la Galleecia en Cauca (o Auca). Sabiendo que el Conde Teodosio Gobernó una Provincia Visigoda desde la Civitate de Auka y los Condes de Lara dicen que provienen de Emperadores romanos, en plural lo dicen los Lara en su lema, emperadoreS romanos.</p>
                 <p>Mas tarde nacen tres emperadores romanos en Auka, Teodosio I el Grande su primo Magno Clemente Máximo y su hijo Flavio Victor. Tenemos localizados dos Mausoleos imperiales uno en la iglesia de San Nicolas y otro en el Circo Romano de Auka Patricia.</p>
                 <p>De Flavio Victor que decir si la tradición lo pone a nacer y morir en Cerezo, recordado en toda la ciudad de Auca y la Cantábrica. Decapitado como San Vitores el 26 de agosto del 388 en el Circo de la civita Auka Patricia. Aun tenemos marcada la piedra de la decapitación en Quintanilleja.</p>
-
                 <h4>Estructuras Romanas en Cerezo de Río Tirón</h4>
-
                 <h5>Campamentos y Presencia Militar</h5>
                 <p>Leyendo estas antiguas afirmaciones, dicen que había legiones romanas asentadas en Auca Patricia(Cerezo de Río Tirón). Tendría un Conde gobernando la ciudad, el Conde Casio.</p>
                 <p>Aun se pueden ver las torres torcidas en las esquinas del campamento romano de piedra de legionarios romanos en el Termino de la Tejera.</p>
                 <p>¿Sabemos cómo es un campamento romano de la Legión? Si buscamos uno ¿como lo reconocerlas? Mira como tuerce la torre en la esquina de la tejera, con foso y altura, bajar a la finca de abajo y mirar cómo se ven muy bien las torres del campamento Romano de piedra, ni que decir que esa era tienes unas piedras extrañas clavadas en el suelo.</p>
                 <p>Y uno de los campamentos auxiliares romanos, aun se puede ver las torres blancas de la tejera, si bajas a la pieza de abajo, Torres blancas con tejas rojas como ocas. Otro en la Maza (como mazarron, puerto de los romanos) en puerto romano aunque la flota estaba en Glera de los Cellox, poner el traductor y que os pronuncie celox y juzgar. Y el campamento de legio romana con tienda de campaña en Oxmilla, a 800 metros del auxilia de San martín que en una donación del Conde de Cerezo y Lantaron, Conde de Castilla y Conde de Álava dice obispado en San Martín (¿Auca? Pensar que en 1750 aun el río oca se llamaba vesica, vesga o Velegia río Vejiga en Latín).</p>
-
                 <h5>Teatros Romanos</h5>
                 <p>Teatro Romano del del siglo I en la civitate de Aucam en Cerezo de Río Tirón. Teatro Romano de la Ciudad de Auca Patricia, del Siglo III o IV en el termino de la Arena en las Canteras este de piedra de arena aunque en el termino de las canteras y diciendo los viejos que se ha acabado la beta... a saber cuando queda de el.</p>
                 <p>En este lugar tenemos otro teatro en Auca Patricia, mas antiguo que que esta en las canteras, este en los palacios, es del siglo I, bueno lo que queda de el, aun se puede apreciar los restos de hormigón romano el Opus.</p>
                 <p>Existe un dicho que dice: No hay alcazaba o alcázar Árabe si no hay un teatro romano al que robarle las piedras. La construcción Árabe se basa en reutilizar materiales existentes. Así que siguiendo esta máxima invariable, vamos a ver que tenemos en las Canteras de Cerezo. ¿Estará el Teatro Romano en el Termino de Las Canteras, el que sigue al puerto o Maza? Las medidas encajan... la forma la tiene y mucho... ya pero eso es una beta de piedras de arena... ya la única beta de Cerezo de Piedra de arena... con forma de teatro, con medidas de teatro... ¿No le estaremos robando las piedras al teatro romano de Auca, verdad?</p>
-
                 <h5>Circo Romano</h5>
                 <p>En las mas antiguas referencias a la historia de San Formerio dicen que en la Vega de los tormentos en el 277 en tiempos del emperador Aureliano, tenia en la vega de los Tormentos un Circo con Leones y un gobernador romano. Un Gobernador de provincia Romano solo puede ser en una ciudad en la zona, Aucam Patricia.</p>
                 <p>Pero tambien en la Vega de los tormentos encontramos unas ruinas que dan la medida exacta para el circo de la historia de San Formerio, con una espina de 160 metros por 8 metros de ancho con agua en su interior y con el angulo para que las cuadrigas salgan de las carceres. el resto de medidas junto a las toponimias son correctas, no hay confusión pues allí no hay nada mas que las ruinas de un circo y una iglesia para sacralizar el lugar de los tormentos a los mártires cristianos, la Iglesia de Santi Emiliani, en Auca, en el valle de Asur. En la Ciudad de Oca capital de la Cantábrica. El circo de Auka Patricia.</p>
                 <p>Un circo romano en Cerezo de río Tirón, las medidas dan la posibilidad, ¿160 metros por 8 metros de ancho? Nace un manantial en medio de la espina, posiblemente tendrían agua como el circo de Majencio, un circo ritual, en el término de la Arena, en la Vega de los tormentos, en el término de las carretas.</p>
-
                 <h5>Puerto Fluvial</h5>
                 <p>Donde estaba el ultimo puerto Fluvial navegable del Río Ebro, en el Gurugu de Segisamam. Aun se puede ver el puerto romano en el termino de Glera de los Celox (barcos de legionarios romanos en ríos).</p>
                 <p>Puerto Romano en Cerezo de río Tirón, último puerto de mar del río Ebro.</p>
-
                 <h5>Mausoleos</h5>
                 <p>Con respecto a que Flavio Teodosio I esté enterrado en Constantinopla, pues en la lista de residentes en el Mausoleo no esta citado, habrá que buscar otro Mausoleo que se le parezca [San Vittore al Corpo, Milán] como el de la Iglesia de San Nicolas en Cerezo de Río Tirón y buscar en sus cuevas de muertos que se conservan debajo de San Nicolas en la [Ciudad Romana de Auca].</p>
                 <p>En el lugar de la decapitación de San Vitores hay un Mausoleo Romano con un circo ritual como el circo del emperador Majencio.</p>
-
             </div>
         </section>
     </main>
-
-
-
     <?php require_once __DIR__ . '/../../_footer.php'; ?>
     <script src="/js/layout.js"></script>
 </body>

--- a/historia/subpaginas/obispado_auca_cerezo.php
+++ b/historia/subpaginas/obispado_auca_cerezo.php
@@ -1,12 +1,6 @@
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
 <head>
-    <style>
-        .article-content p { margin-bottom: 1em; line-height: 1.6; }
-        .article-content h3 { font-family: 'Cinzel', serif; color: var(--color-secundario-dorado); margin-top: 1.5em; margin-bottom: 0.5em; }
-        .article-content h4 { font-family: 'Lora', serif; font-style: italic; color: var(--color-primario-purpura); margin-top: 1em; margin-bottom: 0.3em; }
-        .back-link { display:inline-block; margin-bottom:2em; font-size:0.9em; color:var(--color-primario-purpura); text-decoration:none; border:1px solid var(--color-primario-purpura); padding:0.5em 1em; border-radius:5px; transition:background-color 0.3s, color 0.3s; }
-        .back-link:hover { background-color:var(--color-primario-purpura); color:var(--color-blanco-fondo); }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>

--- a/historia/subpaginas/obispado_oca_auca.php
+++ b/historia/subpaginas/obispado_oca_auca.php
@@ -1,91 +1,41 @@
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
 <head>
-    <style>
-        .article-content p {
-            margin-bottom: 1em;
-            line-height: 1.6;
-        }
-        .article-content h3 {
-            font-family: 'Cinzel', serif;
-            color: var(--color-secundario-dorado);
-            margin-top: 1.5em;
-            margin-bottom: 0.5em;
-        }
-        .article-content h4 {
-            font-family: 'Lora', serif;
-            font-style: italic;
-            color: var(--color-primario-purpura);
-            margin-top: 1em;
-            margin-bottom: 0.3em;
-        }
-        .article-content a {
-            color: var(--epic-gold-main);
-            text-decoration: underline;
-        }
-        .article-content a:hover {
-            color: var(--color-secundario-dorado);
-        }
-        .back-link {
-            display: inline-block;
-            margin-bottom: 2em;
-            font-size: 0.9em;
-            color: var(--color-primario-purpura);
-            text-decoration: none;
-            border: 1px solid var(--color-primario-purpura);
-            padding: 0.5em 1em;
-            border-radius: 5px;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .back-link:hover {
-            background-color: var(--color-primario-purpura);
-            color: var(--color-blanco-fondo);
-        }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
-
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/iglesia_detalle.jpg'); min-height: 40vh;">
         <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
             <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">El Obispado de Oca/Auca y su Papel en la Historia</h1>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
-
                 <h3>La Sede Episcopal de Auca</h3>
                 <p>Obispos de Auca, sabiendo que el valle de asur esta encima de Quintanilleja y la iglesia de San Millan en el Circo de Setefenestras, no leyendo ninguna antigua referencia a Villafranca como Auca ni como ciudad y sin tener esta restos que la abalen como ciudad Patricia capital de la Cantabrica. Cerezo que si tiene restos de una ciudad romana con un decumanus de 1200 metros ademas es nombrada como ciudad en varios contextos, una episcopi de mas 116 metros de largo en San Martin, podemos decir que Cerasio es la antigua Auca Patricia y san Felix de Oca un suburbio de Cerezo al igual que Pedroso o Belorado o Oxmilla, da fe el grandioso Alfoz de Cerezo.</p>
                 <p>Y por si a alguien del público no le queda claro cuánto mide una Civitate Patriciani, pues ahí van unas medias disuasorias para otras disparadas teorías sobre la localización de Auka Patricia capital de la Cantabrica Visigoda con las medidas de su Episcopi San Martín pues Auka Patricia es sede episcopal Así que quiero ver algo parecido a una Catedral.</p>
                 <p>En la ciudad de Oca, en la silla aukensi. Episcopi de Auka Patricia.</p>
                 <p>Encontramos la Catedral de Auka Patricia. 116 metros de eslora hundida en trigo y Olvido. La catedral de Burgos mide 88 metros para referencia.</p>
-
                 <h4>Conexión con Valpuesta y los Primeros Obispos</h4>
                 <p>La realidad fue, sin embargo, bastante más prosaica. Así, por ejemplo, la diócesis canónica de Auca terminaría por ser desmontada y, además, entraron a participar en el juego otras que, en origen, no estaban convocadas, como Valpuesta y Burgos, que, además de absorber a Auca.</p>
                 <p>Podemos decir que Castilla nace en los obispados de Oca y diócesis de Valpuesta.</p>
                 <p>Como la ocupación musulmana de Auca Patricia sube a Valpuesta el Obispado de Oca.</p>
                 <p>En el año 804 se creó el obispado de Valpuesta que sustituyó a Auca durante más de dos siglos y medio.</p>
-
                 <h4>San Martín y el Obispado</h4>
                 <p>De que Máximo y Elen eran muy devotos de San Martín de Tours, pero por esa zona de episcopi San Martín en Cerezo de Río Tirón, en los restos superficiales de la ruina de mas de 116 metros de largo aparecen piezas de cerámica altomedivales, no puedo situar nada romano en la episcopi pues no hemos encontrado superficialmente ni sigilata ni tegulas, pero aun quedan muchas construcciones sepulcrales en la zona, habrá que esperar alguna pista que nos guie al Mausoleo Imperial Romano de Magno Clemente.</p>
                 <p>No os perdáis como se llama la el obispado de Oca... leerlo bien una y otro vez pues esta escrito y no invento. San Martin de Oca se traslado a Gamonal en presencia del Cid Campeador. Ahora sabed que la Iglesia de los Palacios era la de San Martin y en Villafranca al norte en el termino de San Martin también hubo una iglesia de San Martín, empate. Pues habla del obispado de la Iglesia de San Martin de Auca, en los palacios de Cerezo en la Civitate Auca Patricia.</p>
                 <p>En episcopi San Martín, en Capellanía, en Dios te Salve. Una Episcopi con 116 metros como mínimo de largo, como referencia la catedral de Burgos mide 88 metros y la de Bilbao 55 metros, aun la Episcopi de San Martín tiene 90 metros mas anexos. Documentado que tiene Condes de Castilla enterrados en ella.</p>
-
                 <h4>Obispos Relevantes y Concilios</h4>
                 <p>Fronismus, obispo, 913 (segurame'nte Frunimio, obispo de León). Cerezo. {B. de Cárdena, pág. 327.)</p>
                 <p>Gudesteos, obispo, Cerezo, 913. {B. de Cárdena, pág. 327.)</p>
                 <p>El obispo Asterio de Oca parti-cipa en el III Concilio de Toledo en el 589, suscribiendo las actas del mismo. Elhecho de que figure en un lugar destacado, precediendo a 34 prelados, supone unacierta antigüedad en el cargo.</p>
                 <p>***Mumio, Munio *o *Munimio (589-614*).** Asiste al III Concilio de Toledo (589), al II de Zaragoza (592) y al de Barcelona (599). Firma el III Concilio de Toledo, que se celebra bajo Recaredo. Leovigildo ha conquistado y sometido a los pueblos del norte en 574 y desde entonces empiezan a asistir a los Concilios sus obispos: el de Pamplona, el de Calahorra, el de Tarazona y el de Auca.</p>
-
             </div>
         </section>
     </main>
-
-
-
     <?php require_once __DIR__ . '/../../_footer.php'; ?>
     <script src="/js/layout.js"></script>
 </body>

--- a/historia/subpaginas/origenes_castellano_vulgar.php
+++ b/historia/subpaginas/origenes_castellano_vulgar.php
@@ -1,83 +1,34 @@
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
 <head>
-    <style>
-        .article-content p {
-            margin-bottom: 1em;
-            line-height: 1.6;
-        }
-        .article-content h3 {
-            font-family: 'Cinzel', serif;
-            color: var(--color-secundario-dorado);
-            margin-top: 1.5em;
-            margin-bottom: 0.5em;
-        }
-        .article-content h4 {
-            font-family: 'Lora', serif;
-            font-style: italic;
-            color: var(--color-primario-purpura);
-            margin-top: 1em;
-            margin-bottom: 0.3em;
-        }
-        .article-content a {
-            color: var(--epic-gold-main);
-            text-decoration: underline;
-        }
-        .article-content a:hover {
-            color: var(--color-secundario-dorado);
-        }
-        .back-link {
-            display: inline-block;
-            margin-bottom: 2em;
-            font-size: 0.9em;
-            color: var(--color-primario-purpura);
-            text-decoration: none;
-            border: 1px solid var(--color-primario-purpura);
-            padding: 0.5em 1em;
-            border-radius: 5px;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .back-link:hover {
-            background-color: var(--color-primario-purpura);
-            color: var(--color-blanco-fondo);
-        }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
-
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/textos_antiguos.jpg'); min-height: 40vh;">
         <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
             <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">Orígenes del Castellano Vulgar en el Alfoz de Cerezo</h1>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
-
                 <h3>El Alfoz de Cerezo y la Lengua Castellana</h3>
                 <p>Desde Cerezo se gobernaba las Bardulias, dese la cuidad de Auka Patricia (patriniani) con nuestra episcopi de San Martín con 116 metros de largo, toda la provincia Cantábrica en tiempos visigodos (los montes de Cantabria en la Rioja). Somos el Origen de Castilla y del Idioma Castellano y la ciudad de Auka Patricia.</p>
                 <p>En la Ciudad de Auca Patricia capital visigoda de la Cantabrica, desde donde se gobiernan las bardulias, desde la civittate Patricia o patriciani, desde la episcopi de San Martín, desde el Monumental Alcázar con su alfoz que se construyo con los restos de una civita Romana de oca, capital de la cantábrica pues cesar desembarco en segisamaclo sus legiones para su conquista. En Cerezo de Río Tirón origen de Castilla de su Cultura y de su Idioma con Valuesta en su Alfoz.</p>
                 <p>Con escritos de Castellano vulgares aun sin explorar tapados por polvo de miles de años, aun por leer e interpretar que nos guían sobre el origen del Castellano, desde las cuevas se ve San Millan de la Cogolla y Valpuesta esta en el Alfoz de Cerezo.</p>
-
                 <h4>Setefenestras y Valpuesta</h4>
                 <p>En el Origen de Castilla, aquí tenemos Castellano vulgar y el origen tapado y protegido por metro y medio de polvo de miles de años. En el mismo Alfoz que Valpuesta, el origen del idioma Castellano. Si te atreves a subir...</p>
                 <p>Aquí se encuentra dentro de sus paredes la historia completa del Idioma Castellano. Esta es su cuna. Puedes comprobarlo, si te atreves. Arqueología extrema. En Cerezo de Río Tirón. El camino se volvió abrir en septiembre del 2018. Cuantos miles de años tendrán los escritos o grafitis del vulgo que contienen sus paredes. El Origen del Castellano.</p>
                 <p>Milenarias y olvidadas cuevas de Setefenestras, ¿quien dice que no hay camino? Cuna del idioma castellano.</p>
                 <p>Que cerca están los dos fuentes escritas más antiguas del idioma Castellano, al igual que los dos Obispados mas antiguos de Castilla que son Auca y Valpuesta el Alfoz de Cerezo y Lantaron.</p>
-
                 <h4>Contexto Histórico-Lingüístico</h4>
                 <p>¿Porque los primeros escritos en el noble idioma Castellano están en Valpuesta del Alfoz de Cerezo?</p>
                 <p>Fijaros que la historia de Cerezo es la historia de nuestra cultura, cuando más profundicemos en la historia de Cerezo, más claro va ser quienes somos: nuestro idioma apenas si tiene paso visigodo por el... Luego ves que éramos un reducto romano hasta que el tonto de Abundio perdió la Civita frente a Leovigildo, en el 574, luego recadero vuelve otra vez a castigar a Cerezo porque se había vuelto Franco, así que de 120 años de dominación Visigoda, nunca dominaron Cerezo, si hubo un pequeño cambio cultural, pero auca Patricia tal y como dicen sus restos y su historia, nunca fue muy Visigoda. Pasando de ser Romana a Árabe, de la Civitate Auca Patricia romana al Alcazar de Casio en tiempo record.</p>
-
             </div>
         </section>
     </main>
-
-
-
     <?php require_once __DIR__ . '/../../_footer.php'; ?>
     <script src="/js/layout.js"></script>
 </body>

--- a/historia/subpaginas/san_vitores_san_formerio.php
+++ b/historia/subpaginas/san_vitores_san_formerio.php
@@ -1,84 +1,35 @@
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
 <head>
-    <style>
-        .article-content p {
-            margin-bottom: 1em;
-            line-height: 1.6;
-        }
-        .article-content h3 {
-            font-family: 'Cinzel', serif;
-            color: var(--color-secundario-dorado);
-            margin-top: 1.5em;
-            margin-bottom: 0.5em;
-        }
-        .article-content h4 {
-            font-family: 'Lora', serif;
-            font-style: italic;
-            color: var(--color-primario-purpura);
-            margin-top: 1em;
-            margin-bottom: 0.3em;
-        }
-        .article-content a {
-            color: var(--epic-gold-main);
-            text-decoration: underline;
-        }
-        .article-content a:hover {
-            color: var(--color-secundario-dorado);
-        }
-        .back-link {
-            display: inline-block;
-            margin-bottom: 2em;
-            font-size: 0.9em;
-            color: var(--color-primario-purpura);
-            text-decoration: none;
-            border: 1px solid var(--color-primario-purpura);
-            padding: 0.5em 1em;
-            border-radius: 5px;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .back-link:hover {
-            background-color: var(--color-primario-purpura);
-            color: var(--color-blanco-fondo);
-        }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
-
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/santos_vitores_formerio.jpg'); min-height: 40vh;">
         <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
             <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">San Vitores y San Formerio: Mártires de Cerezo</h1>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
-
                 <h3>San Formerio y el Circo Romano</h3>
                 <p>En las mas antiguas referencias a la historia de San Formerio dicen que en la Vega de los tormentos en el 277 en tiempos del emperador Aureliano, tenia en la vega de los Tormentos un Circo con Leones y un gobernador romano. Un Gobernador de provincia Romano solo puede ser en una ciudad en la zona, Aucam Patricia. Es extraño y no puedo explicar el nombre porque Cesarea pues no existe en la documentación romana de época una ciudad de Cesarea por la zona, por lo que no se a que se refriere con la Cesarea a la que hace referencia la historia del libro que enlazo al final del post, pues es la única fuente para dar a Cerezo el nombre de Cesarea.</p>
                 <p>Pero tambien en la Vega de los tormentos encontramos unas ruinas que dan la medida exacta para el circo de la historia de San Formerio, con una espina de 160 metros por 8 metros de ancho con agua en su interior y con el angulo para que las cuadrigas salgan de las carceres. el resto de medidas junto a las toponimias son correctas, no hay confusión pues allí no hay nada mas que las ruinas de un circo y una iglesia para sacralizar el lugar de los tormentos a los mártires cristianos, la Iglesia de Santi Emiliani, en Auca, en el valle de Asur. En la Ciudad de Oca capital de la Cantábrica. El circo de Auka Patricia.</p>
                 <p>Con el Circo romano de Auka Patricia en el valle de asur, con la iglesia de santi emiliani para santificar los tormentos a los cristianos acaecidos en el Circo, como dice la historia de San Formerio. Todos los escritos antiguos apuntan a la Arena de Quintanilleja como la ciudad de oca, lo cual nos perturbaba pues allí si hay un campamento romano de asirios en Campociudad o Castrociudad, pero no concebíamos un Mausoleo Imperial romano con Circo ritual como el de Majencio.</p>
-
                 <h4>San Vitores y su Martirio</h4>
                 <p>De Flavio Victor que decir si la tradición lo pone a nacer y morir en Cerezo, recordado en toda la ciudad de Auca y la Cantábrica. Decapitado como San Vitores el 26 de agosto del 388 en el Circo de la civita Auka Patricia. Aun tenemos marcada la piedra de la decapitación en Quintanilleja.</p>
                 <p>En el lugar de la decapitación de San Vitores hay un Mausoleo Romano con un circo ritual como el circo del emperador Majencio.</p>
                 <p>Flavio Victor 26 de Agosto del 388. San Vitores decapitado a 15 metros de circo el 26 de Agosto.</p>
                 <p>Acordaros que la zona de Álava que tambien se llama oca, nuestros condes de Cerasio Gobernaban tanto dentro de los dominios de Castilla como los de Álava, en tiempos romanos toda la Provincia Cantábrica o quizás hasta la Gallecia, San Formerio y San Vitores están por toda la Cantabria y la Gallecia distribuidos...</p>
-
                 <h4>Interpretaciones y Contexto</h4>
                 <p>Leamos a Marino Pérez de Avellaneda con referencia a San Vitores: No obstante, como ya hemos señalado en 1983 (50), y por ciertos datos relativos a la administración y cargos que parecen de época romana en el Pasionario, cuya redacción sería bastante más antigua, pudiendo situarse entre los siglos IV y V, nos podemos plantear la hipótesis de que quienes le hubieran martirizado pudieran haber sido los romanos, y no los árabes.</p>
                 <p>Así que el Emperador hispano Flavio Victor nacido en la Civitate de Auca Patricia en la Gallecia, decapitado el 26 de agosto del 388 queda por poca duda que es uno de nuestros San Vitores.</p>
                 <p>Camino de Santiago por Cerezo de Río Tirón: Esta ruta aprovechaba los restos de la antigua vía Aurelia, que entraba en la Provincia por las márgenes del río Tirón, donde los geógrafos situaron Segisamunculum, la actual Cerezo; a su paso los peregrinos encontraban el sepulcro de San Vítores, un santo mártir local que había sido decapitado por los moros.</p>
-
             </div>
         </section>
     </main>
-
-
-
     <?php require_once __DIR__ . '/../../_footer.php'; ?>
     <script src="/js/layout.js"></script>
 </body>

--- a/historia/subpaginas_indice.php
+++ b/historia/subpaginas_indice.php
@@ -6,7 +6,6 @@ $error_message = '';
 if (file_exists($json_path)) {
     $json_content = file_get_contents($json_path);
     $decoded_data = json_decode($json_content, true);
-
     if (json_last_error() === JSON_ERROR_NONE) {
         $page_data = $decoded_data;
     } else {
@@ -15,90 +14,33 @@ if (file_exists($json_path)) {
 } else {
     $error_message = 'Error: No se pudo encontrar el archivo JSON de datos: ' . $json_path;
 }
-
 // Valores por defecto por si el JSON falla o no tiene todos los campos
 $titulo_pagina = $page_data['titulo_pagina'] ?? 'Índice de Temas Históricos';
 $descripcion_general = $page_data['descripcion_general'] ?? 'No se pudo cargar la descripción.';
 $temas_detallados = $page_data['temas_detallados'] ?? [];
-
 ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo htmlspecialchars($titulo_pagina); ?> - Cerezo de Río Tirón</title>
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
-
     <!-- Google Fonts, FontAwesome, and epic_theme.css are now in head_common.php -->
-    <style>
-        .subpage-index-list {
-            list-style-type: none;
-            padding: 0;
-        }
-        .subpage-index-item {
-            background-color: rgba(var(--color-primario-purpura-rgb), 0.05);
-            border: 1px solid rgba(var(--color-primario-purpura-rgb), 0.2);
-            padding: 1.5em;
-            margin-bottom: 1.5em;
-            border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.05);
-        }
-        .subpage-index-item h3 {
-            font-family: 'Cinzel', serif;
-            color: var(--color-primario-purpura);
-            margin-top: 0;
-            margin-bottom: 0.5em;
-        }
-        .subpage-index-item p {
-            font-family: 'Lora', serif;
-            line-height: 1.6;
-            color: var(--color-texto-principal);
-            margin-bottom: 1em;
-        }
-        .read-more {
-            display: inline-block;
-            padding: 0.6em 1.2em;
-            background-color: var(--epic-gold-main);
-            color: var(--color-blanco-fondo);
-            text-decoration: none;
-            border-radius: 5px;
-            font-weight: bold;
-            transition: background-color 0.3s ease;
-        }
-        .read-more:hover {
-            background-color: var(--color-secundario-dorado);
-            color: var(--color-negro-contraste);
-        }
-        .page-header.hero {
-            min-height: 30vh; /* Reduced height for index page */
-        }
-        .error-message {
-            background-color: #ffdddd;
-            border: 1px solid #ff0000;
-            color: #d8000c;
-            padding: 1em;
-            margin: 1em 0;
-            border-radius: 5px;
-        }
-    </style>
 </head>
 <body>
-
     <?php require_once __DIR__ . '/../_header.php'; ?>
-
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/imagenes/mapa_antiguo_detalle.jpg');">
         <div class="hero-content">
             <h1><?php echo htmlspecialchars($titulo_pagina); ?></h1>
         </div>
     </header>
-
     <main>
         <section class="section">
             <div class="container">
                 <h2>Explorando la Historia de Cerezo de Río Tirón en Detalle</h2>
-
                 <?php if (!empty($error_message)): ?>
                     <div class="error-message">
                         <p><?php echo htmlspecialchars($error_message); ?></p>
@@ -106,7 +48,6 @@ $temas_detallados = $page_data['temas_detallados'] ?? [];
                 <?php else: ?>
                     <p style="text-align: center; max-width: 80ch; margin-left: auto; margin-right: auto; margin-bottom: 2em;"><?php echo htmlspecialchars($descripcion_general); ?></p>
                     <p style="text-align: center; margin-bottom: 2.5em;"><a href="/historia/nuestra_historia_nuevo4.html" class="read-more" style="background-color: var(--color-primario-purpura);">&laquo; Volver a la página principal de Nuestra Historia</a></p>
-
                     <?php if (!empty($temas_detallados)): ?>
                         <ul class="subpage-index-list">
                             <?php foreach ($temas_detallados as $tema): ?>
@@ -125,13 +66,10 @@ $temas_detallados = $page_data['temas_detallados'] ?? [];
                         <p>No hay temas detallados disponibles en este momento.</p>
                     <?php endif; ?>
                 <?php endif; ?>
-
             </div>
         </section>
     </main>
-
     <?php require_once __DIR__ . '/../_footer.php'; ?>
     <script src="/js/layout.js"></script>
-
 </body>
 </html>

--- a/historia_cerezo/index.php
+++ b/historia_cerezo/index.php
@@ -1,18 +1,12 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
 <head>
     <title>Historia de Cerezo: Cuna y Origen de Castilla</title>
-    <style>
-        body { font-family: sans-serif; margin: 20px; }
-        nav ul { list-style-type: none; padding: 0; }
-        nav ul li { margin-bottom: 10px; }
-        nav h2 { margin-top: 30px; }
-    </style>
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>
 
     <h1>Historia de Cerezo: Cuna y Origen de Castilla</h1>
-
     <nav>
         <h2>Índice de Capítulos</h2>
         <ul>
@@ -28,17 +22,12 @@
             <li><a href="capitulo10.php">Capítulo 10: Cerezo en la Edad Moderna (Siglos XVI-XVIII): Entre la Tradición y las Nuevas Corrientes</a></li>
             <li><a href="capitulo11.php">Capítulo 11: Cerezo en la Edad Contemporánea (Siglos XIX-XXI): Desafíos, Transformaciones y Mirada al Futuro</a></li>
         </ul>
-
         <h2>Exploración Temática</h2>
-        <ul>
             <li><a href="indices/personajes.php">Índice de Personajes</a></li>
             <li><a href="indices/lugares.php">Índice de Lugares</a></li>
             <li><a href="indices/temas_clave.php">Índice de Temas Clave</a></li>
-        </ul>
     </nav>
-
     <?php require_once __DIR__ . '/../_footer.php'; ?>
-
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/includes/load_page_css.php
+++ b/includes/load_page_css.php
@@ -1,8 +1,16 @@
 <?php
-$cssFile = '/assets/css/pages/' . basename($_SERVER['SCRIPT_NAME'], '.php') . '.css';
+$scriptPath = $_SERVER['SCRIPT_NAME'];
 $root = dirname(__DIR__);
 
-// Ensure consolidated navigation styles are loaded
+// Allow CSS files that mirror the script path using underscores
+$sanitized = str_replace('/', '_', ltrim($scriptPath, '/'));
+$sanitized = preg_replace('/\.php$/', '', $sanitized);
+$cssFile = '/assets/css/pages/' . $sanitized . '.css';
+
+if (!file_exists($root . $cssFile)) {
+    // Fallback to using only the basename for backwards compatibility
+    $cssFile = '/assets/css/pages/' . basename($scriptPath, '.php') . '.css';
+}
 
 if (file_exists($root . $cssFile)) {
     echo "<link rel=\"stylesheet\" href=\"{$cssFile}\">\n";


### PR DESCRIPTION
## Summary
- remove `<style>` blocks from history pages
- add `load_page_css.php` includes for history pages
- load page-specific CSS via sanitized path support
- store styles for history pages under `assets/css/pages`

## Testing
- `composer install` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68529a46eb20832999cc90db9bab7cfa