### PR TITLE
Add alt text verification to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
 
+      - name: Verificar atributos alt
+        run: ./scripts/check_alt_texts.sh
+
       - name: Run PHPStan
         run: vendor/bin/phpstan
 

--- a/README.md
+++ b/README.md
@@ -187,4 +187,6 @@ Ejecuta el script `check_alt_texts.sh` para detectar imágenes sin atributo `alt
 ./scripts/check_alt_texts.sh
 ```
 
+Esta comprobación se ejecuta automáticamente en cada pull request gracias a la configuración de GitHub Actions.
+
 Puedes indicar una ruta concreta como argumento si solo quieres escanear una carpeta determinada. El comando mostrará las líneas problemáticas y devolverá un código de salida distinto de cero si encuentra imágenes sin descripción.


### PR DESCRIPTION
## Summary
- add step to GitHub Actions workflow to check alt text
- document automatic alt text verification in README

## Testing
- `composer install --no-interaction --no-progress --prefer-dist` *(fails: command not found)*
- `vendor/bin/phpunit --coverage-clover build/coverage.xml` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6852ab0a3f208329bf055ca74ca911c5