### PR TITLE
Standardize history pages layout

### DIFF
--- a/assets/css/pages/historia_subpaginas_alcazar_de_cerasio.css
+++ b/assets/css/pages/historia_subpaginas_alcazar_de_cerasio.css
@@ -37,3 +37,13 @@
             background-color: var(--color-primario-purpura);
             color: var(--color-blanco-fondo);
         }
+
+#hero-alcazar-de-cerasio {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/alcazar_detalle.jpg'); min-height: 40vh;
+}
+#hero-alcazar-de-cerasio .hero-content {
+    padding: clamp(20px, 4vw, 40px);
+}
+#hero-alcazar-de-cerasio h1 {
+    font-size: clamp(2.2em, 5vw, 3.5em);
+}

--- a/assets/css/pages/historia_subpaginas_alfoz_cerezo_lantaron.css
+++ b/assets/css/pages/historia_subpaginas_alfoz_cerezo_lantaron.css
@@ -37,3 +37,13 @@
             background-color: var(--color-primario-purpura);
             color: var(--color-blanco-fondo);
         }
+
+#hero-alfoz-cerezo-lantaron {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/alfoz_panoramica.jpg'); min-height: 40vh;
+}
+#hero-alfoz-cerezo-lantaron .hero-content {
+    padding: clamp(20px, 4vw, 40px);
+}
+#hero-alfoz-cerezo-lantaron h1 {
+    font-size: clamp(2.2em, 5vw, 3.5em);
+}

--- a/assets/css/pages/historia_subpaginas_auca_patricia_ubicacion.css
+++ b/assets/css/pages/historia_subpaginas_auca_patricia_ubicacion.css
@@ -76,3 +76,13 @@
             color: red;
             font-size: 0.8em;
         }
+
+#hero-auca-patricia-ubicacion {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/paisaje_cerezo.jpg'); min-height: 40vh;
+}
+#hero-auca-patricia-ubicacion .hero-content {
+    padding: clamp(20px, 4vw, 40px);
+}
+#hero-auca-patricia-ubicacion h1 {
+    font-size: clamp(2.2em, 5vw, 3.5em);
+}

--- a/assets/css/pages/historia_subpaginas_becerro_galicano_origen_castilla.css
+++ b/assets/css/pages/historia_subpaginas_becerro_galicano_origen_castilla.css
@@ -44,3 +44,13 @@
             font-style: italic;
             color: #555;
         }
+
+#hero-becerro-galicano-origen-castilla {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/becerro_galicano.jpg'); min-height: 40vh;
+}
+#hero-becerro-galicano-origen-castilla .hero-content {
+    padding: clamp(20px, 4vw, 40px);
+}
+#hero-becerro-galicano-origen-castilla h1 {
+    font-size: clamp(2.2em, 5vw, 3.5em);
+}

--- a/assets/css/pages/historia_subpaginas_condes_castilla_alava_cerasio.css
+++ b/assets/css/pages/historia_subpaginas_condes_castilla_alava_cerasio.css
@@ -43,3 +43,13 @@
             border-radius: 3px;
             font-weight: bold;
         }
+
+#hero-condes-castilla-alava-cerasio {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/condes_hero.jpg'); min-height: 40vh;
+}
+#hero-condes-castilla-alava-cerasio .hero-content {
+    padding: clamp(20px, 4vw, 40px);
+}
+#hero-condes-castilla-alava-cerasio h1 {
+    font-size: clamp(2.2em, 5vw, 3.5em);
+}

--- a/assets/css/pages/historia_subpaginas_evidencia_arqueologica_cerezo.css
+++ b/assets/css/pages/historia_subpaginas_evidencia_arqueologica_cerezo.css
@@ -50,3 +50,13 @@
             border-radius: 5px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         }
+
+#hero-evidencia-arqueologica-cerezo {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/arqueologia_cerezo.jpg'); min-height: 40vh;
+}
+#hero-evidencia-arqueologica-cerezo .hero-content {
+    padding: clamp(20px, 4vw, 40px);
+}
+#hero-evidencia-arqueologica-cerezo h1 {
+    font-size: clamp(2.2em, 5vw, 3.5em);
+}

--- a/assets/css/pages/historia_subpaginas_legado_romano_emperadores_estructuras.css
+++ b/assets/css/pages/historia_subpaginas_legado_romano_emperadores_estructuras.css
@@ -37,3 +37,13 @@
             background-color: var(--color-primario-purpura);
             color: var(--color-blanco-fondo);
         }
+
+#hero-legado-romano-emperadores-estructuras {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/romano_detalle.jpg'); min-height: 40vh;
+}
+#hero-legado-romano-emperadores-estructuras .hero-content {
+    padding: clamp(20px, 4vw, 40px);
+}
+#hero-legado-romano-emperadores-estructuras h1 {
+    font-size: clamp(2.2em, 5vw, 3.5em);
+}

--- a/assets/css/pages/historia_subpaginas_obispado_auca_cerezo.css
+++ b/assets/css/pages/historia_subpaginas_obispado_auca_cerezo.css
@@ -3,3 +3,13 @@
         .article-content h4 { font-family: 'Lora', serif; font-style: italic; color: var(--color-primario-purpura); margin-top: 1em; margin-bottom: 0.3em; }
         .back-link { display:inline-block; margin-bottom:2em; font-size:0.9em; color:var(--color-primario-purpura); text-decoration:none; border:1px solid var(--color-primario-purpura); padding:0.5em 1em; border-radius:5px; transition:background-color 0.3s, color 0.3s; }
         .back-link:hover { background-color:var(--color-primario-purpura); color:var(--color-blanco-fondo); }
+
+#hero-obispado-auca-cerezo {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/iglesia_detalle.jpg'); min-height: 40vh;
+}
+#hero-obispado-auca-cerezo .hero-content {
+    padding: clamp(20px, 4vw, 40px);
+}
+#hero-obispado-auca-cerezo h1 {
+    font-size: clamp(2.2em, 5vw, 3.5em);
+}

--- a/assets/css/pages/historia_subpaginas_obispado_oca_auca.css
+++ b/assets/css/pages/historia_subpaginas_obispado_oca_auca.css
@@ -37,3 +37,13 @@
             background-color: var(--color-primario-purpura);
             color: var(--color-blanco-fondo);
         }
+
+#hero-obispado-oca-auca {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/iglesia_detalle.jpg'); min-height: 40vh;
+}
+#hero-obispado-oca-auca .hero-content {
+    padding: clamp(20px, 4vw, 40px);
+}
+#hero-obispado-oca-auca h1 {
+    font-size: clamp(2.2em, 5vw, 3.5em);
+}

--- a/assets/css/pages/historia_subpaginas_origenes_castellano_vulgar.css
+++ b/assets/css/pages/historia_subpaginas_origenes_castellano_vulgar.css
@@ -37,3 +37,13 @@
             background-color: var(--color-primario-purpura);
             color: var(--color-blanco-fondo);
         }
+
+#hero-origenes-castellano-vulgar {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/textos_antiguos.jpg'); min-height: 40vh;
+}
+#hero-origenes-castellano-vulgar .hero-content {
+    padding: clamp(20px, 4vw, 40px);
+}
+#hero-origenes-castellano-vulgar h1 {
+    font-size: clamp(2.2em, 5vw, 3.5em);
+}

--- a/assets/css/pages/historia_subpaginas_san_vitores_san_formerio.css
+++ b/assets/css/pages/historia_subpaginas_san_vitores_san_formerio.css
@@ -37,3 +37,13 @@
             background-color: var(--color-primario-purpura);
             color: var(--color-blanco-fondo);
         }
+
+#hero-san-vitores-san-formerio {
+    background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/santos_vitores_formerio.jpg'); min-height: 40vh;
+}
+#hero-san-vitores-san-formerio .hero-content {
+    padding: clamp(20px, 4vw, 40px);
+}
+#hero-san-vitores-san-formerio h1 {
+    font-size: clamp(2.2em, 5vw, 3.5em);
+}

--- a/historia/subpaginas/alcazar_de_cerasio.php
+++ b/historia/subpaginas/alcazar_de_cerasio.php
@@ -1,13 +1,16 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <title>El Alcázar de Cerasio: Fortaleza de Castilla</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/alcazar_detalle.jpg'); min-height: 40vh;">
-        <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
-            <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">El Alcázar de Cerasio: Fortaleza de Castilla</h1>
+<header id="hero-alcazar-de-cerasio" class="page-header hero">
+        <div class="hero-content">
+            <h1>El Alcázar de Cerasio: Fortaleza de Castilla</h1>
         </div>
     </header>
     <main>
@@ -33,7 +36,8 @@
             </div>
         </section>
     </main>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia/subpaginas/alfoz_cerezo_lantaron.php
+++ b/historia/subpaginas/alfoz_cerezo_lantaron.php
@@ -1,13 +1,16 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <title>El Alfoz de Cerezo y Lantarón: Territorio Histórico</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/alfoz_panoramica.jpg'); min-height: 40vh;">
-        <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
-            <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">El Alfoz de Cerezo y Lantarón: Territorio Histórico</h1>
+<header id="hero-alfoz-cerezo-lantaron" class="page-header hero">
+        <div class="hero-content">
+            <h1>El Alfoz de Cerezo y Lantarón: Territorio Histórico</h1>
         </div>
     </header>
     <main>
@@ -30,7 +33,8 @@
             </div>
         </section>
     </main>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia/subpaginas/auca_patricia_ubicacion.php
+++ b/historia/subpaginas/auca_patricia_ubicacion.php
@@ -1,3 +1,13 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <title><?php echo htmlspecialchars($titulo_pagina_actual); ?> - Cerezo de Río Tirón</title>
+</head>
+<body>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
+
 <?php
 $id_tema_actual = "auca_patricia_ubicacion"; // ID de esta página específica
 
@@ -47,7 +57,6 @@ if (file_exists($json_historia_indice_path)) {
         $error_message_breadcrumb .= 'Error al decodificar historia_indice.json o título no encontrado. ';
     $error_message_breadcrumb .= 'No se pudo encontrar historia_indice.json. ';
 // Título de la página actual (podría venir del JSON si esta página también fuera generada por el script)
-$titulo_pagina_actual = $breadcrumb_tema_actual_texto; // Usar el título del tema para el <title>
 // Asumiendo que $pdo no está disponible aún, o para asegurar que sí lo esté.
 require_once __DIR__ . '/../../../dashboard/db_connect.php'; // Ajustar ruta si es necesario
 /** @var PDO $pdo */
@@ -56,22 +65,12 @@ if (!$pdo) {
 }
 require_once __DIR__ . '/../../../includes/text_manager.php';
 ?>
-<!DOCTYPE html>
-<html lang="es">
-<head>
-<?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../../includes/load_page_css.php'; ?>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?php echo htmlspecialchars($titulo_pagina_actual); ?> - Cerezo de Río Tirón</title>
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
-    <!-- Google Fonts, FontAwesome, and epic_theme.css are now in head_common.php -->
-</head>
-<body>
-    <?php require_once __DIR__ . '/../../../_header.php'; ?>
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/paisaje_cerezo.jpg'); min-height: 40vh;">
-        <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
-            <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);"><?php echo htmlspecialchars($titulo_pagina_actual); ?></h1>
+    <header id="hero-auca-patricia-ubicacion" class="page-header hero">
+        <div class="hero-content">
+            <h1><?php echo htmlspecialchars($titulo_pagina_actual); ?></h1>
         </div>
     </header>
     <main>
@@ -113,7 +112,6 @@ require_once __DIR__ . '/../../../includes/text_manager.php';
             </div> <!-- Cierre de .container (para la sección) -->
         </section>
     </main>
-    <?php require_once __DIR__ . '/../../../_footer.php'; ?>
     <script>
         // Script para el menú de navegación móvil
         const navToggle = document.querySelector('.nav-toggle');
@@ -131,6 +129,8 @@ require_once __DIR__ . '/../../../includes/text_manager.php';
                     navLinks.classList.remove('active');
             });
     </script>
-    <!-- Removed navbar script, as navbar is replaced by _header.php -->
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
+    <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia/subpaginas/becerro_galicano_origen_castilla.php
+++ b/historia/subpaginas/becerro_galicano_origen_castilla.php
@@ -1,13 +1,16 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <title>El Becerro Galicano y el Origen de Castilla en Auca</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/becerro_galicano.jpg'); min-height: 40vh;">
-        <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
-            <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">El Becerro Galicano y el Origen de Castilla en Auca</h1>
+<header id="hero-becerro-galicano-origen-castilla" class="page-header hero">
+        <div class="hero-content">
+            <h1>El Becerro Galicano y el Origen de Castilla en Auca</h1>
         </div>
     </header>
     <main>
@@ -40,7 +43,8 @@
             </div>
         </section>
     </main>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia/subpaginas/condes_castilla_alava_cerasio.php
+++ b/historia/subpaginas/condes_castilla_alava_cerasio.php
@@ -1,13 +1,16 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <title>Condes de Castilla y Álava en el Alcázar de Cerasio</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/condes_hero.jpg'); min-height: 40vh;">
-        <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
-            <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">Condes de Castilla y Álava en el Alcázar de Cerasio</h1>
+<header id="hero-condes-castilla-alava-cerasio" class="page-header hero">
+        <div class="hero-content">
+            <h1>Condes de Castilla y Álava en el Alcázar de Cerasio</h1>
         </div>
     </header>
     <main>
@@ -31,7 +34,8 @@
             </div>
         </section>
     </main>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia/subpaginas/evidencia_arqueologica_cerezo.php
+++ b/historia/subpaginas/evidencia_arqueologica_cerezo.php
@@ -1,13 +1,16 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <title>Evidencia Arqueológica en Cerezo de Río Tirón</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/arqueologia_cerezo.jpg'); min-height: 40vh;">
-        <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
-            <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">Evidencia Arqueológica en Cerezo de Río Tirón</h1>
+<header id="hero-evidencia-arqueologica-cerezo" class="page-header hero">
+        <div class="hero-content">
+            <h1>Evidencia Arqueológica en Cerezo de Río Tirón</h1>
         </div>
     </header>
     <main>
@@ -41,7 +44,8 @@
             </div>
         </section>
     </main>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia/subpaginas/legado_romano_emperadores_estructuras.php
+++ b/historia/subpaginas/legado_romano_emperadores_estructuras.php
@@ -1,13 +1,16 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <title>Legado Romano en Cerezo: Emperadores y Estructuras</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/romano_detalle.jpg'); min-height: 40vh;">
-        <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
-            <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">Legado Romano en Cerezo: Emperadores y Estructuras</h1>
+<header id="hero-legado-romano-emperadores-estructuras" class="page-header hero">
+        <div class="hero-content">
+            <h1>Legado Romano en Cerezo: Emperadores y Estructuras</h1>
         </div>
     </header>
     <main>
@@ -41,7 +44,8 @@
             </div>
         </section>
     </main>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia/subpaginas/obispado_auca_cerezo.php
+++ b/historia/subpaginas/obispado_auca_cerezo.php
@@ -1,12 +1,16 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <title>El Obispado de Auca en Cerezo de Río Tirón</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/iglesia_detalle.jpg'); min-height: 40vh;">
-        <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
-            <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">El Obispado de Auca en Cerezo de Río Tirón</h1>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
+
+<header id="hero-obispado-auca-cerezo" class="page-header hero">
+        <div class="hero-content">
+            <h1>El Obispado de Auca en Cerezo de Río Tirón</h1>
         </div>
     </header>
     <main>
@@ -41,7 +45,8 @@
             </div>
         </section>
     </main>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia/subpaginas/obispado_oca_auca.php
+++ b/historia/subpaginas/obispado_oca_auca.php
@@ -1,13 +1,16 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <title>El Obispado de Oca/Auca y su Papel en la Historia</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/iglesia_detalle.jpg'); min-height: 40vh;">
-        <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
-            <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">El Obispado de Oca/Auca y su Papel en la Historia</h1>
+<header id="hero-obispado-oca-auca" class="page-header hero">
+        <div class="hero-content">
+            <h1>El Obispado de Oca/Auca y su Papel en la Historia</h1>
         </div>
     </header>
     <main>
@@ -36,7 +39,8 @@
             </div>
         </section>
     </main>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia/subpaginas/origenes_castellano_vulgar.php
+++ b/historia/subpaginas/origenes_castellano_vulgar.php
@@ -1,13 +1,16 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <title>Orígenes del Castellano Vulgar en el Alfoz de Cerezo</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/textos_antiguos.jpg'); min-height: 40vh;">
-        <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
-            <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">Orígenes del Castellano Vulgar en el Alfoz de Cerezo</h1>
+<header id="hero-origenes-castellano-vulgar" class="page-header hero">
+        <div class="hero-content">
+            <h1>Orígenes del Castellano Vulgar en el Alfoz de Cerezo</h1>
         </div>
     </header>
     <main>
@@ -29,7 +32,8 @@
             </div>
         </section>
     </main>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia/subpaginas/san_vitores_san_formerio.php
+++ b/historia/subpaginas/san_vitores_san_formerio.php
@@ -1,13 +1,16 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <title>San Vitores y San Formerio: Mártires de Cerezo</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/imagenes/santos_vitores_formerio.jpg'); min-height: 40vh;">
-        <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
-            <h1 style="font-size: clamp(2.2em, 5vw, 3.5em);">San Vitores y San Formerio: Mártires de Cerezo</h1>
+<header id="hero-san-vitores-san-formerio" class="page-header hero">
+        <div class="hero-content">
+            <h1>San Vitores y San Formerio: Mártires de Cerezo</h1>
         </div>
     </header>
     <main>
@@ -30,7 +33,8 @@
             </div>
         </section>
     </main>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/capitulo1/capitulo1.php
+++ b/historia_cerezo/capitulo1/capitulo1.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
     <title>Capítulo 1: Auca Patricia, la Ciudad Perdida</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
-    <h1>Capítulo 1: Auca Patricia, la Ciudad Perdida</h1>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
+
+<h1>Capítulo 1: Auca Patricia, la Ciudad Perdida</h1>
 
     <section id="evidencias-romanas">
         <h2>Evidencias de una gran ciudad romana</h2>
@@ -44,7 +48,7 @@
     <p><a href="../index.php">Volver al Índice Principal</a></p>
     <p><a href="../capitulo2/capitulo2.php">Continuar al Capítulo 2</a></p>
 
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/capitulo10.php
+++ b/historia_cerezo/capitulo10.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
     <title>Capítulo 10: Cerezo en la Edad Moderna (Siglos XVI-XVIII): Entre la Tradición y las Nuevas Corrientes</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../_header.php'; ?>
-    <h1>Capítulo 10: Cerezo en la Edad Moderna (Siglos XVI-XVIII): Entre la Tradición y las Nuevas Corrientes</h1>
+    <?php require_once __DIR__ . "/../_header.php"; ?>
+
+<h1>Capítulo 10: Cerezo en la Edad Moderna (Siglos XVI-XVIII): Entre la Tradición y las Nuevas Corrientes</h1>
 
     <section id="introduccion-antiguo-regimen">
         <h2>Introducción: Cerezo en el Antiguo Régimen</h2>
@@ -56,7 +60,7 @@
     <p><a href="capitulo9.php">Volver al Capítulo 9</a></p>
     <p><a href="index.php">Volver al Índice Principal</a></p>
 
-    <?php require_once __DIR__ . '/../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/capitulo11.php
+++ b/historia_cerezo/capitulo11.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
     <title>Capítulo 11: Cerezo en la Edad Contemporánea (Siglos XIX-XXI): Desafíos, Transformaciones y Mirada al Futuro</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../_header.php'; ?>
-    <h1>Capítulo 11: Cerezo en la Edad Contemporánea (Siglos XIX-XXI): Desafíos, Transformaciones y Mirada al Futuro</h1>
+    <?php require_once __DIR__ . "/../_header.php"; ?>
+
+<h1>Capítulo 11: Cerezo en la Edad Contemporánea (Siglos XIX-XXI): Desafíos, Transformaciones y Mirada al Futuro</h1>
 
     <section id="introduccion-nuevo-siglo">
         <h2>Introducción: Un Nuevo Siglo, Nuevos Retos</h2>
@@ -64,7 +68,7 @@
     <p><a href="capitulo10.php">Volver al Capítulo 10</a></p>
     <p><a href="index.php">Volver al Índice Principal</a></p>
 
-    <?php require_once __DIR__ . '/../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/capitulo2/capitulo2.php
+++ b/historia_cerezo/capitulo2/capitulo2.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
     <title>Capítulo 2: El Alcázar de Cerasio y los Inicios de Castilla</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
-    <h1>Capítulo 2: El Alcázar de Cerasio y los Inicios de Castilla</h1>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
+
+<h1>Capítulo 2: El Alcázar de Cerasio y los Inicios de Castilla</h1>
 
     <section>
         <h2 id="conde-casio-alcazar">El Conde Casio y la Construcción del Alcázar</h2>
@@ -33,7 +37,7 @@
     <p><a href="../capitulo3/capitulo3.php">Continuar al Capítulo 3</a></p>
     <p><a href="../index.php">Volver al Índice Principal</a></p>
 
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/capitulo3/capitulo3.php
+++ b/historia_cerezo/capitulo3/capitulo3.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
     <title>Capítulo 3: Vestigios y Legado en Cerezo de Río Tirón</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
-    <h1>Capítulo 3: Vestigios y Legado en Cerezo de Río Tirón</h1>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
+
+<h1>Capítulo 3: Vestigios y Legado en Cerezo de Río Tirón</h1>
 
     <section>
         <h2 id="estructuras">Estructuras Defensivas, Religiosas y Civiles: Un Paisaje Histórico</h2>
@@ -40,7 +44,7 @@
     <p><a href="../capitulo4/capitulo4.php">Continuar al Capítulo 4</a></p>
     <p><a href="../index.php">Volver al Índice Principal</a></p>
 
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/capitulo4/capitulo4.php
+++ b/historia_cerezo/capitulo4/capitulo4.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
     <title>Capítulo 4: Interpretaciones y Debate Histórico (Trazas Cruzadas)</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
-    <h1>Capítulo 4: Interpretaciones y Debate Histórico (Trazas Cruzadas)</h1>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
+
+<h1>Capítulo 4: Interpretaciones y Debate Histórico (Trazas Cruzadas)</h1>
 
     <section>
         <h2 id="fuentes-primarias">La Crucial Relectura de las Fuentes Primarias</h2>
@@ -41,7 +45,7 @@
     <p><a href="../capitulo5.php">Continuar al Capítulo 5</a></p>
     <p><a href="../index.php">Volver al Índice Principal</a></p>
 
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/capitulo5.php
+++ b/historia_cerezo/capitulo5.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
     <title>Capítulo 5: Cerezo en la Alta Edad Media: Entre Condes y Reyes</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../_header.php'; ?>
-    <h1>Capítulo 5: Cerezo en la Alta Edad Media: Entre Condes y Reyes</h1>
+    <?php require_once __DIR__ . "/../_header.php"; ?>
+
+<h1>Capítulo 5: Cerezo en la Alta Edad Media: Entre Condes y Reyes</h1>
 
     <section id="introduccion-baluarte">
         <h2>Introducción: Cerasio, Baluarte Consolidado</h2>
@@ -50,7 +54,7 @@
     <p><a href="capitulo6.php">Continuar al Capítulo 6</a></p>
     <p><a href="index.php">Volver al Índice Principal</a></p>
 
-    <?php require_once __DIR__ . '/../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/capitulo6.php
+++ b/historia_cerezo/capitulo6.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
     <title>Capítulo 6: La Vida Cotidiana en Cerasio: Siglos VIII-XI</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../_header.php'; ?>
-    <h1>Capítulo 6: La Vida Cotidiana en Cerasio: Siglos VIII-XI</h1>
+    <?php require_once __DIR__ . "/../_header.php"; ?>
+
+<h1>Capítulo 6: La Vida Cotidiana en Cerasio: Siglos VIII-XI</h1>
 
     <section id="introduccion-vivir-frontera">
         <h2>Introducción: Vivir en la Frontera de Castilla</h2>
@@ -57,7 +61,7 @@
     <p><a href="capitulo7.php">Continuar al Capítulo 7</a></p>
     <p><a href="index.php">Volver al Índice Principal</a></p>
 
-    <?php require_once __DIR__ . '/../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/capitulo7.php
+++ b/historia_cerezo/capitulo7.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
     <title>Capítulo 7: Las Huellas de Roma y el Mundo Prerromano en la Comarca de Cerezo</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../_header.php'; ?>
-    <h1>Capítulo 7: Las Huellas de Roma y el Mundo Prerromano en la Comarca de Cerezo</h1>
+    <?php require_once __DIR__ . "/../_header.php"; ?>
+
+<h1>Capítulo 7: Las Huellas de Roma y el Mundo Prerromano en la Comarca de Cerezo</h1>
 
     <section id="introduccion-paisaje-milenios">
         <h2>Introducción: Un Paisaje con Milenios de Historia</h2>
@@ -64,7 +68,7 @@
     <p><a href="capitulo8.php">Continuar al Capítulo 8</a></p>
     <p><a href="index.php">Volver al Índice Principal</a></p>
 
-    <?php require_once __DIR__ . '/../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/capitulo8.php
+++ b/historia_cerezo/capitulo8.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
     <title>Capítulo 8: Mitos Fundacionales y Leyendas de la Vieja Castilla en Cerezo</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../_header.php'; ?>
-    <h1>Capítulo 8: Mitos Fundacionales y Leyendas de la Vieja Castilla en Cerezo</h1>
+    <?php require_once __DIR__ . "/../_header.php"; ?>
+
+<h1>Capítulo 8: Mitos Fundacionales y Leyendas de la Vieja Castilla en Cerezo</h1>
 
     <section id="introduccion-historia-no-escrita">
         <h2>Introducción: La Historia no Escrita y el Alma de un Pueblo</h2>
@@ -55,7 +59,7 @@
     <p><a href="capitulo7.php">Volver al Capítulo 7</a></p>
     <p><a href="index.php">Volver al Índice Principal</a></p>
 
-    <?php require_once __DIR__ . '/../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/capitulo9.php
+++ b/historia_cerezo/capitulo9.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
     <title>Capítulo 9: Cerezo en la Plena y Baja Edad Media (Siglos XII-XV): Entre el Esplendor y la Crisis</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../_header.php'; ?>
-    <h1>Capítulo 9: Cerezo en la Plena y Baja Edad Media (Siglos XII-XV): Entre el Esplendor y la Crisis</h1>
+    <?php require_once __DIR__ . "/../_header.php"; ?>
+
+<h1>Capítulo 9: Cerezo en la Plena y Baja Edad Media (Siglos XII-XV): Entre el Esplendor y la Crisis</h1>
 
     <section id="introduccion-villa-consolidada">
         <h2>Introducción: Cerezo, Villa Castellana Consolidada</h2>
@@ -56,7 +60,7 @@
     <p><a href="capitulo8.php">Volver al Capítulo 8</a></p>
     <p><a href="index.php">Volver al Índice Principal</a></p>
 
-    <?php require_once __DIR__ . '/../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/entidades/fuentes/becerro_galicano_auca.php
+++ b/historia_cerezo/entidades/fuentes/becerro_galicano_auca.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../../includes/load_page_css.php"; ?>
     <title>El Becerro Galicano y la Mención de Auca/Area Paterniani</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../../_header.php'; ?>
-    <h1>El Becerro Galicano y la Mención de Auca/Area Paterniani</h1>
+    <?php require_once __DIR__ . "/../../../_header.php"; ?>
+
+<h1>El Becerro Galicano y la Mención de Auca/Area Paterniani</h1>
 
     <section>
         <h2>Citas Relevantes del Becerro</h2>
@@ -28,7 +32,7 @@
         <p>"Lo que está claro que en el Becerro Galicano de San Millán de la cogolla en el folio 142 y en el folio 190 nos habla que Castilla nace de las ruinas de la Ciudad de Auca Patricia."</p>
     </section>
 
-    <?php require_once __DIR__ . '/../../../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/entidades/lugares/alcazar_de_cerasio.php
+++ b/historia_cerezo/entidades/lugares/alcazar_de_cerasio.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../../includes/load_page_css.php"; ?>
     <title>El Alcázar de Cerasio</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../../_header.php'; ?>
-    <h1>El Alcázar de Cerasio</h1>
+    <?php require_once __DIR__ . "/../../../_header.php"; ?>
+
+<h1>El Alcázar de Cerasio</h1>
 
     <section>
         <h2>Descripción General</h2>
@@ -40,7 +44,7 @@
         <p>El tamaño y la magnificencia atribuidos al Alcázar de Cerasio son objeto de debate, especialmente en relación con su construcción utilizando los "escombros" de Auca Patricia. Estas afirmaciones son cruciales para la teoría que sitúa el origen de Castilla en Cerezo de Río Tirón.</p>
     </section>
 
-    <?php require_once __DIR__ . '/../../../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/entidades/personajes/conde_casio.php
+++ b/historia_cerezo/entidades/personajes/conde_casio.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../../includes/load_page_css.php"; ?>
     <title>El Conde Casio</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../../_header.php'; ?>
-    <h1>El Conde Casio</h1>
+    <?php require_once __DIR__ . "/../../../_header.php"; ?>
+
+<h1>El Conde Casio</h1>
 
     <section>
         <h2>Origen y Contexto</h2>
@@ -29,7 +33,7 @@
         <p>"El Conde Casio se fue con los Árabes y se volvió Moro dice Ibn Hazm, y se fue a Damasco y se hizo amigo del Califa."</p>
     </section>
 
-    <?php require_once __DIR__ . '/../../../_footer.php'; ?>
+    <?php require_once __DIR__ . "/../../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/index.php
+++ b/historia_cerezo/index.php
@@ -1,12 +1,14 @@
-<?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
     <title>Historia de Cerezo: Cuna y Origen de Castilla</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../_header.php'; ?>
+    <?php require_once __DIR__ . "/../_header.php"; ?>
 
-    <h1>Historia de Cerezo: Cuna y Origen de Castilla</h1>
+<h1>Historia de Cerezo: Cuna y Origen de Castilla</h1>
     <nav>
         <h2>Índice de Capítulos</h2>
         <ul>
@@ -27,7 +29,8 @@
             <li><a href="indices/lugares.php">Índice de Lugares</a></li>
             <li><a href="indices/temas_clave.php">Índice de Temas Clave</a></li>
     </nav>
-    <?php require_once __DIR__ . '/../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/indices/lugares.php
+++ b/historia_cerezo/indices/lugares.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
     <title>Índice de Lugares - Historia de Cerezo</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
-    <h1>Índice de Lugares Relevantes</h1>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
+
+<h1>Índice de Lugares Relevantes</h1>
     <ul>
         <li>Auca Patricia / Ciudad de Oca: <a href="../capitulo1/capitulo1.php">Ver Capítulo 1: Auca Patricia, la Ciudad Perdida</a></li>
         <li>Alcázar de Cerasio: <a href="../entidades/lugares/alcazar_de_cerasio.php">Ver módulo del Alcázar de Cerasio</a></li>
@@ -15,7 +19,8 @@
         <li>Valpuesta: <a href="../capitulo2/capitulo2.php#alfoz-cerezo">Mencionado en Capítulo 2: El Alfoz de Cerezo y Lantarón (Valpuesta)</a></li>
         <li>Hospital de San Jorge: <a href="../capitulo3/capitulo3.php#estructuras">Mencionado en Capítulo 3: Estructuras (Hospital San Jorge)</a></li>
     </ul>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/indices/personajes.php
+++ b/historia_cerezo/indices/personajes.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
     <title>Índice de Personajes - Historia de Cerezo</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
-    <h1>Índice de Personajes Relevantes</h1>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
+
+<h1>Índice de Personajes Relevantes</h1>
     <ul>
         <li>Conde Casio: <a href="../entidades/personajes/conde_casio.php">Ver módulo del Conde Casio</a></li>
         <li>Flavio Teodosio I el Grande: <a href="../capitulo1/capitulo1.php#emperadores-romanos">Mencionado en Capítulo 1: Emperadores Romanos</a></li>
@@ -18,7 +22,8 @@
         <li>San Vitores: <a href="../capitulo3/capitulo3.php#toponimia-tradiciones">Mencionado en Capítulo 3: Toponimia y Tradiciones</a></li>
         <li>San Formerio: <a href="../capitulo3/capitulo3.php#toponimia-tradiciones">Mencionado en Capítulo 3: Toponimia y Tradiciones</a></li>
     </ul>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/historia_cerezo/indices/temas_clave.php
+++ b/historia_cerezo/indices/temas_clave.php
@@ -1,10 +1,14 @@
-<?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+<!DOCTYPE html>
+<html lang="es">
 <head>
+    <?php include __DIR__ . "/../../includes/head_common.php"; ?>
+    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
     <title>Índice de Temas Clave - Historia de Cerezo</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/../../_header.php'; ?>
-    <h1>Índice de Temas Clave</h1>
+    <?php require_once __DIR__ . "/../../_header.php"; ?>
+
+<h1>Índice de Temas Clave</h1>
     <ul>
         <li>
             Origen de Castilla:
@@ -66,7 +70,8 @@
             </ul>
         </li>
     </ul>
-    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+
+    <?php require_once __DIR__ . "/../../_footer.php"; ?>
     <script src="/js/layout.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap all history pages in `historia_cerezo/` and `historia/subpaginas/` with shared header/footer structure
- move hero inline styles to page CSS files

## Testing
- `composer install` *(fails: ext-dom missing)*
- `python -m unittest tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6852ab0da6e88329875e2b3f9f1a1163