### PR TITLE
Improve menu accessibility

### DIFF
--- a/_header.php
+++ b/_header.php
@@ -1,7 +1,7 @@
-<button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false">☰</button>
+<button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
 
 <!-- Left Sliding Panel for Main Menu -->
-<div id="consolidated-menu-items" class="menu-panel left-panel">
+<div id="consolidated-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="consolidated-menu-button">
     <button id="theme-toggle" class="menu-item-button" aria-label="Cambiar tema"><i class="fas fa-lightbulb"></i> <span>Tema</span></button>
     <button id="ai-chat-trigger" class="menu-item-button" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA"><i class="fas fa-comments"></i> <span>Chat IA</span></button>
 
@@ -37,7 +37,7 @@
 </div>
 
 <!-- Right Sliding Panel for AI Chat -->
-<div id="ai-chat-panel" class="menu-panel right-panel">
+<div id="ai-chat-panel" class="menu-panel right-panel" role="dialog" aria-labelledby="ai-chat-title">
     <?php
     // Content from ai-drawer.html will go here
     // It includes the header, response area, input, and submit button for AI chat

--- a/fragments/header/ai-drawer.html
+++ b/fragments/header/ai-drawer.html
@@ -1,6 +1,6 @@
 <div id="ai-drawer" class="ai-drawer">
   <div class="ai-drawer-header">
-    <h3>Asistente IA</h3>
+    <h3 id="ai-chat-title">Asistente IA</h3>
     <button id="close-ai-drawer" aria-label="Cerrar">×</button>
   </div>
   <div class="ai-drawer-content">

--- a/js/menu-controller.js
+++ b/js/menu-controller.js
@@ -16,6 +16,10 @@
             document.body.classList.add(`menu-open-${side}`);
             document.body.classList.add('menu-compressed');
         }
+        const button = document.querySelector(`[data-menu-target="${menu.id}"]`);
+        if(button){
+            button.setAttribute('aria-expanded', 'true');
+        }
     }
 
     function closeMenu(menu){
@@ -25,6 +29,10 @@
             document.body.classList.remove(`menu-open-${side}`);
         }
         document.body.classList.remove('menu-compressed');
+        const button = document.querySelector(`[data-menu-target="${menu.id}"]`);
+        if(button){
+            button.setAttribute('aria-expanded', 'false');
+        }
     }
 
     function toggleMenu(button){


### PR DESCRIPTION
## Summary
- add `role` and `aria` attributes to consolidated menu button
- label menu panels with `role` and `aria-labelledby`
- expose AI chat heading id for accessibility
- update `js/menu-controller.js` so `aria-expanded` tracks menu state

## Testing
- `composer install` *(fails: ext-dom missing)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6852ce9acccc83299543545f91c82b11