### PR TITLE
Add contact form backend submission

### DIFF
--- a/contacto/contacto.php
+++ b/contacto/contacto.php
@@ -49,7 +49,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 
                 <div class="contact-form-container">
                     <?php editableText('contacto_form_titulo', $pdo, 'Formulario de Contacto', 'h2', 'section-title'); ?>
-                    <form id="contactForm" action="mailto:info@condadodecastilla.com">
+                    <form id="contactForm" method="post" action="submit.php">
                         <div class="form-group">
                             <label for="nombre"><i class="fas fa-user"></i> <?php editableText('contacto_form_label_nombre_texto', $pdo, 'Nombre Completo:', 'span'); ?></label>
                             <input type="text" id="nombre" name="nombre" required placeholder="Tu nombre y apellidos">
@@ -94,9 +94,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
                     return;
                 }
                 
-                let mailtoLink = `mailto:info@condadodecastilla.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent("Nombre: " + name + "\nEmail: " + email + "\n\nMensaje:\n" + message)}`;
-                this.action = mailtoLink;
-                alert('Gracias por tu mensaje. Se abrirá tu correo para enviarlo.');
+                // Los datos se enviarán al servidor; solo validamos en el cliente.
             });
         }
     </script>

--- a/contacto/submit.php
+++ b/contacto/submit.php
@@ -1,0 +1,55 @@
+<?php
+require_once __DIR__ . '/../includes/env_loader.php';
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
+
+$feedback_message = '';
+$feedback_type = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['nombre'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $subject = trim($_POST['asunto'] ?? '');
+    $message = trim($_POST['mensaje'] ?? '');
+
+    if ($name === '' || $email === '' || $subject === '' || $message === '') {
+        $feedback_message = 'Por favor completa todos los campos.';
+        $feedback_type = 'error';
+    } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $feedback_message = 'Correo electrónico inválido.';
+        $feedback_type = 'error';
+    } else {
+        $to = getenv('CONTACT_EMAIL') ?: 'info@condadodecastilla.com';
+        $body = "Nombre: $name\nCorreo: $email\n\nMensaje:\n$message";
+        $headers = 'From: ' . $email;
+        $ok = true;
+        if (empty($GLOBALS['TESTING'])) {
+            $ok = mail($to, $subject, $body, $headers);
+        }
+        if ($ok) {
+            $feedback_message = 'Mensaje enviado correctamente.';
+            $feedback_type = 'success';
+        } else {
+            $feedback_message = 'Error al enviar el mensaje.';
+            $feedback_type = 'error';
+        }
+    }
+} else {
+    $feedback_message = 'Método no permitido.';
+    $feedback_type = 'error';
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Envío de Contacto</title>
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
+</head>
+<body>
+<div class="container-epic">
+    <p class="feedback <?php echo htmlspecialchars($feedback_type); ?>"><?php echo htmlspecialchars($feedback_message); ?></p>
+    <p><a href="/contacto/contacto.php">Volver al formulario</a></p>
+</div>
+</body>
+</html>

--- a/tests/ContactFormTest.php
+++ b/tests/ContactFormTest.php
@@ -1,0 +1,36 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ContactFormTest extends TestCase {
+    private function runScript(array $env): array {
+        $script = realpath(__DIR__.'/../contacto/submit.php');
+        $prepend = realpath(__DIR__.'/fixtures/contact_prepend.php');
+        $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
+            escapeshellarg($prepend),
+            escapeshellarg($script)
+        );
+        $env = array_merge([
+            'PATH' => getenv('PATH'),
+            'REDIRECT_STATUS' => '1',
+            'SCRIPT_FILENAME' => $script,
+            'REQUEST_METHOD' => 'POST'
+        ], $env);
+        $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        $status = proc_close($proc);
+        return [$status, $out, $err];
+    }
+
+    public function testSuccessfulSubmission(): void {
+        [$status, $out, $err] = $this->runScript([
+            'CONTACT_NOMBRE' => 'Juan',
+            'CONTACT_EMAIL' => 'juan@example.com',
+            'CONTACT_ASUNTO' => 'Hola',
+            'CONTACT_MENSAJE' => 'Prueba'
+        ]);
+        $this->assertSame(0, $status, $err);
+        $this->assertStringContainsString('Mensaje enviado correctamente', $out);
+    }
+}
+?>

--- a/tests/fixtures/contact_prepend.php
+++ b/tests/fixtures/contact_prepend.php
@@ -1,0 +1,16 @@
+<?php
+chdir(__DIR__ . '/..');
+set_include_path(__DIR__ . PATH_SEPARATOR . get_include_path());
+$_SERVER['HTTP_HOST'] = 'localhost';
+$_SERVER['HTTPS'] = 'off';
+$GLOBALS['TESTING'] = true;
+require_once __DIR__ . '/../../includes/session.php';
+ensure_session_started();
+$_SERVER['REQUEST_METHOD'] = getenv('REQUEST_METHOD') ?: 'POST';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $_POST['nombre'] = getenv('CONTACT_NOMBRE') ?: '';
+    $_POST['email'] = getenv('CONTACT_EMAIL') ?: '';
+    $_POST['asunto'] = getenv('CONTACT_ASUNTO') ?: '';
+    $_POST['mensaje'] = getenv('CONTACT_MENSAJE') ?: '';
+}
+?>


### PR DESCRIPTION
## Summary
- support POST submissions via `contacto/submit.php`
- post to new endpoint from the contact form
- add PHP unit test for form submission

## Testing
- `composer install --ignore-platform-req=ext-fileinfo`
- `vendor/bin/phpunit` *(fails: Missing target links and API tests)*

------
https://chatgpt.com/codex/tasks/task_e_6852ce9ba4fc8329a2d4e7a7914d5176