### PR TITLE
Update GSAP CDN URL

### DIFF
--- a/js/layout.js
+++ b/js/layout.js
@@ -238,7 +238,7 @@ function loadFixedTogglesCss() {
 function loadGsap() {
     if (!window.gsap) {
         const script = document.createElement('script');
-        script.src = 'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js';
+        script.src = 'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.13.0/gsap.min.js';
         document.head.appendChild(script);
     }
 }


### PR DESCRIPTION
## Summary
- update CDN URL for GSAP to version 3.13.0 in `js/layout.js`

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter`
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: `php-cgi: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852ce9d44ac83298e7848df38f191f0