### PR TITLE
Update README testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,11 @@ segundo lanzará todos los tests definidos en `phpunit.xml`.
 
 ### Pruebas de la API Flask
 
-Para ejecutar las pruebas escritas en Python que validan la API Flask utiliza:
+Instala primero las dependencias de Python y luego ejecuta las pruebas que
+validan la API Flask:
 
 ```bash
+pip install -r requirements.txt
 python -m unittest tests/test_flask_api.py
 ```
 


### PR DESCRIPTION
## Summary
- recommend installing requirements via `pip` before running API tests

## Testing
- `python -m unittest tests/test_flask_api.py`
- ❌ `vendor/bin/phpunit` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dbc7c79083298d93fd0549d29d6d