### PR TITLE
Add header element tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ vendor/bin/phpunit
 El primer comando descargará las dependencias necesarias, incluido PHPUnit, y el
 segundo lanzará todos los tests definidos en `phpunit.xml`.
 
+Se incluyen pruebas que cargan las páginas principales del sitio y comprueban la presencia del contenedor `#fixed-header-elements`. Ejecuta `vendor/bin/phpunit` para verificarlas.
+
 ### Pruebas de la API Flask
 
 Instala primero las dependencias de Python y luego ejecuta las pruebas que

--- a/tests/FixedHeaderElementsTest.php
+++ b/tests/FixedHeaderElementsTest.php
@@ -1,0 +1,49 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class FixedHeaderElementsTest extends TestCase {
+    private function runPage(string $script): array {
+        $prepend = realpath(__DIR__.'/fixtures/page_prepend.php');
+        $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
+            escapeshellarg($prepend),
+            escapeshellarg($script)
+        );
+        $env = [
+            'PATH' => getenv('PATH'),
+            'REDIRECT_STATUS' => '1',
+            'SCRIPT_FILENAME' => $script
+        ];
+        $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        $status = proc_close($proc);
+        return [$status, $out, $err];
+    }
+
+    public static function pageProvider(): array {
+        return [
+            [__DIR__.'/../index.php'],
+            [__DIR__.'/../historia/historia.php'],
+            [__DIR__.'/../museo/galeria.php'],
+            [__DIR__.'/../contacto/contacto.php'],
+            [__DIR__.'/../secciones_index/memoria_hispanidad.html'],
+            [__DIR__.'/../personajes/indice_personajes.html'],
+        ];
+    }
+
+    /**
+     * @dataProvider pageProvider
+     */
+    public function testFixedHeaderElementsPresent(string $path): void {
+        if (pathinfo($path, PATHINFO_EXTENSION) === 'php') {
+            [$status, $out, $err] = $this->runPage($path);
+            $this->assertSame(0, $status, $err);
+            $content = $out;
+        } else {
+            $content = file_get_contents($path);
+            $this->assertNotFalse($content, "Failed to read $path");
+        }
+        $this->assertStringContainsString('#fixed-header-elements', $content);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- add FixedHeaderElementsTest to ensure main pages include `#fixed-header-elements`
- mention new tests in README

## Testing
- `vendor/bin/phpunit | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6852e040243083299601d9126b34f73a