### PR TITLE
Fix link checker for lang query and include lang-bar script

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -19,3 +19,4 @@
 </div>
 </footer>
 <script src="/assets/js/main.js"></script>
+<script src="/js/lang-bar.js"></script>

--- a/check_links.sh
+++ b/check_links.sh
@@ -31,16 +31,24 @@ check_links_in_file() {
             continue
         fi
 
+        # Skip pure language selector links like ?lang=es
+        if [[ "$link" == \?lang=* ]]; then
+            continue
+        fi
+
+        # Strip query parameters to check actual file path
+        link_no_query="${link%%\?*}"
+
         # Normalize link: remove leading slash for ls compatibility if it's not the root
-        normalized_link="$link"
-        if [[ "$link" == /* ]]; then
+        normalized_link="$link_no_query"
+        if [[ "$link_no_query" == /* ]]; then
             # If link starts with /, treat it as relative to repo root
-            normalized_link="${link:1}"
+            normalized_link="${link_no_query:1}"
         fi
 
         # Handle cases where normalized_link might be empty after stripping leading /
         if [ -z "$normalized_link" ]; then
-            if [ "$link" == "/" ]; then # Special case for root link
+            if [ "$link_no_query" == "/" ]; then # Special case for root link
                  if [ -f "index.php" ] || [ -f "index.html" ]; then
                     echo "  OK: $link (points to root)" >> "$output_file"
                 else


### PR DESCRIPTION
## Summary
- load language bar script in the footer
- skip `?lang=` links in `check_links.sh`

## Testing
- `composer install` *(fails: ext-dom missing)*
- `vendor/bin/phpunit tests` *(fails: php-cgi missing, many test failures)*
- `pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: flask_app)*
- `./check_links.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852e040fa5083298a305e5fc2ed2e4b