### PR TITLE
Fix language bar links

### DIFF
--- a/fragments/header/language-bar.html
+++ b/fragments/header/language-bar.html
@@ -1,29 +1,29 @@
 <div class="language-bar">
-    <a href="?lang=es" class="lang-flag" title="Español">🇪🇸<span class="visually-hidden">Español</span></a>
-    <a href="?lang=en" class="lang-flag" title="English">🇬🇧<span class="visually-hidden">English</span></a>
-    <a href="?lang=fr" class="lang-flag" title="Français">🇫🇷<span class="visually-hidden">Français</span></a>
-    <a href="?lang=de" class="lang-flag" title="Deutsch">🇩🇪<span class="visually-hidden">Deutsch</span></a>
-    <a href="?lang=it" class="lang-flag" title="Italiano">🇮🇹<span class="visually-hidden">Italiano</span></a>
-    <a href="?lang=pt" class="lang-flag" title="Português">🇵🇹<span class="visually-hidden">Português</span></a>
-    <a href="?lang=ru" class="lang-flag" title="Русский">🇷🇺<span class="visually-hidden">Русский</span></a>
-    <a href="?lang=zh-CN" class="lang-flag" title="中文">🇨🇳<span class="visually-hidden">中文</span></a>
-    <a href="?lang=ja" class="lang-flag" title="日本語">🇯🇵<span class="visually-hidden">日本語</span></a>
-    <a href="?lang=ko" class="lang-flag" title="한국어">🇰🇷<span class="visually-hidden">한국어</span></a>
-    <a href="?lang=ar" class="lang-flag" title="العربية">🇸🇦<span class="visually-hidden">العربية</span></a>
-    <a href="?lang=hi" class="lang-flag" title="हिन्दी">🇮🇳<span class="visually-hidden">हिन्दी</span></a>
-    <a href="?lang=tr" class="lang-flag" title="Türkçe">🇹🇷<span class="visually-hidden">Türkçe</span></a>
-    <a href="?lang=id" class="lang-flag" title="Bahasa Indonesia">🇮🇩<span class="visually-hidden">Bahasa Indonesia</span></a>
-    <a href="?lang=vi" class="lang-flag" title="Tiếng Việt">🇻🇳<span class="visually-hidden">Tiếng Việt</span></a>
-    <a href="?lang=bn" class="lang-flag" title="বাংলা">🇧🇩<span class="visually-hidden">বাংলা</span></a>
-    <a href="?lang=ur" class="lang-flag" title="اردو">🇵🇰<span class="visually-hidden">اردو</span></a>
-    <a href="?lang=fa" class="lang-flag" title="فارسی">🇮🇷<span class="visually-hidden">فارسی</span></a>
-    <a href="?lang=nl" class="lang-flag" title="Nederlands">🇳🇱<span class="visually-hidden">Nederlands</span></a>
-    <a href="?lang=pl" class="lang-flag" title="Polski">🇵🇱<span class="visually-hidden">Polski</span></a>
-    <a href="?lang=uk" class="lang-flag" title="Українська">🇺🇦<span class="visually-hidden">Українська</span></a>
-    <a href="?lang=sw" class="lang-flag" title="Kiswahili">🇰🇪<span class="visually-hidden">Kiswahili</span></a>
-    <a href="?lang=sv" class="lang-flag" title="Svenska">🇸🇪<span class="visually-hidden">Svenska</span></a>
-    <a href="?lang=th" class="lang-flag" title="ไทย">🇹🇭<span class="visually-hidden">ไทย</span></a>
-    <a href="?lang=el" class="lang-flag" title="Ελληνικά">🇬🇷<span class="visually-hidden">Ελληνικά</span></a>
-    <a href="?lang=he" class="lang-flag" title="עברית">🇮🇱<span class="visually-hidden">עברית</span></a>
+    <a href="/?lang=es" class="lang-flag" title="Español">🇪🇸<span class="visually-hidden">Español</span></a>
+    <a href="/?lang=en" class="lang-flag" title="English">🇬🇧<span class="visually-hidden">English</span></a>
+    <a href="/?lang=fr" class="lang-flag" title="Français">🇫🇷<span class="visually-hidden">Français</span></a>
+    <a href="/?lang=de" class="lang-flag" title="Deutsch">🇩🇪<span class="visually-hidden">Deutsch</span></a>
+    <a href="/?lang=it" class="lang-flag" title="Italiano">🇮🇹<span class="visually-hidden">Italiano</span></a>
+    <a href="/?lang=pt" class="lang-flag" title="Português">🇵🇹<span class="visually-hidden">Português</span></a>
+    <a href="/?lang=ru" class="lang-flag" title="Русский">🇷🇺<span class="visually-hidden">Русский</span></a>
+    <a href="/?lang=zh-CN" class="lang-flag" title="中文">🇨🇳<span class="visually-hidden">中文</span></a>
+    <a href="/?lang=ja" class="lang-flag" title="日本語">🇯🇵<span class="visually-hidden">日本語</span></a>
+    <a href="/?lang=ko" class="lang-flag" title="한국어">🇰🇷<span class="visually-hidden">한국어</span></a>
+    <a href="/?lang=ar" class="lang-flag" title="العربية">🇸🇦<span class="visually-hidden">العربية</span></a>
+    <a href="/?lang=hi" class="lang-flag" title="हिन्दी">🇮🇳<span class="visually-hidden">हिन्दी</span></a>
+    <a href="/?lang=tr" class="lang-flag" title="Türkçe">🇹🇷<span class="visually-hidden">Türkçe</span></a>
+    <a href="/?lang=id" class="lang-flag" title="Bahasa Indonesia">🇮🇩<span class="visually-hidden">Bahasa Indonesia</span></a>
+    <a href="/?lang=vi" class="lang-flag" title="Tiếng Việt">🇻🇳<span class="visually-hidden">Tiếng Việt</span></a>
+    <a href="/?lang=bn" class="lang-flag" title="বাংলা">🇧🇩<span class="visually-hidden">বাংলা</span></a>
+    <a href="/?lang=ur" class="lang-flag" title="اردو">🇵🇰<span class="visually-hidden">اردو</span></a>
+    <a href="/?lang=fa" class="lang-flag" title="فارسی">🇮🇷<span class="visually-hidden">فارسی</span></a>
+    <a href="/?lang=nl" class="lang-flag" title="Nederlands">🇳🇱<span class="visually-hidden">Nederlands</span></a>
+    <a href="/?lang=pl" class="lang-flag" title="Polski">🇵🇱<span class="visually-hidden">Polski</span></a>
+    <a href="/?lang=uk" class="lang-flag" title="Українська">🇺🇦<span class="visually-hidden">Українська</span></a>
+    <a href="/?lang=sw" class="lang-flag" title="Kiswahili">🇰🇪<span class="visually-hidden">Kiswahili</span></a>
+    <a href="/?lang=sv" class="lang-flag" title="Svenska">🇸🇪<span class="visually-hidden">Svenska</span></a>
+    <a href="/?lang=th" class="lang-flag" title="ไทย">🇹🇭<span class="visually-hidden">ไทย</span></a>
+    <a href="/?lang=el" class="lang-flag" title="Ελληνικά">🇬🇷<span class="visually-hidden">Ελληνικά</span></a>
+    <a href="/?lang=he" class="lang-flag" title="עברית">🇮🇱<span class="visually-hidden">עברית</span></a>
 </div>
 <div id="google_translate_element"></div>


### PR DESCRIPTION
## Summary
- ensure language selector works under subdirectories by using absolute `/?lang=` links in `fragments/header/language-bar.html`

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- ❌ `composer install && vendor/bin/phpunit` *(command failed: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e3e2bc9c8329b9f48f5ef85e767f