### PR TITLE
Fix duplicate footer placeholders

### DIFF
--- a/personajes/Emperadores_Romanos_Hispanos_Auca/clemente_magno_maximo.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/clemente_magno_maximo.html
@@ -29,8 +29,6 @@
 </ul>
     </main>
     <div id="footer-placeholder"></div>
-
-    <div id="footer-placeholder"></div>
     <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_arcadio.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_arcadio.html
@@ -20,8 +20,6 @@
 <p>No se encontraron otros detalles específicos sobre Flavio Arcadio en <code>nuevo4.md</code>.</p>
     </main>
     <div id="footer-placeholder"></div>
-
-    <div id="footer-placeholder"></div>
     <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_victor.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_victor.html
@@ -38,8 +38,6 @@
 <p>No se encontraron otros detalles específicos sobre Flavio Victor en <code>nuevo4.md</code>.</p>
     </main>
     <div id="footer-placeholder"></div>
-
-    <div id="footer-placeholder"></div>
     <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/teodosio_i.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/teodosio_i.html
@@ -23,8 +23,6 @@
 <p>El documento <code>nuevo4.md</code> establece una conexión directa de Teodosio I con Auca/Cerezo al afirmar: "Mas tarde nacen tres emperadores romanos en Auka, Teodosio I el Grande su primo Magno Clemente Máximo y su hijo Flavio Victor." Esta afirmación sugiere que Auka fue el lugar de nacimiento de estos emperadores, según la perspectiva del autor de <code>nuevo4.md</code>.</p>
     </main>
     <div id="footer-placeholder"></div>
-
-    <div id="footer-placeholder"></div>
     <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- remove repeated footer placeholder markup in Auca emperor pages

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6852e810f83c8329a5f64e5c1e49f02e