### PR TITLE
Remove duplicate meta tags

### DIFF
--- a/404.php
+++ b/404.php
@@ -4,8 +4,6 @@ http_response_code(404);
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Página no encontrada</title>
     <?php include __DIR__ . '/includes/head_common.php'; ?>
 </head>

--- a/alfoz/alfoz.php
+++ b/alfoz/alfoz.php
@@ -12,8 +12,6 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>El Alfoz de Cerasio y Lantarón - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/blog.php
+++ b/blog.php
@@ -35,8 +35,6 @@ $post_slug = isset($_GET['post']) ? $_GET['post'] : null;
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blog</title>
     <link rel="stylesheet" href="/assets/css/custom.css">
 </head>

--- a/citas/agenda.php
+++ b/citas/agenda.php
@@ -43,7 +43,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <html lang="es">
 <head>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
     <title>Programa de Citas para Visitas</title>
 </head>
 <body>

--- a/contacto/contacto.php
+++ b/contacto/contacto.php
@@ -12,8 +12,6 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Contacto - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/cultura/cultura.php
+++ b/cultura/cultura.php
@@ -12,8 +12,6 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cultura y Legado - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/empresa/index.php
+++ b/empresa/index.php
@@ -6,8 +6,6 @@ require_admin_login();
 <html lang="es">
 <head>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gestión de Yacimientos - Empresa Básica</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -44,8 +44,6 @@ if (is_dir($gallery_dir)) {
 <html lang="es">
 <head>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Galería Colaborativa - Condado de Castilla</title>
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
 

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -20,8 +20,6 @@ require_once __DIR__ . '/../includes/ai_utils.php';
 <html lang="es">
 <head>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Atapuerca</title>
 </head>
 <body>

--- a/historia/subpaginas/auca_patricia_ubicacion.php
+++ b/historia/subpaginas/auca_patricia_ubicacion.php
@@ -65,8 +65,6 @@ if (!$pdo) {
 }
 require_once __DIR__ . '/../../../includes/text_manager.php';
 ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
     <header id="hero-auca-patricia-ubicacion" class="page-header hero">
         <div class="hero-content">

--- a/historia/subpaginas_indice.php
+++ b/historia/subpaginas_indice.php
@@ -24,8 +24,6 @@ $temas_detallados = $page_data['temas_detallados'] ?? [];
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
 <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo htmlspecialchars($titulo_pagina); ?> - Cerezo de Río Tirón</title>
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
     <!-- Google Fonts, FontAwesome, and epic_theme.css are now in head_common.php -->

--- a/homonexus.php
+++ b/homonexus.php
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Experimento Homonexus</title>
     <?php include __DIR__ . '/includes/head_common.php'; ?>
 </head>

--- a/index.php
+++ b/index.php
@@ -13,8 +13,6 @@ require_once 'includes/ai_utils.php';
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Condado de Castilla - Cuna de tu Cultura y Lengua</title>
     <?php include __DIR__ . '/includes/head_common.php'; ?>
     <?php require_once __DIR__ . '/includes/load_page_css.php'; ?>

--- a/lugares/alfozcerezolantaron/Alcedo/index.php
+++ b/lugares/alfozcerezolantaron/Alcedo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Alcedo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Ameyugo/index.php
+++ b/lugares/alfozcerezolantaron/Ameyugo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Ameyugo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Bachicabo/index.php
+++ b/lugares/alfozcerezolantaron/Bachicabo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Bachicabo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Barrio/index.php
+++ b/lugares/alfozcerezolantaron/Barrio/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Barrio</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Belorado/index.php
+++ b/lugares/alfozcerezolantaron/Belorado/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Belorado</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Berguenda/index.php
+++ b/lugares/alfozcerezolantaron/Berguenda/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Bergüenda</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Caicedo_de_Yuso/index.php
+++ b/lugares/alfozcerezolantaron/Caicedo_de_Yuso/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Caicedo de Yuso</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Carcamo/index.php
+++ b/lugares/alfozcerezolantaron/Carcamo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Cárcamo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Castellum/index.php
+++ b/lugares/alfozcerezolantaron/Castellum/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Castellum</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Cellorigo/index.php
+++ b/lugares/alfozcerezolantaron/Cellorigo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Cellorigo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Cerezo_de_Rio_Tiron/index.php
+++ b/lugares/alfozcerezolantaron/Cerezo_de_Rio_Tiron/index.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cerezo de Río Tirón: Corazón del Condado de Castilla</title>
     <meta name="description" content="Explora la rica historia, las imponentes ruinas y el legado cultural de Cerezo de Río Tirón, un lugar clave en la historia del Condado de Castilla.">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">

--- a/lugares/alfozcerezolantaron/Comunion/index.php
+++ b/lugares/alfozcerezolantaron/Comunion/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Comunión</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Cuzcurrita_de_Rio_Tiron/index.php
+++ b/lugares/alfozcerezolantaron/Cuzcurrita_de_Rio_Tiron/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Cuzcurrita de Río Tirón</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Espejo/index.php
+++ b/lugares/alfozcerezolantaron/Espejo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Espejo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Fontecha/index.php
+++ b/lugares/alfozcerezolantaron/Fontecha/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Fontecha</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Fresno_de_Rio_Tiron/index.php
+++ b/lugares/alfozcerezolantaron/Fresno_de_Rio_Tiron/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Fresno de Río Tirón</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Granon/index.php
+++ b/lugares/alfozcerezolantaron/Granon/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Grañón</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Gurendes/index.php
+++ b/lugares/alfozcerezolantaron/Gurendes/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Gurendes</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Herramelluri/index.php
+++ b/lugares/alfozcerezolantaron/Herramelluri/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Herramélluri</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Ibrillos/index.php
+++ b/lugares/alfozcerezolantaron/Ibrillos/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Ibrillos</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Lecinana_del_Camino/index.php
+++ b/lugares/alfozcerezolantaron/Lecinana_del_Camino/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Leciñana del Camino</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Molinilla/index.php
+++ b/lugares/alfozcerezolantaron/Molinilla/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Molinilla</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Monte/index.php
+++ b/lugares/alfozcerezolantaron/Monte/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Monte</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Nograro/index.php
+++ b/lugares/alfozcerezolantaron/Nograro/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Nograro</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Ochanduri/index.php
+++ b/lugares/alfozcerezolantaron/Ochanduri/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Ochánduri</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Pancorbo/index.php
+++ b/lugares/alfozcerezolantaron/Pancorbo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Pancorbo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Pinedo/index.php
+++ b/lugares/alfozcerezolantaron/Pinedo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Pinedo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Posada/index.php
+++ b/lugares/alfozcerezolantaron/Posada/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Posada</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Poza_de_la_Sal/index.php
+++ b/lugares/alfozcerezolantaron/Poza_de_la_Sal/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Poza de la Sal</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Puentelarra/index.php
+++ b/lugares/alfozcerezolantaron/Puentelarra/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Puentelarrá</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Quejo/index.php
+++ b/lugares/alfozcerezolantaron/Quejo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Quejo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Quintanaloranco/index.php
+++ b/lugares/alfozcerezolantaron/Quintanaloranco/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Quintanaloranco</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Quintanilla_San_Garcia/index.php
+++ b/lugares/alfozcerezolantaron/Quintanilla_San_Garcia/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Quintanilla San García</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Quintanilla_del_Monte/index.php
+++ b/lugares/alfozcerezolantaron/Quintanilla_del_Monte/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Quintanilla del Monte</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Recilla/index.php
+++ b/lugares/alfozcerezolantaron/Recilla/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Recilla</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Redecilla_del_Campo/index.php
+++ b/lugares/alfozcerezolantaron/Redecilla_del_Campo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Redecilla del Campo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Salcedo/index.php
+++ b/lugares/alfozcerezolantaron/Salcedo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Salcedo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/San_Emilianus/index.php
+++ b/lugares/alfozcerezolantaron/San_Emilianus/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>San Emilianus</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/San_Millan_de_Yecora/index.php
+++ b/lugares/alfozcerezolantaron/San_Millan_de_Yecora/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>San Millán de Yécora</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/San_Zadornil/index.php
+++ b/lugares/alfozcerezolantaron/San_Zadornil/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>San Zadornil</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Sobron/index.php
+++ b/lugares/alfozcerezolantaron/Sobron/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Sobrón</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Sotillo_de_Rioja/index.php
+++ b/lugares/alfozcerezolantaron/Sotillo_de_Rioja/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Sotillo de Rioja</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Tirgo/index.php
+++ b/lugares/alfozcerezolantaron/Tirgo/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Tirgo</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Tormantos/index.php
+++ b/lugares/alfozcerezolantaron/Tormantos/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Tormantos</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Trevino/index.php
+++ b/lugares/alfozcerezolantaron/Trevino/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Treviño</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Tuesta/index.php
+++ b/lugares/alfozcerezolantaron/Tuesta/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Tuesta</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Turiso/index.php
+++ b/lugares/alfozcerezolantaron/Turiso/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Turiso</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Valluercanes/index.php
+++ b/lugares/alfozcerezolantaron/Valluercanes/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Valluércanes</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Valpuesta/index.php
+++ b/lugares/alfozcerezolantaron/Valpuesta/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Valpuesta</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Velasco/index.php
+++ b/lugares/alfozcerezolantaron/Velasco/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Velasco</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Villafranca_Montes_de_Oca/index.php
+++ b/lugares/alfozcerezolantaron/Villafranca_Montes_de_Oca/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Villafranca Montes de Oca</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Villafria/index.php
+++ b/lugares/alfozcerezolantaron/Villafria/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Villafría</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Villamaderne/index.php
+++ b/lugares/alfozcerezolantaron/Villamaderne/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Villamaderne</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Villanue/index.php
+++ b/lugares/alfozcerezolantaron/Villanue/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Villanue</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Villanueva_Soportilla/index.php
+++ b/lugares/alfozcerezolantaron/Villanueva_Soportilla/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Villanueva Soportilla</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Villanueva_de_Gurendes/index.php
+++ b/lugares/alfozcerezolantaron/Villanueva_de_Gurendes/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Villanueva de Gurendes</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/Zubillaga/index.php
+++ b/lugares/alfozcerezolantaron/Zubillaga/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Zubillaga</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/alfoz.php
+++ b/lugares/alfozcerezolantaron/alfoz.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>El Alfoz de Cerasio y Lantarón - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/lugares/alfozcerezolantaron/indexalfoz.php
+++ b/lugares/alfozcerezolantaron/indexalfoz.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-  <meta charset="UTF-8">
   <title>Alfoz de Cerezo y Lantarón</title>
   <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/cerasio.php
+++ b/lugares/cerasio.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cerasio - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/lugares/el_culebron.php
+++ b/lugares/el_culebron.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>El Culebrón - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/lugares/lugares.php
+++ b/lugares/lugares.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lugares Emblemáticos - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/museo/galeria.php
+++ b/museo/galeria.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Galería del Museo - Condado de Castilla</title>
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
     <!-- Google Fonts, FontAwesome, and epic_theme.css are now in head_common.php -->

--- a/museo/museo.php
+++ b/museo/museo.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Museo Colaborativo del Condado - Condado de Castilla</title>
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
     <script src="https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.core.min.js"></script>

--- a/museo/museo_3d.php
+++ b/museo/museo_3d.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Museo 3D Interactivo - Condado de Castilla</title>
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>

--- a/ruinas/edificaciones_civiles_publicas/circo_romano.php
+++ b/ruinas/edificaciones_civiles_publicas/circo_romano.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Circo Romano de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/edificaciones_civiles_publicas/foro_romano.php
+++ b/ruinas/edificaciones_civiles_publicas/foro_romano.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Foro Romano de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/edificaciones_civiles_publicas/index.php
+++ b/ruinas/edificaciones_civiles_publicas/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8"><title>Edificaciones Civiles y Públicas - Ruinas</title>
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>

--- a/ruinas/edificaciones_civiles_publicas/orfeones_odeones.php
+++ b/ruinas/edificaciones_civiles_publicas/orfeones_odeones.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orfeones y Odeones - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/edificaciones_civiles_publicas/puerto_fluvial_gurugu.php
+++ b/ruinas/edificaciones_civiles_publicas/puerto_fluvial_gurugu.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Puerto Fluvial del Gurugú - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/edificaciones_civiles_publicas/teatro_romano.php
+++ b/ruinas/edificaciones_civiles_publicas/teatro_romano.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Teatro Romano de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/estructuras_defensivas/alcazar_cerasio.php
+++ b/ruinas/estructuras_defensivas/alcazar_cerasio.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Alcázar de Cerasio - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/estructuras_defensivas/campamento_romano_tejera.php
+++ b/ruinas/estructuras_defensivas/campamento_romano_tejera.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Campamento Romano de la Tejera - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/estructuras_defensivas/index.php
+++ b/ruinas/estructuras_defensivas/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8"><title>Estructuras Defensivas - Ruinas</title>
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>

--- a/ruinas/estructuras_defensivas/murallas_auca.php
+++ b/ruinas/estructuras_defensivas/murallas_auca.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Murallas de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/estructuras_defensivas/otros_campamentos_romanos.php
+++ b/ruinas/estructuras_defensivas/otros_campamentos_romanos.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Otros Campamentos Romanos - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/estructuras_defensivas/otros_castillos.php
+++ b/ruinas/estructuras_defensivas/otros_castillos.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Otros Castillos y Fortificaciones - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/estructuras_defensivas/torres_vigia.php
+++ b/ruinas/estructuras_defensivas/torres_vigia.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Torres de Vigía y Defensa - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/estructuras_funerarias_religiosas/iglesia_la_llana_mezquita_yanna.php
+++ b/ruinas/estructuras_funerarias_religiosas/iglesia_la_llana_mezquita_yanna.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Iglesia de la Llana (Antigua Mezquita de Yanna) - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/ruinas/estructuras_funerarias_religiosas/index.php
+++ b/ruinas/estructuras_funerarias_religiosas/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8"><title>Estructuras Funerarias y Religiosas - Ruinas</title>
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>

--- a/ruinas/estructuras_funerarias_religiosas/mausoleo_circo_auca.php
+++ b/ruinas/estructuras_funerarias_religiosas/mausoleo_circo_auca.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mausoleo del Circo de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/estructuras_funerarias_religiosas/mausoleo_magno_clemente_maximo.php
+++ b/ruinas/estructuras_funerarias_religiosas/mausoleo_magno_clemente_maximo.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mausoleo de Magno Clemente Máximo - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/estructuras_funerarias_religiosas/mausoleo_san_nicolas.php
+++ b/ruinas/estructuras_funerarias_religiosas/mausoleo_san_nicolas.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mausoleo Imperial de San Nicolás - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/estructuras_funerarias_religiosas/necropolis_san_martin.php
+++ b/ruinas/estructuras_funerarias_religiosas/necropolis_san_martin.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Necrópolis de San Martín - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/estructuras_residenciales_elite/index.php
+++ b/ruinas/estructuras_residenciales_elite/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8"><title>Estructuras Residenciales de Élite - Ruinas</title>
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>

--- a/ruinas/estructuras_residenciales_elite/palacios_romanos_auca.php
+++ b/ruinas/estructuras_residenciales_elite/palacios_romanos_auca.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Palacios Romanos de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/ruinas/hallazgos_representaciones/alabastro_de_cerasio.php
+++ b/ruinas/hallazgos_representaciones/alabastro_de_cerasio.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Alabastro de Cerasio - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/ruinas/hallazgos_representaciones/cuevas_setefenestras.php
+++ b/ruinas/hallazgos_representaciones/cuevas_setefenestras.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cuevas de Setefenestras - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/ruinas/hallazgos_representaciones/descripciones_generales.php
+++ b/ruinas/hallazgos_representaciones/descripciones_generales.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Descripciones Generales de Ruinas - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/hallazgos_representaciones/fotos_hallazgos.php
+++ b/ruinas/hallazgos_representaciones/fotos_hallazgos.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fotografías y Hallazgos Menores - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/hallazgos_representaciones/index.php
+++ b/ruinas/hallazgos_representaciones/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8"><title>Hallazgos y Representaciones - Ruinas</title>
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>

--- a/ruinas/hallazgos_representaciones/monedas_antiguas.php
+++ b/ruinas/hallazgos_representaciones/monedas_antiguas.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Monedas Antiguas de Cerezo/Auca - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/ruinas/hallazgos_representaciones/tallas_inscripciones.php
+++ b/ruinas/hallazgos_representaciones/tallas_inscripciones.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tallas, Arte Rupestre e Inscripciones - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/index.php
+++ b/ruinas/index.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ruinas y Vestigios del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/infraestructura_general/hitos_miliares.php
+++ b/ruinas/infraestructura_general/hitos_miliares.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hitos Miliares Romanos - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 

--- a/ruinas/infraestructura_general/hospital_san_jorge.php
+++ b/ruinas/infraestructura_general/hospital_san_jorge.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hospital de San Jorge y Talla de San Antón - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/ruinas/infraestructura_general/index.php
+++ b/ruinas/infraestructura_general/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8"><title>Infraestructura General - Ruinas</title>
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>

--- a/ruinas/infraestructura_general/mansio_romana_meson.php
+++ b/ruinas/infraestructura_general/mansio_romana_meson.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mansio Romana en el Mesón - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/ruinas/infraestructura_general/puentes_romanos_cerezo.php
+++ b/ruinas/infraestructura_general/puentes_romanos_cerezo.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Puentes Romanos de Cerezo de Río Tirón - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/ruinas/infraestructura_general/tunel_antiguo.php
+++ b/ruinas/infraestructura_general/tunel_antiguo.php
@@ -2,8 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Túnel Antiguo en Cerezo - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/tienda/index.php
+++ b/tienda/index.php
@@ -7,8 +7,6 @@ require_once __DIR__ . '/../includes/auth.php';
 <html lang="es">
 <head>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tienda</title>
     <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
 </head>


### PR DESCRIPTION
## Summary
- rely on `head_common.php` for all charset and viewport meta tags
- clean up meta tag duplicates across PHP pages

## Testing
- `pip install -r requirements.txt`
- `python -m pytest tests/test_flask_api.py`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6852e812b0a4832996b8abeaa5c1cc76