### PR TITLE
Add HTML document structure to content pages

### DIFF
--- a/contenido/historia/alcazar_de_cerasio.php
+++ b/contenido/historia/alcazar_de_cerasio.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
 

--- a/contenido/historia/alfoz_cerezo_lantaron.php
+++ b/contenido/historia/alfoz_cerezo_lantaron.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
 

--- a/contenido/historia/auca_patricia_ubicacion.php
+++ b/contenido/historia/auca_patricia_ubicacion.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
 

--- a/contenido/historia/becerro_galicano_origen_castilla.php
+++ b/contenido/historia/becerro_galicano_origen_castilla.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
 

--- a/contenido/historia/condes_castilla_alava_cerasio.php
+++ b/contenido/historia/condes_castilla_alava_cerasio.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
 

--- a/contenido/historia/evidencia_arqueologica_cerezo.php
+++ b/contenido/historia/evidencia_arqueologica_cerezo.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
 

--- a/contenido/historia/legado_romano_emperadores_estructuras.php
+++ b/contenido/historia/legado_romano_emperadores_estructuras.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
 

--- a/contenido/historia/obispado_oca_auca.php
+++ b/contenido/historia/obispado_oca_auca.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
 

--- a/contenido/historia/origenes_castellano_vulgar.php
+++ b/contenido/historia/origenes_castellano_vulgar.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
 

--- a/contenido/lugares/alcedo.php
+++ b/contenido/lugares/alcedo.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
 

--- a/contenido/lugares/ameyugo.php
+++ b/contenido/lugares/ameyugo.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../_header.php'; ?>
 

--- a/contenido/lugares/cerezo_de_rio_tiron/interactivo.php
+++ b/contenido/lugares/cerezo_de_rio_tiron/interactivo.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../../_header.php'; ?>
 

--- a/contenido/lugares/cerezo_de_rio_tiron/introduccion.php
+++ b/contenido/lugares/cerezo_de_rio_tiron/introduccion.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../../_header.php'; ?>
 

--- a/contenido/lugares/cerezo_de_rio_tiron/legado.php
+++ b/contenido/lugares/cerezo_de_rio_tiron/legado.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../../_header.php'; ?>
 

--- a/contenido/lugares/cerezo_de_rio_tiron/ruinas.php
+++ b/contenido/lugares/cerezo_de_rio_tiron/ruinas.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../../_header.php'; ?>
 

--- a/contenido/lugares/cerezo_de_rio_tiron/visita.php
+++ b/contenido/lugares/cerezo_de_rio_tiron/visita.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../../../_header.php'; ?>
 

--- a/historia/atapuerca_static_converted.php
+++ b/historia/atapuerca_static_converted.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>
     <header class="page-header hero" style="background-image: linear-gradient(rgba(0,0,0, 0.5), rgba(0,0,0, 0.5)), url('../assets/img/placeholder.jpg');"> <!-- Basic hero style -->

--- a/historia/documentos/index.php
+++ b/historia/documentos/index.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
 <body>
 
     <?php require_once __DIR__ . '/../../_header.php'; ?>

--- a/historia/galeria_historica/index.php
+++ b/historia/galeria_historica/index.php
@@ -1,6 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
 <?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
-<head>
 </head>
 <body>
 

--- a/historia/historia.php
+++ b/historia/historia.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+</head>
 <body>
 
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/historia/nuestra_historia_nuevo4.php
+++ b/historia/nuestra_historia_nuevo4.php
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>
 


### PR DESCRIPTION
## Summary
- include DOCTYPE and `<html>` wrappers in `contenido` pages
- include DOCTYPE and `<html>` wrappers in `historia` pages

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml`
- `vendor/bin/phpunit` *(fails: `php-cgi: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852e812514c83299adbe0c75e465291