### PR TITLE
Adjust menu positions below language bar

### DIFF
--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -3,7 +3,7 @@
 /* Main toggle button for the consolidated menu */
 #consolidated-menu-button {
     position: fixed !important;
-    top: 20px !important;
+    top: 88px !important;
     left: 20px !important;
     right: auto !important;
     z-index: 1005 !important; /* También z-index por si acaso */
@@ -25,7 +25,7 @@
 /* Common styles for both sliding panels */
 .menu-panel {
     position: fixed;
-    top: 0;
+    top: 88px;
     bottom: 0; /* Make panel full height */
     width: 300px; /* Adjust width as needed */
     max-width: 80%; /* Max width for smaller screens */
@@ -228,9 +228,10 @@
         width: 280px; /* Slightly narrower for mobile */
         padding: 10px; /* Compacted */
         padding-top: 45px; /* Compacted */
+        top: 88px;
     }
     #consolidated-menu-button {
-        top: 10px; /* Compacted */
+        top: 88px; /* Adjusted for language bar */
         left: 10px; /* Compacted */
         right: auto; /* Compacted */
         font-size: 1em; /* Compacted */


### PR DESCRIPTION
## Summary
- push consolidated menu button and panel below language bar
- keep mobile rules consistent

## Testing
- `composer install` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6852f32ef9a883298576573dc7304f58