### PR TITLE
Fix Google Translate visibility and add basic test

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -61,7 +61,8 @@ body {
 
 /* Ensure the Google Translate widget itself is not accidentally shown if not already hidden by inline style */
 #google_translate_element {
-    display: none !important;
+    /* Previously hidden to avoid visual clutter; now displayed to allow on-page translation */
+    display: inline-block;
 }
 
 /* Ocultar visualmente pero mantener accesible */

--- a/tests/manual/test_lang.html
+++ b/tests/manual/test_lang.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Test Translation</title>
+<link rel="stylesheet" href="/assets/css/custom.css">
+</head>
+<body>
+<div class="language-bar">
+    <a href="/?lang=en" class="lang-flag">🇬🇧</a>
+    <a href="/?lang=fr" class="lang-flag">🇫🇷</a>
+</div>
+<div id="google_translate_element"></div>
+<p id="text">Hola Mundo</p>
+<script src="/js/lang-bar.js"></script>
+</body>
+</html>

--- a/tests/manual/test_translation.js
+++ b/tests/manual/test_translation.js
@@ -1,0 +1,16 @@
+const puppeteer = require('puppeteer');
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/tests/manual/test_lang.html?lang=en');
+  await page.waitForSelector('#google_translate_element');
+  await new Promise(r => setTimeout(r, 4000)); // wait for API load
+  const textBefore = await page.$eval('#text', el => el.innerText);
+  const flags = await page.$$('.lang-flag');
+  await flags[0].click();
+  await new Promise(r => setTimeout(r, 5000));
+  const textAfter = await page.$eval('#text', el => el.innerText);
+  console.log('Text before:', textBefore);
+  console.log('Text after:', textAfter);
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- show google translate widget
- add simple manual test page and script for translation bar

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `node tests/manual/test_translation.js` *(fails: translation not triggered)*

------
https://chatgpt.com/codex/tasks/task_e_6852f32d6f2083298073470deadd6c38