### PR TITLE
Update README meta tag section

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ GEMINI_API_KEY=tu_clave_personal
 ```
 Solo se admite la variable `GEMINI_API_KEY`; otros nombres anteriores han sido eliminados.
 
-El valor se inyectará en la etiqueta `<meta name="gemini-api-key">` generada por `includes/head_common.php` y será leído por `assets/js/main.js` para realizar las peticiones.
+El valor se inyectará en la etiqueta `<meta name="gemini-api-key">` generada por `includes/head_common.php` y será utilizado por las funciones del servidor definidas en `includes/ai_utils.php` para realizar las peticiones.
 
 ## Ejecución de pruebas
 


### PR DESCRIPTION
## Summary
- clarify Gemini API key injection and usage
- note that server-side functions read the key

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f6bba0508329a125e53759c42582