### PR TITLE
Fix Google Translate flag bar

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -61,7 +61,8 @@ body {
 
 /* Ensure the Google Translate widget itself is not accidentally shown if not already hidden by inline style */
 #google_translate_element {
-    display: none !important;
+    /* Hide the default Google widget; translation handled via flags */
+    display: none;
 }
 
 /* Ocultar visualmente pero mantener accesible */
@@ -95,4 +96,25 @@ body {
 .language-bar .lang-flag:hover {
     opacity: 1;
     transform: scale(1.1); /* Aumentar también en hover para consistencia */
+}
+
+/* Additional flags container hidden by default */
+#additional-flags {
+    display: none;
+    margin-top: 4px;
+}
+
+/* Button to reveal extra languages */
+.more-flags-btn {
+    margin-left: 8px;
+    background: var(--epic-gold-main);
+    border: none;
+    color: var(--epic-purple-emperor);
+    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+
+.more-flags-btn[aria-expanded="true"] {
+    background: var(--epic-gold-secondary);
 }

--- a/fragments/header/language-bar.html
+++ b/fragments/header/language-bar.html
@@ -3,27 +3,30 @@
     <a href="/?lang=en" class="lang-flag" title="English">🇬🇧<span class="visually-hidden">English</span></a>
     <a href="/?lang=fr" class="lang-flag" title="Français">🇫🇷<span class="visually-hidden">Français</span></a>
     <a href="/?lang=de" class="lang-flag" title="Deutsch">🇩🇪<span class="visually-hidden">Deutsch</span></a>
-    <a href="/?lang=it" class="lang-flag" title="Italiano">🇮🇹<span class="visually-hidden">Italiano</span></a>
-    <a href="/?lang=pt" class="lang-flag" title="Português">🇵🇹<span class="visually-hidden">Português</span></a>
-    <a href="/?lang=ru" class="lang-flag" title="Русский">🇷🇺<span class="visually-hidden">Русский</span></a>
-    <a href="/?lang=zh-CN" class="lang-flag" title="中文">🇨🇳<span class="visually-hidden">中文</span></a>
-    <a href="/?lang=ja" class="lang-flag" title="日本語">🇯🇵<span class="visually-hidden">日本語</span></a>
-    <a href="/?lang=ko" class="lang-flag" title="한국어">🇰🇷<span class="visually-hidden">한국어</span></a>
-    <a href="/?lang=ar" class="lang-flag" title="العربية">🇸🇦<span class="visually-hidden">العربية</span></a>
-    <a href="/?lang=hi" class="lang-flag" title="हिन्दी">🇮🇳<span class="visually-hidden">हिन्दी</span></a>
-    <a href="/?lang=tr" class="lang-flag" title="Türkçe">🇹🇷<span class="visually-hidden">Türkçe</span></a>
-    <a href="/?lang=id" class="lang-flag" title="Bahasa Indonesia">🇮🇩<span class="visually-hidden">Bahasa Indonesia</span></a>
-    <a href="/?lang=vi" class="lang-flag" title="Tiếng Việt">🇻🇳<span class="visually-hidden">Tiếng Việt</span></a>
-    <a href="/?lang=bn" class="lang-flag" title="বাংলা">🇧🇩<span class="visually-hidden">বাংলা</span></a>
-    <a href="/?lang=ur" class="lang-flag" title="اردو">🇵🇰<span class="visually-hidden">اردو</span></a>
-    <a href="/?lang=fa" class="lang-flag" title="فارسی">🇮🇷<span class="visually-hidden">فارسی</span></a>
-    <a href="/?lang=nl" class="lang-flag" title="Nederlands">🇳🇱<span class="visually-hidden">Nederlands</span></a>
-    <a href="/?lang=pl" class="lang-flag" title="Polski">🇵🇱<span class="visually-hidden">Polski</span></a>
-    <a href="/?lang=uk" class="lang-flag" title="Українська">🇺🇦<span class="visually-hidden">Українська</span></a>
-    <a href="/?lang=sw" class="lang-flag" title="Kiswahili">🇰🇪<span class="visually-hidden">Kiswahili</span></a>
-    <a href="/?lang=sv" class="lang-flag" title="Svenska">🇸🇪<span class="visually-hidden">Svenska</span></a>
-    <a href="/?lang=th" class="lang-flag" title="ไทย">🇹🇭<span class="visually-hidden">ไทย</span></a>
-    <a href="/?lang=el" class="lang-flag" title="Ελληνικά">🇬🇷<span class="visually-hidden">Ελληνικά</span></a>
-    <a href="/?lang=he" class="lang-flag" title="עברית">🇮🇱<span class="visually-hidden">עברית</span></a>
+    <button id="more-lang-toggle" class="more-flags-btn" aria-expanded="false" aria-controls="additional-flags" title="Más idiomas">+</button>
+    <div id="additional-flags" class="additional-flags">
+        <a href="/?lang=it" class="lang-flag" title="Italiano">🇮🇹<span class="visually-hidden">Italiano</span></a>
+        <a href="/?lang=pt" class="lang-flag" title="Português">🇵🇹<span class="visually-hidden">Português</span></a>
+        <a href="/?lang=ru" class="lang-flag" title="Русский">🇷🇺<span class="visually-hidden">Русский</span></a>
+        <a href="/?lang=zh-CN" class="lang-flag" title="中文">🇨🇳<span class="visually-hidden">中文</span></a>
+        <a href="/?lang=ja" class="lang-flag" title="日本語">🇯🇵<span class="visually-hidden">日本語</span></a>
+        <a href="/?lang=ko" class="lang-flag" title="한국어">🇰🇷<span class="visually-hidden">한국어</span></a>
+        <a href="/?lang=ar" class="lang-flag" title="العربية">🇸🇦<span class="visually-hidden">العربية</span></a>
+        <a href="/?lang=hi" class="lang-flag" title="हिन्दी">🇮🇳<span class="visually-hidden">हिन्दी</span></a>
+        <a href="/?lang=tr" class="lang-flag" title="Türkçe">🇹🇷<span class="visually-hidden">Türkçe</span></a>
+        <a href="/?lang=id" class="lang-flag" title="Bahasa Indonesia">🇮🇩<span class="visually-hidden">Bahasa Indonesia</span></a>
+        <a href="/?lang=vi" class="lang-flag" title="Tiếng Việt">🇻🇳<span class="visually-hidden">Tiếng Việt</span></a>
+        <a href="/?lang=bn" class="lang-flag" title="বাংলা">🇧🇩<span class="visually-hidden">বাংলা</span></a>
+        <a href="/?lang=ur" class="lang-flag" title="اردو">🇵🇰<span class="visually-hidden">اردو</span></a>
+        <a href="/?lang=fa" class="lang-flag" title="فارسی">🇮🇷<span class="visually-hidden">فارسی</span></a>
+        <a href="/?lang=nl" class="lang-flag" title="Nederlands">🇳🇱<span class="visually-hidden">Nederlands</span></a>
+        <a href="/?lang=pl" class="lang-flag" title="Polski">🇵🇱<span class="visually-hidden">Polski</span></a>
+        <a href="/?lang=uk" class="lang-flag" title="Українська">🇺🇦<span class="visually-hidden">Українська</span></a>
+        <a href="/?lang=sw" class="lang-flag" title="Kiswahili">🇰🇪<span class="visually-hidden">Kiswahili</span></a>
+        <a href="/?lang=sv" class="lang-flag" title="Svenska">🇸🇪<span class="visually-hidden">Svenska</span></a>
+        <a href="/?lang=th" class="lang-flag" title="ไทย">🇹🇭<span class="visually-hidden">ไทย</span></a>
+        <a href="/?lang=el" class="lang-flag" title="Ελληνικά">🇬🇷<span class="visually-hidden">Ελληνικά</span></a>
+        <a href="/?lang=he" class="lang-flag" title="עברית">🇮🇱<span class="visually-hidden">עברית</span></a>
+    </div>
 </div>
 <div id="google_translate_element"></div>

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -6,6 +6,8 @@ function setupLanguageBar() {
         const lang = new URLSearchParams(window.location.search).get('lang');
         debugLog(`setupLanguageBar: Initial language from URL: ${lang}`);
         const flagLinks = document.querySelectorAll('.language-bar .lang-flag');
+        const moreToggle = document.getElementById('more-lang-toggle');
+        const additional = document.getElementById('additional-flags');
 
         flagLinks.forEach(link => {
             link.classList.remove('active-lang');
@@ -17,11 +19,17 @@ function setupLanguageBar() {
                 e.preventDefault();
                 const target = this.getAttribute('href').split('lang=')[1];
                 debugLog(`setupLanguageBar: Flag clicked, target language: ${target}`);
-                const params = new URLSearchParams(window.location.search);
-                params.set('lang', target); // Always use params.set as requested
-                window.location.search = params.toString();
+                handleTranslation(target, flagLinks);
             });
         });
+
+        if (moreToggle && additional) {
+            moreToggle.addEventListener('click', () => {
+                const expanded = moreToggle.getAttribute('aria-expanded') === 'true';
+                moreToggle.setAttribute('aria-expanded', String(!expanded));
+                additional.style.display = expanded ? 'none' : 'inline';
+            });
+        }
 
         if (lang) {
             flagLinks.forEach(link => {
@@ -44,6 +52,28 @@ function setupLanguageBar() {
         }
     } catch (error) {
         console.error("setupLanguageBar: Error during setup:", error);
+    }
+}
+
+function handleTranslation(lang, flagLinks) {
+    const params = new URLSearchParams(window.location.search);
+    params.set('lang', lang);
+    history.replaceState(null, '', '?' + params.toString());
+
+    flagLinks.forEach(l => {
+        if (l.getAttribute('href').includes('lang=' + lang)) {
+            l.classList.add('active-lang');
+            l.setAttribute('aria-current', 'true');
+        } else {
+            l.classList.remove('active-lang');
+            l.removeAttribute('aria-current');
+        }
+    });
+
+    if (typeof google !== 'undefined' && google.translate && google.translate.TranslateElement) {
+        translatePage(lang);
+    } else {
+        loadGoogleTranslate(lang);
     }
 }
 

--- a/tests/manual/test_lang.html
+++ b/tests/manual/test_lang.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Test Translation</title>
+<link rel="stylesheet" href="/assets/css/custom.css">
+</head>
+<body>
+<div class="language-bar">
+    <a href="/?lang=es" class="lang-flag">🇪🇸</a>
+    <a href="/?lang=en" class="lang-flag">🇬🇧</a>
+    <a href="/?lang=fr" class="lang-flag">🇫🇷</a>
+    <a href="/?lang=de" class="lang-flag">🇩🇪</a>
+    <button id="more-lang-toggle" class="more-flags-btn" aria-expanded="false" aria-controls="additional-flags">+</button>
+    <div id="additional-flags" class="additional-flags">
+        <a href="/?lang=it" class="lang-flag">🇮🇹</a>
+        <a href="/?lang=pt" class="lang-flag">🇵🇹</a>
+    </div>
+</div>
+<div id="google_translate_element"></div>
+<p id="text">Hola Mundo</p>
+<script src="/js/lang-bar.js"></script>
+</body>
+</html>

--- a/tests/manual/test_translation.js
+++ b/tests/manual/test_translation.js
@@ -1,0 +1,16 @@
+const puppeteer = require('puppeteer');
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/tests/manual/test_lang.html?lang=en');
+  await page.waitForSelector('#google_translate_element');
+  await new Promise(r => setTimeout(r, 4000)); // wait for API load
+  const textBefore = await page.$eval('#text', el => el.innerText);
+  const flags = await page.$$('.lang-flag');
+  await flags[0].click();
+  await new Promise(r => setTimeout(r, 5000));
+  const textAfter = await page.$eval('#text', el => el.innerText);
+  console.log('Text before:', textBefore);
+  console.log('Text after:', textAfter);
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- hide Google widget
- reorganize language bar with a plus button
- translate without reloading when flags clicked
- show more flags in manual test page

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `node tests/manual/test_translation.js` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6852f32d6f2083298073470deadd6c38