### PR TITLE
Fix error message markup in Atapuerca page

### DIFF
--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -108,7 +108,7 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                     const textoParaResumir = contentContainer.textContent.trim();
 
                     if (!textoParaResumir) {
-                        resumenContenedor.innerHTML = '<p style="color:red;">Error: No se pudo extraer contenido para resumir.</p>';
+                        resumenContenedor.innerHTML = '<p class="ia-tool-error">Error: No se pudo extraer contenido para resumir.</p>';
                         return;
                     }
 
@@ -138,14 +138,14 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                             // El summary ya viene formateado con nl2br(htmlspecialchars()) desde el backend
                             resumenContenedor.innerHTML = data.summary;
                         } else if (data.error) {
-                            resumenContenedor.innerHTML = `<p style="color:red;">Error al generar resumen: ${data.error}</p>`;
+                            resumenContenedor.innerHTML = `<p class="ia-tool-error">Error al generar resumen: ${data.error}</p>`;
                         } else {
-                            resumenContenedor.innerHTML = '<p style="color:red;">Error: Respuesta inesperada del servicio de resumen.</p>';
+                            resumenContenedor.innerHTML = '<p class="ia-tool-error">Error: Respuesta inesperada del servicio de resumen.</p>';
                         }
                     })
                     .catch(error => {
                         console.error('Error en la petición fetch para resumen:', error);
-                        resumenContenedor.innerHTML = `<p style="color:red;">Error de conexión o solicitud: ${error.message}</p>`;
+                        resumenContenedor.innerHTML = `<p class="ia-tool-error">Error de conexión o solicitud: ${error.message}</p>`;
                     });
                 });
             }


### PR DESCRIPTION
## Summary
- update Atapuerca page to use the `.ia-tool-error` class

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_6852fbcda4cc8329b7a19c5a3bc09bee