### PR TITLE
Update translation docs and tests

### DIFF
--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -11,7 +11,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `js/load_menu_parts.js` | Dynamically loads menu fragments into the header when needed. |
 | `js/header-loader.js` | Fetches `/_header.php` and injects it into `#header-placeholder` for static pages. |
 | `js/ia-tools.js` | Implements AI assistant utilities such as summaries, translations and chat. |
-| `js/lang-bar.js` | Controls the language selection bar and triggers Google Translate. |
+| `js/lang-bar.js` | Loads Google Translate when a `?lang=` URL parameter is present. |
 | `js/lugares-data.js` | Provides static data used by `lugares-dynamic-list.js`. |
 | `js/lugares-dynamic-list.js` | Generates the list of places dynamically from `lugares-data.js`. |
 | `js/museo-2d-gallery.js` | Logic for the collaborative museum 2D gallery including uploads and modals. |
@@ -19,3 +19,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `js/museum-3d/` | Additional modules used by the 3D viewer. |
 
 Deprecated or merged scripts such as `js/menu-controller.js` and `js/sliding-menu.js` have been removed in favour of `assets/js/main.js`.
+
+## Simplified Translation
+
+Pages are translated by passing a `lang` query parameter in the URL. When this parameter is present, `js/lang-bar.js` dynamically loads the Google Translate widget and applies the selected language without showing flag icons or a language bar.

--- a/tests/manual/test_lang.html
+++ b/tests/manual/test_lang.html
@@ -6,10 +6,6 @@
 <link rel="stylesheet" href="/assets/css/custom.css">
 </head>
 <body>
-<div class="language-bar">
-    <a href="/?lang=en" class="lang-flag">🇬🇧</a>
-    <a href="/?lang=fr" class="lang-flag">🇫🇷</a>
-</div>
 <div id="google_translate_element"></div>
 <p id="text">Hola Mundo</p>
 <script src="/js/lang-bar.js"></script>

--- a/tests/manual/test_translation.js
+++ b/tests/manual/test_translation.js
@@ -5,12 +5,12 @@ const puppeteer = require('puppeteer');
   await page.goto('http://localhost:8080/tests/manual/test_lang.html?lang=en');
   await page.waitForSelector('#google_translate_element');
   await new Promise(r => setTimeout(r, 4000)); // wait for API load
-  const textBefore = await page.$eval('#text', el => el.innerText);
-  const flags = await page.$$('.lang-flag');
-  await flags[0].click();
+  const textEn = await page.$eval('#text', el => el.innerText);
+  await page.goto('http://localhost:8080/tests/manual/test_lang.html?lang=fr');
+  await page.waitForSelector('#google_translate_element');
   await new Promise(r => setTimeout(r, 5000));
-  const textAfter = await page.$eval('#text', el => el.innerText);
-  console.log('Text before:', textBefore);
-  console.log('Text after:', textAfter);
+  const textFr = await page.$eval('#text', el => el.innerText);
+  console.log('Text EN:', textEn);
+  console.log('Text FR:', textFr);
   await browser.close();
 })();


### PR DESCRIPTION
## Summary
- clarify translation mechanism without language bar
- update manual translation test html
- revise Puppeteer test to switch lang via URL

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6852ff7adacc832989fcda1895afe77a