### PR TITLE
Update translation docs and manual tests

### DIFF
--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -1,6 +1,6 @@
 # JavaScript Modules Overview
 
-This document summarizes the purpose of the main JavaScript files present in the repository after consolidation.
+This document summarizes the purpose of the main JavaScript files present in the repository after consolidation. The translation system has been simplified: `js/lang-bar.js` now checks the URL for a `lang` parameter and loads Google Translate automatically, so flag links are no longer required.
 
 | File | Description |
 |------|-------------|
@@ -11,7 +11,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `js/load_menu_parts.js` | Dynamically loads menu fragments into the header when needed. |
 | `js/header-loader.js` | Fetches `/_header.php` and injects it into `#header-placeholder` for static pages. |
 | `js/ia-tools.js` | Implements AI assistant utilities such as summaries, translations and chat. |
-| `js/lang-bar.js` | Controls the language selection bar and triggers Google Translate. |
+| `js/lang-bar.js` | Applies Google Translate when a `lang` query parameter is present. The previous flag-based UI is optional. |
 | `js/lugares-data.js` | Provides static data used by `lugares-dynamic-list.js`. |
 | `js/lugares-dynamic-list.js` | Generates the list of places dynamically from `lugares-data.js`. |
 | `js/museo-2d-gallery.js` | Logic for the collaborative museum 2D gallery including uploads and modals. |

--- a/tests/manual/test_lang.html
+++ b/tests/manual/test_lang.html
@@ -3,15 +3,24 @@
 <head>
 <meta charset="UTF-8">
 <title>Test Translation</title>
-<link rel="stylesheet" href="/assets/css/custom.css">
 </head>
 <body>
-<div class="language-bar">
-    <a href="/?lang=en" class="lang-flag">🇬🇧</a>
-    <a href="/?lang=fr" class="lang-flag">🇫🇷</a>
-</div>
-<div id="google_translate_element"></div>
 <p id="text">Hola Mundo</p>
-<script src="/js/lang-bar.js"></script>
+<button id="translate-btn">Traducir</button>
+<script>
+document.getElementById('translate-btn').addEventListener('click', () => {
+  fetch('/ajax_actions/get_translation.php', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+    body: JSON.stringify({ text_to_translate: document.getElementById('text').innerText, target_lang: 'en' })
+  })
+  .then(res => res.json())
+  .then(data => {
+    if (data.success && data.translation) {
+      document.getElementById('text').innerText = data.translation;
+    }
+  });
+});
+</script>
 </body>
 </html>

--- a/tests/manual/test_translation.js
+++ b/tests/manual/test_translation.js
@@ -2,13 +2,10 @@ const puppeteer = require('puppeteer');
 (async () => {
   const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
   const page = await browser.newPage();
-  await page.goto('http://localhost:8080/tests/manual/test_lang.html?lang=en');
-  await page.waitForSelector('#google_translate_element');
-  await new Promise(r => setTimeout(r, 4000)); // wait for API load
+  await page.goto('http://localhost:8080/tests/manual/test_lang.html');
   const textBefore = await page.$eval('#text', el => el.innerText);
-  const flags = await page.$$('.lang-flag');
-  await flags[0].click();
-  await new Promise(r => setTimeout(r, 5000));
+  await page.click('#translate-btn');
+  await page.waitForFunction(() => document.getElementById('text').innerText !== 'Hola Mundo', { timeout: 10000 });
   const textAfter = await page.$eval('#text', el => el.innerText);
   console.log('Text before:', textBefore);
   console.log('Text after:', textAfter);


### PR DESCRIPTION
## Summary
- update JS modules overview with new translation description
- revise manual translation test page to not rely on flag links
- adapt Puppeteer script accordingly

## Testing
- `composer install` *(fails: ext-dom missing)*
- `vendor/bin/phpunit` *(fails: could not find driver, php-cgi missing)*
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_685302e4edf88329b76e4b414d19a827