### PR TITLE
Improve header layout and AI chat

### DIFF
--- a/_header.php
+++ b/_header.php
@@ -1,12 +1,11 @@
 <?php
-// Language bar temporarily disabled
-// echo file_get_contents(__DIR__ . "/fragments/header/language-bar.html");
+echo file_get_contents(__DIR__ . "/fragments/header/language-bar.html");
 ?>
 <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
+<button id="theme-toggle" aria-label="Cambiar tema"><i class="fas fa-lightbulb"></i></button>
 
 <!-- Left Sliding Panel for Main Menu -->
 <div id="consolidated-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="consolidated-menu-button">
-    <button id="theme-toggle" class="menu-item-button" aria-label="Cambiar tema"><i class="fas fa-lightbulb"></i> <span>Tema</span></button>
     <button id="ai-chat-trigger" class="menu-item-button" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA"><i class="fas fa-comments"></i> <span>Chat IA</span></button>
 
     <div class="menu-section">

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -26,9 +26,9 @@
 /* Theme Toggle Button - Original Position (will be adjusted for mobile) */
 #theme-toggle {
     position: fixed;
-    top: 88px; /* lowered position */
-    left: 50%;
-    transform: translateX(-50%);
+    top: var(--language-bar-offset);
+    left: 70px;
+    transform: none;
     background-color: var(--epic-transparent-overlay-medium);
     border: 2px solid var(--epic-gold-secondary);
     border-radius: var(--global-border-radius);
@@ -183,16 +183,11 @@ body.dark-mode #homonexus-toggle:hover i {
 
 /* Mobile Adjustments for Toggles */
 @media (max-width: 768px) {
-    /*
     #theme-toggle {
-        left: auto; / * Override PC centering * /
-        right: 115px; / * (homonexus-toggle right 65px + width 44px = 109px) + 6px gap * /
-        / * Note: Ensure #ia-chat-toggle is at right: 15px and #homonexus-toggle at right: 65px * /
+        left: auto;
+        right: 60px;
+        top: var(--language-bar-offset);
     }
-    */
-    /* #sidebar-toggle remains top: 88px; left: 15px; */
-    /* #ia-chat-toggle remains top: 88px; right: 15px; */
-    /* #homonexus-toggle remains top: 88px; right: 65px; */
 }
 
 /* Consider further adjustments for very small screens if needed, e.g., hiding some toggles */
@@ -218,4 +213,5 @@ body.dark-mode #homonexus-toggle:hover i {
     /* Adjust right offsets so buttons remain separated */
     #ia-chat-toggle { right: 10px; }
     #homonexus-toggle { right: 50px; }
+    #theme-toggle { right: 60px; left: auto; }
 }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -278,6 +278,18 @@ header { /* New header for hamburger only */
     opacity: 0.85;
 }
 
+#ai-dialog {
+    margin-top: 10px;
+    padding: 10px;
+    border: 1px solid var(--current-separator);
+    background-color: var(--current-bg);
+    color: var(--current-text);
+    border-radius: 4px;
+    width: 100%;
+    max-height: 150px;
+    overflow-y: auto;
+}
+
 /* Ajustes para que el contenido del main no se solape con el header fijo */
 /* El #main-content ya tiene margin-top, pero si hay otros headers fijos, se necesitaría más */
 

--- a/fragments/header/ai-drawer.html
+++ b/fragments/header/ai-drawer.html
@@ -13,5 +13,6 @@
     <div id="ai-response"></div>
     <input id="ai-input" type="text" placeholder="Escribe tu consulta...">
     <button id="ai-submit">Enviar</button>
+    <dialog id="ai-dialog" class="chat-dialog"></dialog>
   </div>
 </div>

--- a/js/ia-tools.js
+++ b/js/ia-tools.js
@@ -269,10 +269,23 @@ function handleChatMessage(chatInput, chatArea) {
         } else {
             appendMessage(chatArea, 'Respuesta inesperada del servidor.', 'ai-error');
         }
+        showChatDialog(chatArea.innerText);
     })
     .catch(err => {
         const thinkingMessage = chatArea.querySelector('.ai-status-message');
         if (thinkingMessage) thinkingMessage.remove();
         appendMessage(chatArea, err.message || 'Error de conexión desconocido.', 'ai-error');
+        showChatDialog(chatArea.innerText);
     });
+}
+
+function showChatDialog(text) {
+    const dialog = document.getElementById('ai-dialog');
+    if (!dialog) return;
+    dialog.textContent = text;
+    if (typeof dialog.showModal === 'function') {
+        if (!dialog.open) dialog.showModal();
+    } else {
+        dialog.style.display = 'block';
+    }
 }


### PR DESCRIPTION
## Summary
- always show Google language bar
- move theme toggle next to menu button
- add AI chat dialog container
- open the chat dialog when Gemini responds
- style AI dialog and theme toggle positions

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853053913b083298186b16415442c22