### PR TITLE
Default dark theme

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -67,11 +67,14 @@ document.addEventListener('DOMContentLoaded', () => {
     if (themeToggle) {
         const icon = themeToggle.querySelector('i');
         const storedTheme = localStorage.getItem('theme');
-        if (storedTheme === 'dark') {
+        if (storedTheme === 'dark' || !storedTheme) {
             document.body.classList.add('dark-mode');
             if (icon) {
                 icon.classList.remove('fa-moon');
                 icon.classList.add('fa-sun');
+            }
+            if (!storedTheme) {
+                localStorage.setItem('theme', 'dark');
             }
         }
         themeToggle.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- ensure dark mode is active by default

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: could not find driver)*
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_685306e331d483299e47ac1ce64fe5c6