### PR TITLE
Adjust AI dialog styles

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -286,7 +286,8 @@ header { /* New header for hamburger only */
     color: var(--current-text);
     border-radius: 4px;
     width: 100%;
-    max-height: 150px;
+    max-height: none;
+    height: auto;
     overflow-y: auto;
 }
 

--- a/fragments/header/ai-drawer.html
+++ b/fragments/header/ai-drawer.html
@@ -13,6 +13,6 @@
     <div id="ai-response"></div>
     <input id="ai-input" type="text" placeholder="Escribe tu consulta...">
     <button id="ai-submit">Enviar</button>
-    <dialog id="ai-dialog" class="chat-dialog"></dialog>
+    <dialog id="ai-dialog" class="chat-dialog">respuesta</dialog>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- make the chat dialog auto size
- show placeholder text in the AI drawer

## Testing
- `npx --yes phpunit` *(fails: Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_685313a9c7308329b65d1c1dca9861a4