### PR TITLE
Fix duplicate menu entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,8 @@ esperadas para cada elemento del menú principal:
 Mantén esta lista actualizada cuando se añadan o eliminen páginas para que se
 pueda validar fácilmente el contenido del menú.
 
-El menú lateral derecho se genera a partir de `fragments/menus/tools-menu.html` y
-ofrece accesos rápidos a páginas clave. Se incluye dentro del elemento
-`<nav id="slide-menu-right">` en `_header.php` y comparte la misma temática de
-colores morado y oro viejo que el resto de la cabecera.
+Anteriormente existía un menú de herramientas adicional, pero se ha retirado
+para evitar enlaces duplicados en la navegación.
 
 ## Cambios recientes
 

--- a/_header.php
+++ b/_header.php
@@ -17,14 +17,6 @@ echo file_get_contents(__DIR__ . "/fragments/header/language-bar.html");
         ?>
     </div>
     <div class="menu-section">
-        <h4 class="gradient-text">Herramientas</h4>
-        <?php
-        if (file_exists(__DIR__ . '/fragments/menus/tools-menu.html')) {
-            echo file_get_contents(__DIR__ . '/fragments/menus/tools-menu.html');
-        }
-        ?>
-    </div>
-    <div class="menu-section">
         <h4 class="gradient-text">Admin</h4>
         <?php include __DIR__ . '/fragments/menus/admin-menu.php'; ?>
     </div>

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -27,7 +27,7 @@ if (file_exists(__DIR__ . '/fragments/menus/main-menu.html')) {
 }
 ?>
 ```
-De igual manera se incluyen `tools-menu.html`, `admin-menu.php` y `social-menu.html` dentro de bloques `<div class="menu-section">`.
+El panel también incluye `admin-menu.php` y `social-menu.html` dentro de bloques `<div class="menu-section">`.
 
 ## Personalización del menú deslizante y nuevas páginas
 * **Estilos**: modifica `assets/css/menus/consolidated-menu.css` para cambiar colores morado y oro viejo, anchura u otros efectos del panel `.menu-panel`.

--- a/fragments/menus/tools-menu.html
+++ b/fragments/menus/tools-menu.html
@@ -1,7 +1,0 @@
-<ul id="tools-menu" class="nav-links">
-    <li><a href="/index.php">Inicio</a></li>
-    <li><a href="/museo/galeria.php">Museo Colaborativo</a></li>
-    <li><a href="/tienda/index.php">Tienda</a></li>
-    <li><a href="/foro/index.php">Foro</a></li>
-    <li><a href="/contacto/contacto.php">Contacto</a></li>
-</ul>

--- a/tests/ToolsMenuLinksTest.php
+++ b/tests/ToolsMenuLinksTest.php
@@ -21,7 +21,11 @@ class ToolsMenuLinksTest extends TestCase {
     }
 
     public static function urlProvider(): array {
-        $html = file_get_contents(__DIR__.'/../fragments/menus/tools-menu.html');
+        $path = __DIR__.'/../fragments/menus/tools-menu.html';
+        if (!file_exists($path)) {
+            return [];
+        }
+        $html = file_get_contents($path);
         $dom = new DOMDocument();
         libxml_use_internal_errors(true);
         $dom->loadHTML($html);


### PR DESCRIPTION
## Summary
- remove outdated tools menu
- adjust header and docs to stop referencing the tools menu
- update test helper to skip when tools menu is missing

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685313f84b508329a4ecacfe3d53dbab