### PR TITLE
Update login redirect

### DIFF
--- a/dashboard/login.php
+++ b/dashboard/login.php
@@ -51,7 +51,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                     $_SESSION['user_role'] = $user['role'];
 
                     // Determine redirect URL
-                    $redirect_to = '/index.php'; // Default redirect
+                    $redirect_to = '/dashboard/index.php'; // Default redirect to dashboard
                     if (isset($_SESSION['redirect_after_login'])) {
                         $redirect_to = $_SESSION['redirect_after_login'];
                         unset($_SESSION['redirect_after_login']); // Clear it after use
@@ -63,6 +63,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                         // Ensure $redirect_to is not inadvertently /index.html if that was the stored session value
                         if ($redirect_to === '/index.html') {
                             $redirect_to = '/index.php';
+                        } elseif ($redirect_to === '/dashboard/index.html') {
+                            $redirect_to = '/dashboard/index.php';
                         }
                         header("Location: " . $redirect_to);
                         if (empty($GLOBALS['TESTING'])) {

--- a/tests/LoginLogoutTest.php
+++ b/tests/LoginLogoutTest.php
@@ -54,7 +54,7 @@ class LoginLogoutTest extends TestCase {
         [$status, $out, $err] = $this->runScript(__DIR__.'/../dashboard/login.php', $env);
         $this->assertSame(0, $status, $err);
         $headers = $this->parseHeaders($out);
-        $this->assertSame('/index.php', $headers['Location'][0] ?? null);
+        $this->assertSame('/dashboard/index.php', $headers['Location'][0] ?? null);
         $this->assertArrayHasKey('Set-Cookie', $headers);
         preg_match('/PHPSESSID=([^;]+)/', $headers['Set-Cookie'][0], $m);
         $this->assertNotEmpty($m);


### PR DESCRIPTION
## Summary
- default to /dashboard/index.php after logging in
- fix test expecting redirect location

## Testing
- `vendor/bin/phpunit -c phpunit.xml` *(fails: php-cgi not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685314b149bc8329a88d1a1bb066f447