### PR TITLE
Add language bar toggle

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -61,8 +61,7 @@ body {
 
 /* Ensure the Google Translate widget itself is not accidentally shown if not already hidden by inline style */
 #google_translate_element {
-    /* Previously hidden to avoid visual clutter; now displayed to allow on-page translation */
-    display: inline-block;
+    display: none;
 }
 
 /* Ocultar visualmente pero mantener accesible */

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -59,6 +59,27 @@
     transform: rotate(20deg);
 }
 
+/* Language Bar Toggle */
+#lang-bar-toggle {
+    position: fixed;
+    top: var(--language-bar-offset);
+    right: 115px;
+    background-color: var(--epic-purple-emperor);
+    color: var(--epic-gold-main);
+    border: 2px solid var(--epic-gold-secondary);
+    border-radius: var(--global-border-radius);
+    padding: 8px 12px;
+    cursor: pointer;
+    z-index: 3001;
+    transition: background-color var(--global-transition-speed) ease,
+                color var(--global-transition-speed) ease;
+}
+
+#lang-bar-toggle:hover {
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+}
+
 
 /* Hide Google translate banner */
 .goog-te-banner-frame.skiptranslate {

--- a/fragments/header/language-bar.html
+++ b/fragments/header/language-bar.html
@@ -1,2 +1,4 @@
 <!-- No manual language links. Translation handled automatically via Google Translate -->
 <div id="google_translate_element"></div>
+<button id="lang-bar-toggle" aria-label="Mostrar u ocultar traducción">Traducir</button>
+

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -14,8 +14,40 @@ function loadGoogleTranslate() {
     document.head.appendChild(script);
 }
 
+function toggleLanguageBar() {
+    const el = document.getElementById('google_translate_element');
+    if (!el) return;
+
+    if (!window.googleTranslateLoaded) {
+        loadGoogleTranslate();
+        window.googleTranslateLoaded = true;
+    }
+
+    const isHidden = el.style.display === 'none' || getComputedStyle(el).display === 'none';
+    if (isHidden) {
+        el.style.display = 'block';
+        const offset = el.offsetHeight || 40;
+        document.documentElement.style.setProperty('--language-bar-offset', offset + 'px');
+    } else {
+        el.style.display = 'none';
+        document.documentElement.style.setProperty('--language-bar-offset', '0px');
+    }
+}
+
+function initLangBarToggle() {
+    const btn = document.getElementById('lang-bar-toggle');
+    if (btn) {
+        btn.addEventListener('click', toggleLanguageBar);
+    }
+    const el = document.getElementById('google_translate_element');
+    if (el) {
+        el.style.display = 'none';
+        document.documentElement.style.setProperty('--language-bar-offset', '0px');
+    }
+}
+
 if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', loadGoogleTranslate);
+    document.addEventListener('DOMContentLoaded', initLangBarToggle);
 } else {
-    loadGoogleTranslate();
+    initLangBarToggle();
 }

--- a/tests/manual/test_lang.html
+++ b/tests/manual/test_lang.html
@@ -7,7 +7,9 @@
 </head>
 <body>
 <div id="google_translate_element"></div>
+<button id="lang-bar-toggle">Traducir</button>
 <p id="text">Hola Mundo</p>
 <script src="/js/lang-bar.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- add a toggle button for the translation bar
- hide Google Translate element until requested
- style the toggle in the purple and gold theme
- update manual test page for toggling

## Testing
- `python -m unittest tests/test_flask_api.py`
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*
- `node tests/manual/test_translation.js` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685315f7b840832990d746f21858c961