### PR TITLE
Improve db connect error handling

### DIFF
--- a/alfoz/alfoz.php
+++ b/alfoz/alfoz.php
@@ -2,7 +2,12 @@
 require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';      // For is_admin_logged_in()
-require_once __DIR__ . '/../dashboard/db_connect.php'; // Provides $pdo
+try {
+    require_once __DIR__ . '/../dashboard/db_connect.php'; // Provides $pdo
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";

--- a/api_galeria.php
+++ b/api_galeria.php
@@ -1,7 +1,12 @@
 <?php
 // api_galeria.php - Endpoint para manejar la galeria colaborativa
 
-require_once 'dashboard/db_connect.php';
+try {
+    require_once 'dashboard/db_connect.php';
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 require_once 'includes/auth.php';
 
 if (session_status() == PHP_SESSION_NONE) {

--- a/api_museo.php
+++ b/api_museo.php
@@ -2,7 +2,12 @@
 // api_museo.php
 
 // Include necessary files
-require_once 'dashboard/db_connect.php'; // Adjust path as necessary
+try {
+    require_once 'dashboard/db_connect.php'; // Adjust path as necessary
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 require_once 'includes/auth.php'; // Adjust path as necessary
 require_once 'includes/csrf.php';
 

--- a/api_tienda.php
+++ b/api_tienda.php
@@ -1,5 +1,10 @@
 <?php
-require_once 'dashboard/db_connect.php';
+try {
+    require_once 'dashboard/db_connect.php';
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 require_once 'includes/auth.php';
 require_once 'includes/csrf.php';
 

--- a/contacto/contacto.php
+++ b/contacto/contacto.php
@@ -2,7 +2,12 @@
 require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';      // For is_admin_logged_in()
-require_once __DIR__ . '/../dashboard/db_connect.php'; // Provides $pdo
+try {
+    require_once __DIR__ . '/../dashboard/db_connect.php'; // Provides $pdo
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";

--- a/cultura/cultura.php
+++ b/cultura/cultura.php
@@ -2,7 +2,12 @@
 require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';      // For is_admin_logged_in()
-require_once __DIR__ . '/../dashboard/db_connect.php'; // Provides $pdo
+try {
+    require_once __DIR__ . '/../dashboard/db_connect.php'; // Provides $pdo
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";

--- a/dashboard/db_connect.php
+++ b/dashboard/db_connect.php
@@ -30,10 +30,8 @@ $db_name = "condado_castilla_db"; // Nombre de tu base de datos PostgreSQL
 $db_user = "condado_user";        // Usuario de tu base de datos PostgreSQL
 $db_pass = getenv('CONDADO_DB_PASSWORD'); // Definido vía variable de entorno
 if ($db_pass === false) {
-    // Si la variable no existe, deja $pdo como null y registra el problema
-    error_log('dashboard/db_connect.php - CONDADO_DB_PASSWORD not set');
-    $pdo = null;
-    return;
+    // Lanzar una excepción explícita si la variable no existe
+    throw new RuntimeException('dashboard/db_connect.php - CONDADO_DB_PASSWORD not set');
 }
 $db_port = "5432";                // Puerto estándar de PostgreSQL
 

--- a/dashboard/edit_texts.php
+++ b/dashboard/edit_texts.php
@@ -3,7 +3,12 @@ require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
-require_once 'db_connect.php'; // Use include_path to allow test override
+try {
+    require_once 'db_connect.php'; // Use include_path to allow test override
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";

--- a/dashboard/get_stats.php
+++ b/dashboard/get_stats.php
@@ -7,7 +7,12 @@ ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';
 require_admin_login();
 
-require_once 'db_connect.php'; // Establece la conexión $pdo
+try {
+    require_once 'db_connect.php'; // Establece la conexión $pdo
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 
 $response = ['success' => false, 'message' => 'Error desconocido.', 'data' => []];
 

--- a/dashboard/login.php
+++ b/dashboard/login.php
@@ -5,7 +5,12 @@ ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
 require_once __DIR__ . '/../includes/csrf.php';
-require_once 'dashboard/db_connect.php'; // Use include_path to allow test override
+try {
+    require_once 'dashboard/db_connect.php'; // Use include_path to allow test override
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";

--- a/dashboard/save_text.php
+++ b/dashboard/save_text.php
@@ -3,7 +3,12 @@ require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 
 require_once __DIR__ . '/../includes/auth.php';
-require_once 'db_connect.php'; // Use include_path to allow test override
+try {
+    require_once 'db_connect.php'; // Use include_path to allow test override
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";

--- a/dashboard/tienda_admin.php
+++ b/dashboard/tienda_admin.php
@@ -2,7 +2,12 @@
 require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';
-require_once 'db_connect.php'; // Use include_path to allow test override
+try {
+    require_once 'db_connect.php'; // Use include_path to allow test override
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";

--- a/foro/index.php
+++ b/foro/index.php
@@ -1,7 +1,12 @@
 <?php
 require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
-require_once __DIR__ . '/../dashboard/db_connect.php';
+try {
+    require_once __DIR__ . '/../dashboard/db_connect.php';
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 require_once __DIR__ . '/../includes/config.php';
 require_once __DIR__ . '/../includes/csrf.php';
 $agents = require __DIR__ . '/../config/forum_agents.php';

--- a/foro/manage_comments.php
+++ b/foro/manage_comments.php
@@ -2,7 +2,12 @@
 require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';
-require_once __DIR__ . '/../dashboard/db_connect.php';
+try {
+    require_once __DIR__ . '/../dashboard/db_connect.php';
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 require_once __DIR__ . '/../includes/csrf.php';
 require_admin_login();
 

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -3,7 +3,12 @@ require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';      // For is_admin_logged_in()
 // dashboard/db_connect.php ya podría estar comentado, asegurarse que se incluye para $pdo
-require_once __DIR__ . '/../dashboard/db_connect.php'; // Necesario para $pdo
+try {
+    require_once __DIR__ . '/../dashboard/db_connect.php'; // Necesario para $pdo
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -7,7 +7,12 @@ if (session_status() == PHP_SESSION_NONE) {
     }
 }
 // Asumimos que db_connect.php establece $pdo
-require_once __DIR__ . '/../dashboard/db_connect.php';
+try {
+    require_once __DIR__ . '/../dashboard/db_connect.php';
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";

--- a/historia/subpaginas/auca_patricia_ubicacion.php
+++ b/historia/subpaginas/auca_patricia_ubicacion.php
@@ -58,7 +58,12 @@ if (file_exists($json_historia_indice_path)) {
     $error_message_breadcrumb .= 'No se pudo encontrar historia_indice.json. ';
 // Título de la página actual (podría venir del JSON si esta página también fuera generada por el script)
 // Asumiendo que $pdo no está disponible aún, o para asegurar que sí lo esté.
-require_once __DIR__ . '/../../../dashboard/db_connect.php'; // Ajustar ruta si es necesario
+try {
+    require_once __DIR__ . '/../../../dashboard/db_connect.php'; // Ajustar ruta si es necesario
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";

--- a/index.php
+++ b/index.php
@@ -2,7 +2,12 @@
 require_once __DIR__ . '/includes/session.php';
 ensure_session_started();
 require_once 'includes/auth.php';      // For is_admin_logged_in()
-require_once 'dashboard/db_connect.php'; // Provides $pdo
+try {
+    require_once 'dashboard/db_connect.php'; // Provides $pdo
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 $db_warning = '';
 if (!$pdo) {

--- a/museo/editar_pieza.php
+++ b/museo/editar_pieza.php
@@ -2,7 +2,12 @@
 require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
 require_once __DIR__ . '/../includes/auth.php';
-require_once __DIR__ . '/../dashboard/db_connect.php';
+try {
+    require_once __DIR__ . '/../dashboard/db_connect.php';
+} catch (RuntimeException $e) {
+    error_log($e->getMessage());
+    $pdo = null;
+}
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";


### PR DESCRIPTION
## Summary
- throw an exception if `CONDADO_DB_PASSWORD` is missing
- catch the new exception in pages that include `db_connect.php`
- keep pages functional in read-only mode when no DB password is provided

## Testing
- `vendor/bin/phpunit` *(fails: LoginLogoutTest::testLoginLogout and others)*
- `python -m unittest tests/test_flask_api.py`


------
https://chatgpt.com/codex/tasks/task_e_685314ad8a048329abec164b80ab83a2