### PR TITLE
Improve translate toggle

### DIFF
--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -63,20 +63,32 @@
 #lang-bar-toggle {
     position: fixed;
     top: var(--language-bar-offset);
-    right: 115px;
+    right: 15px;
     background-color: var(--epic-purple-emperor);
     color: var(--epic-gold-main);
     border: 2px solid var(--epic-gold-secondary);
     border-radius: var(--global-border-radius);
-    padding: 8px 12px;
+    padding: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
     cursor: pointer;
     z-index: 3001;
     transition: background-color var(--global-transition-speed) ease,
                 color var(--global-transition-speed) ease;
 }
 
+#lang-bar-toggle i {
+    color: var(--epic-gold-main);
+}
+
 #lang-bar-toggle:hover {
     background-color: var(--epic-gold-main);
+}
+
+#lang-bar-toggle:hover i {
     color: var(--epic-purple-emperor);
 }
 

--- a/fragments/header/language-bar.html
+++ b/fragments/header/language-bar.html
@@ -1,4 +1,7 @@
 <!-- No manual language links. Translation handled automatically via Google Translate -->
 <div id="google_translate_element"></div>
-<button id="lang-bar-toggle" aria-label="Mostrar u ocultar traducción">Traducir</button>
+<button id="lang-bar-toggle" aria-label="Mostrar u ocultar traducción">
+    <i class="fas fa-globe"></i>
+    <span class="visually-hidden">Traducir</span>
+</button>
 


### PR DESCRIPTION
## Summary
- use icon for translation toggle button
- style translation button and place it on the right

## Testing
- `composer install` *(fails: ext-dom missing at first but resolved)*
- `vendor/bin/phpunit` *(fails: php-cgi missing)*
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_685318571b5c8329bb802bb853d89b20