### PR TITLE
Remove deprecated header loader script

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ para evitar enlaces duplicados en la navegación.
 
 ## Cambios recientes
 
-- Eliminado `js/header_loader.js` y referencias a dicho script, ya que la cabecera se carga ahora de forma estática.
+- Eliminado `js/header_loader.js` y su inclusión en `includes/head_common.php`; la cabecera se carga ahora directamente desde `_header.php`.
 
 
 

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -22,4 +22,3 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <script defer src="/assets/vendor/js/bootstrap.bundle.min.js"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" />
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
-<script defer src="/js/header-loader.js"></script>


### PR DESCRIPTION
## Summary
- remove unused `header-loader.js` include in `head_common.php`
- note in README that the script and its reference were removed

## Testing
- `./vendor/bin/phpunit` *(fails: `php-cgi` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531b18afd88329bec026c00e640645