### PR TITLE
Fix theme toggle icon and document default mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,7 @@ El proyecto define cinco agentes que participan en el foro para orientar las con
 - **Elena la Tecnóloga** – aplica innovación tecnológica al servicio del patrimonio.
 
 Para ajustar sus biografías o añadir nuevos perfiles edita el archivo `config/forum_agents.php` y actualiza el array de configuración.
+
+## Tema predeterminado
+
+El sitio arranca en modo oscuro. Si el navegador no tiene guardada una preferencia en `localStorage`, el script `assets/js/main.js` añade la clase `dark-mode` al elemento `<body>` y muestra el icono `fa-sun` en el botón de cambio de tema. Al pulsar dicho botón se alterna entre modo oscuro y claro, actualizando el icono (`fa-sun` o `fa-moon`) y almacenando la elección para futuras visitas.

--- a/_header.php
+++ b/_header.php
@@ -2,7 +2,7 @@
 echo file_get_contents(__DIR__ . "/fragments/header/language-bar.html");
 ?>
 <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
-<button id="theme-toggle" aria-label="Cambiar tema"><i class="fas fa-lightbulb"></i></button>
+<button id="theme-toggle" aria-label="Cambiar tema"><i class="fas fa-moon"></i></button>
 
 <!-- Left Sliding Panel for Main Menu -->
 <div id="consolidated-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="consolidated-menu-button">

--- a/tests/themeToggleTest.js
+++ b/tests/themeToggleTest.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const {JSDOM} = require('jsdom');
+
+const headerHtml = fs.readFileSync('_header.php', 'utf8');
+const scriptJs = fs.readFileSync('assets/js/main.js', 'utf8');
+
+const dom = new JSDOM(`<body>${headerHtml}</body>`, {
+  runScripts: "dangerously",
+  resources: "usable",
+  url: "https://example.com"
+});
+
+const {window} = dom;
+window.localStorage.setItem('theme', 'dark');
+
+const scriptEl = window.document.createElement('script');
+scriptEl.textContent = scriptJs;
+window.document.body.appendChild(scriptEl);
+
+window.addEventListener('DOMContentLoaded', () => {
+  const themeToggle = window.document.getElementById('theme-toggle');
+  const icon = themeToggle.querySelector('i');
+  console.log('initial', icon.className, window.document.body.classList.contains('dark-mode'));
+  themeToggle.click();
+  console.log('afterClick', icon.className, window.document.body.classList.contains('dark-mode'));
+  themeToggle.click();
+  console.log('afterSecond', icon.className, window.document.body.classList.contains('dark-mode'));
+});


### PR DESCRIPTION
## Summary
- show fa-moon icon by default in the header
- explain the theme default behaviour in README
- add a small jsdom test for the theme toggle

## Testing
- `python3 -m unittest tests/test_flask_api.py -v`
- `node tests/themeToggleTest.js`


------
https://chatgpt.com/codex/tasks/task_e_68531b1ac13c832981600009afa781db