### PR TITLE
Fix language bar offset handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ para evitar enlaces duplicados en la navegación.
 
 ## Cambios recientes
 
-- Eliminado `js/header_loader.js` y referencias a dicho script, ya que la cabecera se carga ahora de forma estática.
+- Se ha reintroducido `js/header-loader.js` para insertar dinámicamente `/_header.php` en `#header-placeholder` de las páginas estáticas.
+- Este script inicializa además `setupLanguageBar` y `applyLanguageBarOffset` para que la barra de idioma funcione correctamente.
 
 
 

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -11,7 +11,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `js/load_menu_parts.js` | Dynamically loads menu fragments into the header when needed. |
 | `js/header-loader.js` | Fetches `/_header.php` and injects it into `#header-placeholder` for static pages. |
 | `js/ia-tools.js` | Implements AI assistant utilities such as summaries, translations and chat. |
-| `js/lang-bar.js` | Loads Google Translate when a `?lang=` URL parameter is present. |
+| `js/lang-bar.js` | Handles the Google Translate widget, toggling the bar and setting `--language-bar-offset` to keep the header aligned. |
 | `js/lugares-data.js` | Provides static data used by `lugares-dynamic-list.js`. |
 | `js/lugares-dynamic-list.js` | Generates the list of places dynamically from `lugares-data.js`. |
 | `js/museo-2d-gallery.js` | Logic for the collaborative museum 2D gallery including uploads and modals. |
@@ -22,4 +22,4 @@ Deprecated or merged scripts such as `js/menu-controller.js` and `js/sliding-men
 
 ## Simplified Translation
 
-Pages are translated by passing a `lang` query parameter in the URL. When this parameter is present, `js/lang-bar.js` dynamically loads the Google Translate widget and applies the selected language without showing flag icons or a language bar.
+Pages are translated by passing a `lang` query parameter in the URL. When this parameter is present, `js/lang-bar.js` loads the Google Translate widget on demand. The same script toggles the language bar when the globe button is clicked and updates the `--language-bar-offset` CSS variable so the fixed header shifts smoothly.

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -14,6 +14,15 @@ function loadGoogleTranslate() {
     document.head.appendChild(script);
 }
 
+function applyLanguageBarOffset() {
+    const el = document.getElementById('google_translate_element');
+    if (!el) return;
+
+    const isHidden = el.style.display === 'none' || getComputedStyle(el).display === 'none';
+    const offset = isHidden ? 0 : (el.offsetHeight || 40);
+    document.documentElement.style.setProperty('--language-bar-offset', offset + 'px');
+}
+
 function toggleLanguageBar() {
     const el = document.getElementById('google_translate_element');
     if (!el) return;
@@ -26,12 +35,10 @@ function toggleLanguageBar() {
     const isHidden = el.style.display === 'none' || getComputedStyle(el).display === 'none';
     if (isHidden) {
         el.style.display = 'block';
-        const offset = el.offsetHeight || 40;
-        document.documentElement.style.setProperty('--language-bar-offset', offset + 'px');
     } else {
         el.style.display = 'none';
-        document.documentElement.style.setProperty('--language-bar-offset', '0px');
     }
+    applyLanguageBarOffset();
 }
 
 function initLangBarToggle() {
@@ -42,8 +49,8 @@ function initLangBarToggle() {
     const el = document.getElementById('google_translate_element');
     if (el) {
         el.style.display = 'none';
-        document.documentElement.style.setProperty('--language-bar-offset', '0px');
     }
+    applyLanguageBarOffset();
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- implement `applyLanguageBarOffset` in `js/lang-bar.js`
- call new helper from the language bar toggle and initialisation
- clarify that `header-loader.js` is used again in README
- document language bar behaviour in `docs/js-modules-overview.md`

## Testing
- `python3 -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68531b1c36e48329ae87ef17d1e172f9