### PR TITLE
Update language bar toggle behavior

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -59,9 +59,20 @@ body {
     top: 0px !important;
 }
 
-/* Ensure the Google Translate widget itself is not accidentally shown if not already hidden by inline style */
+/* Style for Google Translate widget - hidden off-canvas by default */
 #google_translate_element {
-    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    transform: translateY(-100%);
+    transition: transform 0.3s ease;
+    z-index: 3500;
+}
+
+/* Visible state for the language bar */
+#google_translate_element.visible {
+    transform: translateY(0);
 }
 
 /* Ocultar visualmente pero mantener accesible */

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -23,13 +23,13 @@ function toggleLanguageBar() {
         window.googleTranslateLoaded = true;
     }
 
-    const isHidden = el.style.display === 'none' || getComputedStyle(el).display === 'none';
-    if (isHidden) {
-        el.style.display = 'block';
+    const isVisible = el.classList.contains('visible');
+    if (!isVisible) {
+        el.classList.add('visible');
         const offset = el.offsetHeight || 40;
         document.documentElement.style.setProperty('--language-bar-offset', offset + 'px');
     } else {
-        el.style.display = 'none';
+        el.classList.remove('visible');
         document.documentElement.style.setProperty('--language-bar-offset', '0px');
     }
 }
@@ -41,7 +41,7 @@ function initLangBarToggle() {
     }
     const el = document.getElementById('google_translate_element');
     if (el) {
-        el.style.display = 'none';
+        el.classList.remove('visible');
         document.documentElement.style.setProperty('--language-bar-offset', '0px');
     }
 }


### PR DESCRIPTION
## Summary
- hide the Google Translate bar off-canvas and animate with `transform`
- toggle visibility via a CSS class and update offset in JS

## Testing
- `python -m unittest tests/test_flask_api.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532a34ecac8329ba5d7b8fcc125923