### PR TITLE
Refactor language bar offset logic

### DIFF
--- a/js/header-loader.js
+++ b/js/header-loader.js
@@ -6,9 +6,6 @@
             .then(resp => resp.text())
             .then(html => {
                 placeholder.innerHTML = html;
-                if (typeof setupLanguageBar === 'function') {
-                    setupLanguageBar();
-                }
                 if (typeof applyLanguageBarOffset === 'function') {
                     applyLanguageBarOffset();
                 }

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -14,6 +14,14 @@ function loadGoogleTranslate() {
     document.head.appendChild(script);
 }
 
+function applyLanguageBarOffset() {
+    const el = document.getElementById('google_translate_element');
+    if (!el) return;
+    const isHidden = el.style.display === 'none' || getComputedStyle(el).display === 'none';
+    const offset = isHidden ? 0 : (el.offsetHeight || 40);
+    document.documentElement.style.setProperty('--language-bar-offset', offset + 'px');
+}
+
 function toggleLanguageBar() {
     const el = document.getElementById('google_translate_element');
     if (!el) return;
@@ -24,14 +32,8 @@ function toggleLanguageBar() {
     }
 
     const isHidden = el.style.display === 'none' || getComputedStyle(el).display === 'none';
-    if (isHidden) {
-        el.style.display = 'block';
-        const offset = el.offsetHeight || 40;
-        document.documentElement.style.setProperty('--language-bar-offset', offset + 'px');
-    } else {
-        el.style.display = 'none';
-        document.documentElement.style.setProperty('--language-bar-offset', '0px');
-    }
+    el.style.display = isHidden ? 'block' : 'none';
+    applyLanguageBarOffset();
 }
 
 function initLangBarToggle() {
@@ -44,6 +46,7 @@ function initLangBarToggle() {
         el.style.display = 'none';
         document.documentElement.style.setProperty('--language-bar-offset', '0px');
     }
+    window.applyLanguageBarOffset = applyLanguageBarOffset;
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- keep header loader simple by removing obsolete setup hook
- centralize applyLanguageBarOffset in `js/lang-bar.js`
- toggle translation bar using the new helper

## Testing
- `pip install -r requirements.txt --quiet`
- `python -m unittest tests/test_flask_api.py`
- `python -m unittest discover -s tests`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68532a35ac3883299601389bd2ebc929