### PR TITLE
Ensure sliding menu markup and document compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,22 @@ Para ajustar sus biografías o añadir nuevos perfiles edita el archivo `config/
 ## Tema predeterminado
 
 El sitio arranca en modo oscuro. Si el navegador no tiene guardada una preferencia en `localStorage`, el script `assets/js/main.js` añade la clase `dark-mode` al elemento `<body>` y muestra el icono `fa-sun` en el botón de cambio de tema. Al pulsar dicho botón se alterna entre modo oscuro y claro, actualizando el icono (`fa-sun` o `fa-moon`) y almacenando la elección para futuras visitas.
+
+## Efecto de compresión del menú deslizante
+
+Cada vez que se abre un panel `.menu-panel`, `assets/js/main.js` agrega la clase `menu-compressed` al elemento `<body>` junto con `menu-open-left` o `menu-open-right` según el lado del que se despliegue. Estas clases están definidas en `assets/css/sliding_menu.css`:
+
+```css
+body.menu-compressed {
+    transition: transform 0.3s ease;
+    transform: scale(0.97);
+}
+body.menu-open-left {
+    transform: translateX(260px) scale(0.97);
+}
+body.menu-open-right {
+    transform: translateX(-260px) scale(0.97);
+}
+```
+
+El contenido se desplaza ligeramente y se escala al 97%, dando la sensación de que el sitio se comprime por el lateral desde el que aparece el menú. Al cerrarlo, las clases se eliminan y la página vuelve a su posición original.

--- a/foro/index.php
+++ b/foro/index.php
@@ -62,11 +62,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo) {
 <body>
 <?php require_once __DIR__ . '/../_header.php'; ?>
 <button id="menu-btn" class="menu-btn" data-menu-target="agents-menu">☰ Expertos</button>
-<nav id="agents-menu" class="slide-menu left">
+<div id="agents-menu" class="menu-panel left-panel">
 <?php foreach ($agents as $id => $ag): ?>
     <a href="#<?php echo $id; ?>" class="gradient-title"><?php echo htmlspecialchars($ag['name']); ?></a>
 <?php endforeach; ?>
-</nav>
+</div>
 <main class="container page-content-block">
     <h1 style="text-align:center;">Foro de Expertos</h1>
     <?php if (!empty($_SESSION['forum_error'])): ?>


### PR DESCRIPTION
## Summary
- standardize forum page markup to use `.menu-panel`
- explain the menu compression effect in README

## Testing
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68532ca1df708329be7f366286cba6e0