### PR TITLE
Use gradient-text across history & forum pages

### DIFF
--- a/assets/css/pages/foro.css
+++ b/assets/css/pages/foro.css
@@ -7,11 +7,6 @@ body { background-color: rgba(245,235,220,0.95); }
     border-left: 5px solid var(--color-primario-purpura, #4A0D67);
     backdrop-filter: blur(3px);
 }
-.gradient-title {
-    background: linear-gradient(45deg, var(--color-primario-purpura, #4A0D67), var(--color-secundario-dorado, #B8860B));
-    -webkit-background-clip: text;
-    color: transparent;
-}
 .agent-profile textarea { width: 100%; margin: 0.5em 0; }
 .feedback { padding: 10px; margin: 10px 0; border-radius: 4px; }
 .feedback.error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }

--- a/foro/index.php
+++ b/foro/index.php
@@ -64,17 +64,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo) {
 <button id="menu-btn" class="menu-btn" data-menu-target="agents-menu">☰ Expertos</button>
 <nav id="agents-menu" class="slide-menu left">
 <?php foreach ($agents as $id => $ag): ?>
-    <a href="#<?php echo $id; ?>" class="gradient-title"><?php echo htmlspecialchars($ag['name']); ?></a>
+    <a href="#<?php echo $id; ?>" class="gradient-text"><?php echo htmlspecialchars($ag['name']); ?></a>
 <?php endforeach; ?>
 </nav>
 <main class="container page-content-block">
-    <h1 style="text-align:center;">Foro de Expertos</h1>
+    <h1 style="text-align:center;" class="gradient-text">Foro de Expertos</h1>
     <?php if (!empty($_SESSION['forum_error'])): ?>
         <p class="feedback error"><?php echo htmlspecialchars($_SESSION['forum_error']); unset($_SESSION['forum_error']); ?></p>
     <?php endif; ?>
     <?php foreach ($agents as $id => $ag): ?>
     <section id="<?php echo $id; ?>" class="agent-profile">
-        <h2 class="gradient-title"><?php echo htmlspecialchars($ag['name']); ?></h2>
+        <h2 class="gradient-text"><?php echo htmlspecialchars($ag['name']); ?></h2>
         <p><?php echo htmlspecialchars($ag['bio']); ?></p>
         <form method="post">
             <input type="hidden" name="agent" value="<?php echo $id; ?>">

--- a/historia/historia.php
+++ b/historia/historia.php
@@ -9,7 +9,7 @@
 
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_historia_background.jpg');">
         <div class="hero-content">
-            <h1>Línea de Tiempo de Nuestra Historia</h1>
+            <h1 class="gradient-text">Línea de Tiempo de Nuestra Historia</h1>
             <p>Un recorrido cronológico por los eventos y eras que forjaron el Condado de Castilla y la identidad de Cerezo de Río Tirón.</p>
         </div>
     </header>
@@ -17,7 +17,7 @@
     <main>
         <section class="section timeline-section alternate-bg">
             <div class="container">
-                <h2 class="section-title">Un Viaje Milenario</h2>
+                <h2 class="section-title gradient-text">Un Viaje Milenario</h2>
                 <p class="timeline-intro">
                     Desde los primeros homínidos en la Sierra de Atapuerca hasta la configuración actual de nuestra comarca, 
                     te invitamos a explorar los hitos cruciales que han modelado nuestra rica identidad a lo largo de los siglos.
@@ -28,7 +28,7 @@
                             <img src="/assets/img/estrella.png" alt="Hito en la línea de tiempo: Prehistoria">
                         </div>
                         <div class="timeline-content">
-                            <h3>Prehistoria: Atapuerca y Primeros Pobladores</h3>
+                            <h3 class="gradient-text">Prehistoria: Atapuerca y Primeros Pobladores</h3>
                             <p>Los yacimientos de la Sierra de Atapuerca, Patrimonio de la Humanidad, revelan la presencia humana en Europa desde hace más de un millón de años. Descubre los vestigios de nuestros ancestros más remotos y su forma de vida en un entorno que ya prefiguraba la importancia estratégica de la región.</p>
                             <a href="atapuerca.php" class="read-more timeline-read-more">Explorar Atapuerca</a>
                         </div>
@@ -38,7 +38,7 @@
                              <img src="/assets/img/estrella.png" alt="Hito en la línea de tiempo: Pueblos Prerromanos">
                         </div>
                         <div class="timeline-content">
-                            <h3>Pueblos Prerromanos: Berones, Autrigones y Cántabros</h3>
+                            <h3 class="gradient-text">Pueblos Prerromanos: Berones, Autrigones y Cántabros</h3>
                             <p>Antes de la llegada de Roma, la región fue habitada por diversas tribus celtíberas como los Berones, Autrigones y los aguerridos Cántabros (Concanos/Caucanos). Estos pueblos dejaron una profunda huella en el territorio a través de sus castros, ritos y una feroz resistencia que definiría su carácter.</p>
                              <a href="#prerromanos-detalle" class="read-more timeline-read-more">Conocer los Pueblos</a>
                         </div>
@@ -48,7 +48,7 @@
                              <img src="/assets/img/estrella.png" alt="Hito en la línea de tiempo: Romanización">
                         </div>
                         <div class="timeline-content">
-                            <h3>Romanización: Auca Patricia y el Legado Imperial</h3>
+                            <h3 class="gradient-text">Romanización: Auca Patricia y el Legado Imperial</h3>
                             <p>La conquista romana transformó la península. Auca Patricia (cerca de Cerezo) se erigió como una importante civitas y sede episcopal, integrando la región en la vasta red del Imperio Romano y dejando un legado arqueológico monumental que incluye calzadas, villas y obras públicas.</p>
                              <a href="#romanizacion-detalle" class="read-more timeline-read-more">Ver Época Romana</a>
                         </div>
@@ -58,7 +58,7 @@
                              <img src="/assets/img/estrella.png" alt="Hito en la línea de tiempo: Época Visigoda">
                         </div>
                         <div class="timeline-content">
-                            <h3>Época Visigoda: Continuidad y Transformación</h3>
+                            <h3 class="gradient-text">Época Visigoda: Continuidad y Transformación</h3>
                             <p>Tras la caída del Imperio Romano de Occidente, los visigodos establecieron su reino en Hispania. Auca Patricia mantuvo su relevancia como sede episcopal, y la región experimentó una mezcla de continuidad romana y nuevas influencias germánicas, sentando las bases para la futura Castilla.</p>
                              <a href="#visigoda-detalle" class="read-more timeline-read-more">Explorar Periodo Visigodo</a>
                         </div>
@@ -68,7 +68,7 @@
                              <img src="/assets/img/estrella.png" alt="Hito en la línea de tiempo: Presencia Árabe">
                         </div>
                         <div class="timeline-content">
-                            <h3>Presencia Árabe y Resistencia Cristiana (Siglos VIII-X)</h3>
+                            <h3 class="gradient-text">Presencia Árabe y Resistencia Cristiana (Siglos VIII-X)</h3>
                             <p>La conquista musulmana de la península en el 711 transformó el panorama político. Aunque la presencia árabe directa en estas tierras del norte pudo ser menos duradera o intensa que en otras zonas, la región se convirtió en una crucial zona de frontera. El Alcázar de Casio, atribuido al Conde Casio (figura de transición), y la posterior organización de los condados cristianos fueron respuestas directas a esta nueva realidad, marcando el inicio de la Reconquista y la forja de la identidad castellana.</p>
                              <a href="#arabe-detalle" class="read-more timeline-read-more">La Frontera y el Origen</a>
                         </div>
@@ -78,7 +78,7 @@
                              <img src="/assets/img/estrella.png" alt="Hito en la línea de tiempo: Alta Edad Media">
                         </div>
                         <div class="timeline-content">
-                            <h3>Alta Edad Media: El Nacimiento del Condado de Castilla</h3>
+                            <h3 class="gradient-text">Alta Edad Media: El Nacimiento del Condado de Castilla</h3>
                             <p>En este contexto de reinos cambiantes y la Reconquista, surge y se consolida el Condado de Castilla. Figuras como Rodrigo, Diego Rodríguez Porcelos y Gonzalo Téllez forjaron en Cerezo y Lantarón un bastión fundamental, marcando el inicio de una nueva entidad política y cultural que daría forma a la futura España.</p>
                              <a href="#altaedadmedia-detalle" class="read-more timeline-read-more">El Condado</a>
                         </div>
@@ -88,7 +88,7 @@
                             <img src="/assets/img/estrellaGordita.png" alt="Hito en la línea de tiempo: Explorando los Orígenes de Castilla">
                         </div>
                         <div class="timeline-content">
-                            <h3>Explorando Auca Patricia, Cerasio y los Orígenes de Castilla</h3>
+                            <h3 class="gradient-text">Explorando Auca Patricia, Cerasio y los Orígenes de Castilla</h3>
                             <p>Un análisis detallado sobre la importancia de Auca Patricia, el Alcázar de Cerasio y su papel fundamental en la historia y origen de Castilla, basado en investigaciones y textos históricos.</p>
                             <a href="/historia/nuestra_historia_nuevo4.php" class="read-more timeline-read-more">Leer Más Sobre los Orígenes de Castilla</a>
                         </div>
@@ -98,7 +98,7 @@
                             <img src="/assets/img/estrellaGordita.png" alt="Hito en la línea de tiempo: Documentos Históricos">
                         </div>
                         <div class="timeline-content">
-                            <h3>Documentos Históricos del Condado</h3>
+                            <h3 class="gradient-text">Documentos Históricos del Condado</h3>
                             <p>Accede a una colección de documentos, manuscritos y archivos relevantes para la investigación y comprensión de la historia de Cerezo de Río Tirón y el Condado de Castilla. Incluye PDFs, textos y otros formatos.</p>
                             <a href="/historia/documentos/index.html" class="read-more timeline-read-more">Explorar Documentos</a>
                         </div>
@@ -108,7 +108,7 @@
                             <img src="/assets/img/estrellaGordita.png" alt="Hito en la línea de tiempo: Galería Histórica">
                         </div>
                         <div class="timeline-content">
-                            <h3>Galería Visual de la Historia</h3>
+                            <h3 class="gradient-text">Galería Visual de la Historia</h3>
                             <p>Descubre imágenes, mapas antiguos, fotografías de artefactos y otras representaciones visuales que ilustran la rica herencia histórica de nuestra región. Cada elemento incluye una descripción detallada.</p>
                             <a href="/historia/galeria_historica/index.html" class="read-more timeline-read-more">Visitar Galería</a>
                         </div>
@@ -118,7 +118,7 @@
                              <img src="/assets/img/estrella.png" alt="Hito en la línea de tiempo: Plena y Baja Edad Media">
                         </div>
                         <div class="timeline-content">
-                            <h3>Plena y Baja Edad Media: Consolidación y Señoríos</h3>
+                            <h3 class="gradient-text">Plena y Baja Edad Media: Consolidación y Señoríos</h3>
                             <p>El Condado se convierte en Reino, expandiendo su influencia. La región de Cerezo y el Alfoz de Lantarón viven bajo diferentes señoríos, con la construcción y reforma de castillos, murallas e iglesias que aún hoy definen el paisaje y narran historias de poder y fe.</p>
                              <a href="#plenabajaedadmedia-detalle" class="read-more timeline-read-more">Ver la Evolución</a>
                         </div>
@@ -128,7 +128,7 @@
                              <img src="/assets/img/estrella.png" alt="Hito en la línea de tiempo: Edad Moderna y Contemporánea">
                         </div>
                         <div class="timeline-content">
-                            <h3>Edad Moderna y Contemporánea: De los Austrias a Nuestros Días</h3>
+                            <h3 class="gradient-text">Edad Moderna y Contemporánea: De los Austrias a Nuestros Días</h3>
                             <p>Los avatares de la historia de España siguen marcando la región, desde el Antiguo Régimen, pasando por las guerras y transformaciones sociales del siglo XIX y XX, hasta el presente, donde se busca preservar y difundir un rico patrimonio cultural e histórico.</p>
                              <a href="#edadmodernacontemporanea-detalle" class="read-more timeline-read-more">Historia Reciente</a>
                         </div>

--- a/historia/subpaginas/obispado_auca_cerezo.php
+++ b/historia/subpaginas/obispado_auca_cerezo.php
@@ -10,17 +10,17 @@
 
 <header id="hero-obispado-auca-cerezo" class="page-header hero">
         <div class="hero-content">
-            <h1>El Obispado de Auca en Cerezo de Río Tirón</h1>
+            <h1 class="gradient-text">El Obispado de Auca en Cerezo de Río Tirón</h1>
         </div>
     </header>
     <main>
         <section class="section">
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
-                <h3>Auca Patricia y la Diócesis de Oca</h3>
+                <h3 class="gradient-text">Auca Patricia y la Diócesis de Oca</h3>
                 <p>La tradición ha situado el antiguo obispado de Auca&nbsp;—conocido también como Oca— en las cercanías de Villafranca, pero numerosos indicios arqueológicos y literarios apuntan a que la sede episcopal se hallaba realmente en Cerezo de Río Tirón. Las imponentes murallas romanas y la gran iglesia de San Martín, de más de 100&nbsp;metros de longitud, se identifican con la <em>Civitate Auca Patricia</em>.</p>
                 <p>Esta ciudad habría sido la cabeza de la Cantabria visigoda. Tras las invasiones del siglo&nbsp;VIII, el obispado se trasladó a Valpuesta y más tarde se restauró en Burgos, pero en origen estuvo ligado a Cerezo. A veces se confunde esta civitas con la llamada <em>Cauca</em>; ambos nombres aparecen asociados a la misma comarca.</p>
-                <h3>Lista de Obispos</h3>
+                <h3 class="gradient-text">Lista de Obispos</h3>
                 <p>Entre los prelados conocidos de la diócesis destacan:</p>
                 <ul>
                     <li>Asterio (mencionado en 589)</li>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
@@ -246,7 +246,7 @@
 
     <header class="page-header-personaje">
         <div class="container">
-            <h1>Rodrigo, Primer Conde de Castilla</h1>
+            <h1 class="gradient-text">Rodrigo, Primer Conde de Castilla</h1>
         </div>
     </header>
 
@@ -255,17 +255,17 @@
             <div class="container">
                 <div class="content-wrapper">
                     <img src="/assets/img/condes/rodrigo_el_conde_placeholder.jpg" alt="Representación del Conde Rodrigo" class="personaje-imagen-principal" onerror="this.onerror=null;this.src='/assets/img/placeholder.jpg';">
-                    <h2>Biografía y Relevancia</h2>
+                    <h2 class="gradient-text">Biografía y Relevancia</h2>
                     <p>
                         Rodrigo fue el primer Conde de Castilla documentado, gobernando aproximadamente entre los años 850 y 873. Designado por Ordoño I de Asturias, su principal encomienda fue la defensa de la marca oriental del reino asturiano ("Castella Vetula" o Castilla la Vieja) frente a las incursiones musulmanas procedentes de Al-Ándalus. Se le atribuye la repoblación de Amaya en el 860, un punto estratégico para la defensa de la región. Fue una figura crucial en la organización inicial del territorio que llegaría a ser el Condado y posteriormente el Reino de Castilla. Su hijo, Diego Rodríguez Porcelos, le sucedió y continuó su labor.
                     </p>
 
-                    <h3>Perspectiva de "nuevo4.md"</h3>
+                    <h3 class="gradient-text">Perspectiva de "nuevo4.md"</h3>
                     <p>
                         El documento <code>nuevo4.md</code> se refiere a Rodrigo como el 'Primer Conde de Cerezo y Lantarón – Conde de Castilla y Álava'. Se destaca su papel como padre de Diego Rodríguez Porcelos. Un evento central en su mención es la Batalla de la Morcuera, que <code>nuevo4.md</code> sitúa desarrollándose enteramente en el Alfoz de Cerezo y Lantarón, y en la cual Rodrigo habría perdido. Se implica que sus castillos estaban dentro de este alfoz. Adicionalmente, su fortaleza 'Alqila', descrita como un complejo de cuatro castillos, es referida como 'cuna y tumba de Condes de Castilla'. El texto lo posiciona como uno de los primeros en ostentar los títulos de Conde de Castilla y Álava.
                     </p>
 
-                    <h3>Hitos Importantes</h3>
+                    <h3 class="gradient-text">Hitos Importantes</h3>
                     <ul>
                         <li>Primer Conde de Castilla documentado (c. 850-873).</li>
                         <li>Según <code>nuevo4.md</code>, fue el Primer Conde de Cerezo y Lantarón, además de Conde de Castilla y Álava.</li>

--- a/personajes/indice_personajes.html
+++ b/personajes/indice_personajes.html
@@ -24,7 +24,7 @@
     <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.75), rgba(var(--color-negro-contraste-rgb), 0.88)), url('/assets/img/hero_personajes_background.jpg');">
         <div class="hero-content">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <h1>Índice de Personajes Históricos y Legendarios</h1>
+            <h1 class="gradient-text">Índice de Personajes Históricos y Legendarios</h1>
             <p>Un compendio de las figuras que forjaron la historia y el mito de nuestras tierras.</p>
         </div>
     </header>
@@ -37,7 +37,7 @@
                 <div id="error-message-container" style="color: red; text-align: center;"></div>
                 <ul class="indice-categorias">
                     <li>
-                        <h3><i class="fas fa-chess-king"></i> Condes de Castilla, Álava y Lantarón</h3>
+                        <h3 class="gradient-text"><i class="fas fa-chess-king"></i> Condes de Castilla, Álava y Lantarón</h3>
                         <ul class="indice-personajes-lista" id="condes-lista">
                             <li><a href="/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html">Rodrigo (Rodrigo el Conde)</a></li>
                             <li><a href="/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html">Diego Rodríguez Porcelos</a></li>
@@ -49,7 +49,7 @@
                         </ul>
                     </li>
                     <li>
-                        <h3><i class="fas fa-shield-alt"></i> Militares y Gobernantes</h3>
+                        <h3 class="gradient-text"><i class="fas fa-shield-alt"></i> Militares y Gobernantes</h3>
                         <ul class="indice-personajes-lista" id="militares-lista">
                             <li><a href="/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html">Conde Casio (Cerasio)</a></li>
                             <li><a href="/personajes/Militares_y_Gobernantes/ramiro_i_de_asturias.html">Ramiro I de Asturias</a></li>
@@ -61,7 +61,7 @@
                         </ul>
                     </li>
                     <li>
-                        <h3><i class="fas fa-cross"></i> Santos y Mártires</h3>
+                        <h3 class="gradient-text"><i class="fas fa-cross"></i> Santos y Mártires</h3>
                         <ul class="indice-personajes-lista" id="santos-lista">
                             <li><a href="/personajes/Santos_y_Martires/abades_sonna_donnino_damian.html">Abades Sonna, Donnino y Damián</a></li>
                             <li><a href="/personajes/Santos_y_Martires/obispos_gudesteos_frunimio.html">Obispos Gudesteos y Frunimio</a></li>
@@ -74,7 +74,7 @@
                         </ul>
                     </li>
                     <li>
-                        <h3><i class="fas fa-landmark"></i> Emperadores Romanos de Cuna Hispana</h3>
+                        <h3 class="gradient-text"><i class="fas fa-landmark"></i> Emperadores Romanos de Cuna Hispana</h3>
                         <ul class="indice-personajes-lista" id="emperadores-lista">
                             <li><a href="/personajes/Emperadores_Romanos_Hispanos_Auca/aureliano.html">Aureliano</a></li>
                             <li><a href="/personajes/Emperadores_Romanos_Hispanos_Auca/constantino.html">Constantino</a></li>
@@ -85,27 +85,27 @@
                         </ul>
                     </li>
                     <li>
-                        <h3><i class="fas fa-hands-helping"></i> Órdenes y Legados</h3>
+                        <h3 class="gradient-text"><i class="fas fa-hands-helping"></i> Órdenes y Legados</h3>
                         <ul class="indice-personajes-lista" id="ordenes-lista">
                             <li><a href="/personajes/Ordenes_y_Legados/monjes_hospitalarios_san_jorge_y_san_anton.html">Monjes Hospitalarios de San Jorge y San Antón</a></li>
                             <li><a href="/personajes/Ordenes_y_Legados/paterna_banucasi.html">Paterna (Banucasi)</a></li>
                         </ul>
                     </li>
                     <li>
-                        <h3><i class="fas fa-crown"></i> Reyes y Reinas</h3>
+                        <h3 class="gradient-text"><i class="fas fa-crown"></i> Reyes y Reinas</h3>
                         <ul class="indice-personajes-lista" id="reyes-lista">
                             <li><a href="/personajes/Militares_y_Gobernantes/alfonso_ii_el_casto.html">Alfonso II el Casto</a></li>
                             <li><a href="/personajes/Militares_y_Gobernantes/leovigildo.html">Leovigildo</a></li>
                         </ul>
                     </li>
                     <li>
-                        <h3><i class="fas fa-pen-nib"></i> Escritores y Cronistas</h3>
+                        <h3 class="gradient-text"><i class="fas fa-pen-nib"></i> Escritores y Cronistas</h3>
                         <ul class="indice-personajes-lista" id="escritores-lista">
                             <li><a href="/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html">Fray Prudencio de Sandoval</a></li>
                         </ul>
                     </li>
                     <li>
-                        <h3><i class="fas fa-book-open"></i> Leyendas y Cuentos</h3>
+                        <h3 class="gradient-text"><i class="fas fa-book-open"></i> Leyendas y Cuentos</h3>
                         <ul class="indice-personajes-lista" id="leyendas-lista">
                             <li><a href="/personajes/Leyendas_y_Cuentos/beatriz.html">Beatriz de las Aguas Misteriosas</a></li>
                         </ul>
@@ -113,7 +113,7 @@
                 </ul>
 
                 <section class="character-gallery-container">
-                    <h2>Galería de Personajes</h2>
+                    <h2 class="gradient-text">Galería de Personajes</h2>
                     <div class="gallery-grid" id="galeria-personajes-grid">
                         <div class="gallery-item">
                             <img src="/assets/img/placeholder_personaje.png" alt="Rodrigo el Conde">


### PR DESCRIPTION
## Summary
- reuse existing `.gradient-text` class to highlight main headings
- remove page-specific gradient style from `foro.css`
- apply gradient to forum headings
- update history timeline pages with gradient text
- style characters index and one biography page with gradient headers

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*


------
https://chatgpt.com/codex/tasks/task_e_68532ca275e08329900bd356d4b1da65