### PR TITLE
Update test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,16 @@ El valor se inyectará en la etiqueta `<meta name="gemini-api-key">` generada po
 
 ## Ejecución de pruebas
 
-Instala **todas** las dependencias antes de lanzar las suites de pruebas. Las pruebas dependen de PHP, Composer y las extensiones indicadas, por lo que no se ejecutarán si alguno de estos componentes falta:
+Instala **todas** las dependencias antes de lanzar las suites de pruebas. Las pruebas dependen de PHP, Composer y las extensiones indicadas, por lo que no se ejecutarán si alguno de estos componentes falta. Ejecuta primero:
 
 ```bash
 composer install
 pip install -r requirements.txt
 ```
+
+`composer install` debe ejecutarse **antes** de usar `vendor/bin/phpunit` y
+`pip install -r requirements.txt` debe lanzarse **antes** de ejecutar las
+pruebas de Python.
 
 Con las dependencias ya presentes, ejecuta cada conjunto de tests de forma explícita:
 


### PR DESCRIPTION
## Summary
- clarify requirement of running `composer install` and `pip install -r requirements.txt` before executing tests

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml`
- `pip install -r requirements.txt`
- `vendor/bin/phpunit --version` *(fails: PHP extensions missing)*
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68532d9e96c0832996aba47fd81f5c8e