### PR TITLE
Fix image heights for smaller screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,6 @@ Para ajustar sus biografías o añadir nuevos perfiles edita el archivo `config/
 ## Tema predeterminado
 
 El sitio arranca en modo oscuro. Si el navegador no tiene guardada una preferencia en `localStorage`, el script `assets/js/main.js` añade la clase `dark-mode` al elemento `<body>` y muestra el icono `fa-sun` en el botón de cambio de tema. Al pulsar dicho botón se alterna entre modo oscuro y claro, actualizando el icono (`fa-sun` o `fa-moon`) y almacenando la elección para futuras visitas.
+
+## Mejoras de diseño responsive
+Se sustituyeron alturas fijas de 300px por `max-height` o unidades basadas en el viewport para adaptarse mejor a pantallas pequeñas. También se añadió una media query para dispositivos con un ancho inferior a 600px.

--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -1181,8 +1181,8 @@ body.dark-mode .footer .social-links a:focus-visible {
     position: absolute;
     top: 50%;
     left: 50%;
-    width: 300px;
-    height: 300px;
+    width: 40vmin;
+    max-height: 40vmin; /* Use viewport unit for responsiveness */
     background-image: url('/assets/img/estrella.png');
     background-size: contain;
     background-repeat: no-repeat;
@@ -1560,7 +1560,7 @@ ul li, ol li { text-align: center; } // Broader rule from estilos.css
     border-radius: 50%;
     -o-object-fit: cover;
        object-fit: cover;
-    height: 300px;
+    max-height: 40vh; /* Allow image to shrink on shorter screens */
     background-color: var(--color-piedra-clara, #EAE0C8); /* Mapped */
     box-shadow: var(--box-shadow-elevado, 0 10px 35px rgba(10, 10, 10, 0.2)); /* Mapped */
 }
@@ -2592,6 +2592,12 @@ button, input[type="submit"], input[type="button"], .cta-button, .submit-button,
     margin-left: auto;
     margin-right: auto;
     text-align: center;
+}
+
+@media (max-width: 600px) {
+    .page-content-block.personaje-detail-content img.personaje-imagen-principal {
+        max-height: 30vh;
+    }
 }
 
 .menu-panel .menu-item-button {

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
@@ -147,7 +147,7 @@
             border: 4px solid var(--color-piedra-media);
             border-radius: 50%;
             object-fit: cover;
-            height: 300px;
+            max-height: 40vh;
         }
         .content-wrapper h2 {
             text-align:left;

--- a/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
+++ b/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
@@ -147,7 +147,7 @@
             border: 4px solid var(--color-piedra-media);
             border-radius: 50%;
             object-fit: cover;
-            height: 300px;
+            max-height: 40vh;
         }
         .content-wrapper h2 {
             text-align:left;


### PR DESCRIPTION
## Summary
- make star decorative element responsive
- adjust character portrait max-heights
- add small-screen media query
- update a couple of pages to use new max-height rule
- document responsive improvement

## Testing
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*
- `python3 -m pytest tests/test_flask_api.py -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68532da0f7888329a882e59ad2326b20