### PR TITLE
Add response box for AI chat

### DIFF
--- a/assets/css/header/ia-chat.css
+++ b/assets/css/header/ia-chat.css
@@ -94,3 +94,22 @@ body.menu-open-right #gemini-ai-panel { /* This selector might need JS to add 'm
 #gemini-chat-submit:hover {
     background-color: var(--epic-gold-secondary);
 }
+
+#ai-response-box {
+    width: 100%;
+    min-height: 80px;
+    margin-top: 0.5rem;
+    background: rgba(var(--epic-purple-emperor-rgb), 0.1);
+    border: 1px solid var(--epic-gold-secondary);
+    color: var(--current-text);
+    padding: 8px;
+    border-radius: 4px;
+    resize: vertical;
+}
+
+#ai-chat-title {
+    background: linear-gradient(45deg, var(--epic-purple-emperor), var(--epic-gold-main));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    font-weight: bold;
+}

--- a/fragments/header/ai-drawer.html
+++ b/fragments/header/ai-drawer.html
@@ -16,5 +16,6 @@
       <button id="gemini-chat-submit">Enviar</button>
     </div>
     <dialog id="ai-dialog" class="chat-dialog">respuesta</dialog>
+    <div id="ai-response-container"><textarea id="ai-response-box" readonly></textarea></div>
   </div>
 </div>

--- a/js/ia-tools.js
+++ b/js/ia-tools.js
@@ -238,6 +238,8 @@ function handleChatMessage(chatInput, chatArea) {
 
     appendMessage(chatArea, userText, 'user');
     chatInput.value = '';
+    const responseBox = document.getElementById('ai-response-box');
+    if (responseBox) responseBox.value = '';
 
     // Using the enhanced appendMessage for "Thinking..." state
     appendMessage(chatArea, '<em>Pensando...</em>', 'ai-status');
@@ -262,19 +264,26 @@ function handleChatMessage(chatInput, chatArea) {
         const thinkingMessage = chatArea.querySelector('.ai-status-message');
         if (thinkingMessage) thinkingMessage.remove();
 
+        const responseBox = document.getElementById('ai-response-box');
         if (data.success && data.response) {
             appendMessage(chatArea, data.response, 'ai');
+            if (responseBox) responseBox.value = data.response;
         } else if (data.error) {
             appendMessage(chatArea, data.error, 'ai-error');
+            if (responseBox) responseBox.value = data.error;
         } else {
             appendMessage(chatArea, 'Respuesta inesperada del servidor.', 'ai-error');
+            if (responseBox) responseBox.value = 'Respuesta inesperada del servidor.';
         }
         showChatDialog(chatArea.innerText);
     })
     .catch(err => {
         const thinkingMessage = chatArea.querySelector('.ai-status-message');
         if (thinkingMessage) thinkingMessage.remove();
-        appendMessage(chatArea, err.message || 'Error de conexión desconocido.', 'ai-error');
+        const errMsg = err.message || 'Error de conexión desconocido.';
+        appendMessage(chatArea, errMsg, 'ai-error');
+        const responseBox = document.getElementById('ai-response-box');
+        if (responseBox) responseBox.value = errMsg;
         showChatDialog(chatArea.innerText);
     });
 }


### PR DESCRIPTION
## Summary
- show a gradient title for the IA drawer
- display a new AI response textarea
- sync chat messages to response box

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685331ec5b14832992ccf9e382628681