### PR TITLE
Fix translation button

### DIFF
--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -61,6 +61,17 @@ function initLangBarToggle() {
         document.documentElement.style.setProperty('--language-bar-offset', '0px');
         document.body.style.setProperty('--language-bar-offset', '0px');
     }
+
+    const params = new URLSearchParams(window.location.search);
+    const lang = params.get('lang');
+    if (lang) {
+        if (!window.googleTranslateLoaded) {
+            loadGoogleTranslate();
+            window.googleTranslateLoaded = true;
+        }
+        document.cookie = 'googtrans=/es/' + lang + ';path=/';
+        toggleLanguageBar();
+    }
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- auto load Google Translate when `lang` query param is present

## Testing
- `PYTHONPATH=. pytest -q tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6853326a618883298aa15f03ce7664de