### PR TITLE
Define alert color vars and use them

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -73,6 +73,10 @@
     --epic-input-border: #ccc;
     --epic-text-muted: #666;
     --epic-action-bg: #f0fff0;
+    /* Alert variables */
+    --alert-bg: #ffdddd;
+    --alert-border: #ff0000;
+    --alert-text: #d8000c;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/assets/css/pages/historia_subpaginas_indice.css
+++ b/assets/css/pages/historia_subpaginas_indice.css
@@ -40,9 +40,9 @@
             min-height: 30vh; /* Reduced height for index page */
         }
         .error-message {
-            background-color: #ffdddd;
-            border: 1px solid #ff0000;
-            color: #d8000c;
+            background-color: var(--alert-bg);
+            border: 1px solid var(--alert-border);
+            color: var(--alert-text);
             padding: 1em;
             margin: 1em 0;
             border-radius: 5px;

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -12,5 +12,8 @@ Esta guía resume la paleta de colores usada de forma consistente en todo el pro
 | `--color-texto-principal` | Marrón oscuro para la tipografía | `#2c1d12` |
 | `--color-fondo-pagina` | Blanco hueso sutil de fondo | `#fdfaf6` |
 | `--color-negro-contraste` | Negro de alto contraste | `#1A1A1A` |
+| `--alert-bg` | Fondo de mensajes de alerta | `#ffdddd` |
+| `--alert-border` | Borde de mensajes de alerta | `#ff0000` |
+| `--alert-text` | Texto de mensajes de alerta | `#d8000c` |
 
 Los equivalentes `-rgb` se encuentran en la misma hoja de estilos para crear transparencias con `rgba()`.


### PR DESCRIPTION
## Summary
- define `--alert-bg`, `--alert-border`, and `--alert-text` in `epic_theme.css`
- use these variables in `historia_subpaginas_indice.css`
- document the new variables in the style guide

## Testing
- `PYTHONPATH=. pytest tests/test_flask_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685333a6b1ac8329907f8c16c756707d