### PR TITLE
Fix language bar initialization

### DIFF
--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -74,8 +74,20 @@ function initLangBarToggle() {
     }
 }
 
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initLangBarToggle);
-} else {
+function setupLanguageBar() {
     initLangBarToggle();
+}
+
+function applyLanguageBarOffset() {
+    const el = document.getElementById('google_translate_element');
+    const isHidden = !el || el.style.display === 'none' || getComputedStyle(el).display === 'none';
+    const offset = (!isHidden && el.offsetHeight) ? el.offsetHeight : 0;
+    document.documentElement.style.setProperty('--language-bar-offset', offset + 'px');
+    document.body.style.setProperty('--language-bar-offset', offset + 'px');
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupLanguageBar);
+} else {
+    setupLanguageBar();
 }


### PR DESCRIPTION
## Summary
- add missing setupLanguageBar and applyLanguageBarOffset helpers
- ensure language bar initialization runs on DOMContentLoaded

## Testing
- `npm test` *(fails: Missing script)*
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68533dee8c608329896b20909af0a951