### PR TITLE
Improve chat panel accessibility

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -24,6 +24,12 @@ document.addEventListener('DOMContentLoaded', () => {
         btn.setAttribute('aria-expanded', open);
         if (side) document.body.classList.toggle(`menu-open-${side}`, open);
         document.body.classList.toggle('menu-compressed', open);
+        if (open && menu.id === 'ai-chat-panel') {
+            const chatArea = document.getElementById('gemini-chat-area');
+            if (chatArea) {
+                chatArea.focus();
+            }
+        }
     };
 
     document.querySelectorAll('[data-menu-target]').forEach(btn => {

--- a/fragments/header/ai-drawer.html
+++ b/fragments/header/ai-drawer.html
@@ -10,7 +10,7 @@
         <button id="ia-research-btn">Investigar</button>
         <button id="ia-websearch-btn">Buscar web</button>
     </div>
-    <div id="gemini-chat-area"></div>
+    <div id="gemini-chat-area" aria-live="polite" tabindex="0"></div>
     <div id="gemini-chat-input-container">
       <input id="gemini-chat-input" type="text" placeholder="Escribe tu consulta...">
       <button id="gemini-chat-submit">Enviar</button>


### PR DESCRIPTION
## Summary
- make chat area live region for screen readers
- focus chat area when opening the AI chat panel

## Testing
- `./scripts/check_alt_texts.sh`
- `vendor/bin/phpstan` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_app')*

------
https://chatgpt.com/codex/tasks/task_e_68533fcc32f08329b4a79a5b6277af18