### PR TITLE
Add robots.txt and integrate with setup

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://condadodecastilla.com/sitemap.xml

--- a/scripts/setup_project.sh
+++ b/scripts/setup_project.sh
@@ -34,6 +34,16 @@ if [ ! -f "$PROJECT_ROOT/.env" ] && [ -f "$PROJECT_ROOT/.env.example" ]; then
     echo "Archivo .env creado a partir de .env.example"
 fi
 
+# Ensure robots.txt exists
+if [ ! -f "$PROJECT_ROOT/robots.txt" ]; then
+    cat > "$PROJECT_ROOT/robots.txt" <<'EOF'
+User-agent: *
+Allow: /
+Sitemap: https://condadodecastilla.com/sitemap.xml
+EOF
+    echo "robots.txt creado"
+fi
+
 # Create upload directories
 mkdir -p "$PROJECT_ROOT"/uploads/galeria \
          "$PROJECT_ROOT"/uploads_storage/museo_piezas \


### PR DESCRIPTION
## Summary
- add `robots.txt`
- ensure setup script generates `robots.txt` if absent

## Testing
- `./scripts/check_alt_texts.sh`
- `vendor/bin/phpstan` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68533fa02b54832990581e54f41fc2f0