### PR TITLE
Remove duplicate font references

### DIFF
--- a/alfoz/alfoz.php
+++ b/alfoz/alfoz.php
@@ -15,10 +15,6 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
     <title>El Alfoz de Cerasio y Lantarón - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <?php include __DIR__ . '/../includes/head_common.php'; ?>
     <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>

--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap');
 
 :root {
     --epic-error-red: #D9534F; /* Default error red */

--- a/contacto/contacto.php
+++ b/contacto/contacto.php
@@ -15,10 +15,6 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
     <title>Contacto - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <?php include __DIR__ . '/../includes/head_common.php'; ?>
     <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>

--- a/cultura/cultura.php
+++ b/cultura/cultura.php
@@ -15,10 +15,6 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
     <title>Cultura y Legado - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <?php include __DIR__ . '/../includes/head_common.php'; ?>
     <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>

--- a/historia/galeria_historica/index.php
+++ b/historia/galeria_historica/index.php
@@ -42,6 +42,5 @@
     <?php require_once __DIR__ . '/../../_footer.php'; ?>
     <script src="/js/layout.js"></script>
     <!-- Consider adding a link to Font Awesome if not already included globally, e.g., in _header.php or main CSS -->
-    <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"> -->
 </body>
 </html>

--- a/lugares/alfozcerezolantaron/Cerezo_de_Rio_Tiron/index.php
+++ b/lugares/alfozcerezolantaron/Cerezo_de_Rio_Tiron/index.php
@@ -6,10 +6,6 @@
     <meta name="description" content="Explora la rica historia, las imponentes ruinas y el legado cultural de Cerezo de Río Tirón, un lugar clave en la historia del Condado de Castilla.">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/alfozcerezolantaron/alfoz.php
+++ b/lugares/alfozcerezolantaron/alfoz.php
@@ -5,10 +5,6 @@
     <title>El Alfoz de Cerasio y Lantarón - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/cerasio.php
+++ b/lugares/cerasio.php
@@ -5,10 +5,6 @@
     <title>Cerasio - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/lugares/el_culebron.php
+++ b/lugares/el_culebron.php
@@ -4,10 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>El Culebrón - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>

--- a/lugares/lugares.php
+++ b/lugares/lugares.php
@@ -5,10 +5,6 @@
     <title>Lugares Emblemáticos - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="stylesheet" href="/assets/css/header.css">

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html
@@ -3,5 +3,4 @@
 <head>
     <title>Fernando Diaz - Condado de Castilla</title>
     <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/constantino.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/constantino.html
@@ -3,5 +3,4 @@
 <head>
     <title>Constantino - Emperadores Romanos en Auca</title>
     <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/personajes/Militares_y_Gobernantes/alba_esposa_corocotta.html
+++ b/personajes/Militares_y_Gobernantes/alba_esposa_corocotta.html
@@ -3,5 +3,4 @@
 <head>
     <title>Alba Esposa Corocotta - Condado de Castilla</title>
     <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/personajes/Militares_y_Gobernantes/turok_nerea_amaia_hijos_corocotta.html
+++ b/personajes/Militares_y_Gobernantes/turok_nerea_amaia_hijos_corocotta.html
@@ -3,5 +3,4 @@
 <head>
     <title>Turok Nerea Amaia Hijos Corocotta - Condado de Castilla</title>
     <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/personajes/Ordenes_y_Legados/monjes_hospitalarios_san_jorge_y_san_anton.html
+++ b/personajes/Ordenes_y_Legados/monjes_hospitalarios_san_jorge_y_san_anton.html
@@ -3,5 +3,4 @@
 <head>
     <title>Monjes Hospitalarios San Jorge Y San Anton - Condado de Castilla</title>
     <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/ruinas/edificaciones_civiles_publicas/circo_romano.php
+++ b/ruinas/edificaciones_civiles_publicas/circo_romano.php
@@ -5,10 +5,6 @@
     <title>Circo Romano de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/edificaciones_civiles_publicas/foro_romano.php
+++ b/ruinas/edificaciones_civiles_publicas/foro_romano.php
@@ -5,10 +5,6 @@
     <title>Foro Romano de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/edificaciones_civiles_publicas/orfeones_odeones.php
+++ b/ruinas/edificaciones_civiles_publicas/orfeones_odeones.php
@@ -5,10 +5,6 @@
     <title>Orfeones y Odeones - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/edificaciones_civiles_publicas/puerto_fluvial_gurugu.php
+++ b/ruinas/edificaciones_civiles_publicas/puerto_fluvial_gurugu.php
@@ -5,10 +5,6 @@
     <title>Puerto Fluvial del Gurugú - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/edificaciones_civiles_publicas/teatro_romano.php
+++ b/ruinas/edificaciones_civiles_publicas/teatro_romano.php
@@ -5,10 +5,6 @@
     <title>Teatro Romano de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/estructuras_defensivas/alcazar_cerasio.php
+++ b/ruinas/estructuras_defensivas/alcazar_cerasio.php
@@ -5,10 +5,6 @@
     <title>Alcázar de Cerasio - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/estructuras_defensivas/campamento_romano_tejera.php
+++ b/ruinas/estructuras_defensivas/campamento_romano_tejera.php
@@ -5,10 +5,6 @@
     <title>Campamento Romano de la Tejera - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/estructuras_defensivas/murallas_auca.php
+++ b/ruinas/estructuras_defensivas/murallas_auca.php
@@ -5,10 +5,6 @@
     <title>Murallas de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/estructuras_defensivas/otros_campamentos_romanos.php
+++ b/ruinas/estructuras_defensivas/otros_campamentos_romanos.php
@@ -5,10 +5,6 @@
     <title>Otros Campamentos Romanos - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/estructuras_defensivas/otros_castillos.php
+++ b/ruinas/estructuras_defensivas/otros_castillos.php
@@ -5,10 +5,6 @@
     <title>Otros Castillos y Fortificaciones - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/estructuras_defensivas/torres_vigia.php
+++ b/ruinas/estructuras_defensivas/torres_vigia.php
@@ -5,10 +5,6 @@
     <title>Torres de Vigía y Defensa - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/estructuras_funerarias_religiosas/mausoleo_circo_auca.php
+++ b/ruinas/estructuras_funerarias_religiosas/mausoleo_circo_auca.php
@@ -5,10 +5,6 @@
     <title>Mausoleo del Circo de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/estructuras_funerarias_religiosas/mausoleo_magno_clemente_maximo.php
+++ b/ruinas/estructuras_funerarias_religiosas/mausoleo_magno_clemente_maximo.php
@@ -5,10 +5,6 @@
     <title>Mausoleo de Magno Clemente Máximo - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/estructuras_funerarias_religiosas/mausoleo_san_nicolas.php
+++ b/ruinas/estructuras_funerarias_religiosas/mausoleo_san_nicolas.php
@@ -5,10 +5,6 @@
     <title>Mausoleo Imperial de San Nicolás - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/estructuras_funerarias_religiosas/necropolis_san_martin.php
+++ b/ruinas/estructuras_funerarias_religiosas/necropolis_san_martin.php
@@ -5,10 +5,6 @@
     <title>Necrópolis de San Martín - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/estructuras_residenciales_elite/palacios_romanos_auca.php
+++ b/ruinas/estructuras_residenciales_elite/palacios_romanos_auca.php
@@ -4,10 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Palacios Romanos de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>

--- a/ruinas/hallazgos_representaciones/alabastro_de_cerasio.php
+++ b/ruinas/hallazgos_representaciones/alabastro_de_cerasio.php
@@ -4,10 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Alabastro de Cerasio - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>

--- a/ruinas/hallazgos_representaciones/descripciones_generales.php
+++ b/ruinas/hallazgos_representaciones/descripciones_generales.php
@@ -5,10 +5,6 @@
     <title>Descripciones Generales de Ruinas - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/hallazgos_representaciones/fotos_hallazgos.php
+++ b/ruinas/hallazgos_representaciones/fotos_hallazgos.php
@@ -5,10 +5,6 @@
     <title>Fotografías y Hallazgos Menores - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/hallazgos_representaciones/monedas_antiguas.php
+++ b/ruinas/hallazgos_representaciones/monedas_antiguas.php
@@ -4,10 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Monedas Antiguas de Cerezo/Auca - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>

--- a/ruinas/hallazgos_representaciones/tallas_inscripciones.php
+++ b/ruinas/hallazgos_representaciones/tallas_inscripciones.php
@@ -5,10 +5,6 @@
     <title>Tallas, Arte Rupestre e Inscripciones - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/index.php
+++ b/ruinas/index.php
@@ -5,10 +5,6 @@
     <title>Ruinas y Vestigios del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="stylesheet" href="/assets/css/header.css">

--- a/ruinas/infraestructura_general/hitos_miliares.php
+++ b/ruinas/infraestructura_general/hitos_miliares.php
@@ -5,10 +5,6 @@
     <title>Hitos Miliares Romanos - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/ruinas/infraestructura_general/puentes_romanos_cerezo.php
+++ b/ruinas/infraestructura_general/puentes_romanos_cerezo.php
@@ -4,10 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Puentes Romanos de Cerezo de Río Tirón - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- keep Google Fonts and FontAwesome references only in `includes/head_common.php`
- delete duplicate font `<link>` tags across pages
- remove the Google Fonts `@import` from `assets/css/epic_theme.css`

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68533f9b7d188329ab63ad074cb47994