### PR TITLE
Fix font load path

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap');
-
 :root {
     --epic-error-red: #D9534F; /* Default error red */
     --epic-purple-emperor: #4A0D67;


### PR DESCRIPTION
## Summary
- remove Google Fonts `@import` from `epic_theme.css`

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `npm install`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68533fa167688329b3faf8425523f500