### PR TITLE
Add manage comments stylesheet

### DIFF
--- a/assets/css/pages/manage_comments.css
+++ b/assets/css/pages/manage_comments.css
@@ -1,0 +1,6 @@
+body { background-color: var(--epic-alabaster-bg); padding: 20px; }
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 8px; border: 1px solid #ccc; }
+.feedback { padding: 10px; margin: 10px 0; border-radius: 4px; }
+.feedback.success { background-color: var(--epic-success-bg); color: var(--epic-success-text); border: 1px solid var(--epic-success-border); }
+.feedback.error { background-color: var(--epic-danger-bg); color: var(--epic-danger-text); border: 1px solid var(--epic-danger-border); }

--- a/foro/manage_comments.php
+++ b/foro/manage_comments.php
@@ -47,14 +47,7 @@ if ($pdo) {
 <head>
     <title>Administrar Comentarios</title>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <style>
-        body { background-color: #f4f4f4; padding: 20px; }
-        table { width: 100%; border-collapse: collapse; }
-        th, td { padding: 8px; border: 1px solid #ccc; }
-        .feedback { padding: 10px; margin: 10px 0; border-radius: 4px; }
-        .feedback.success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
-        .feedback.error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
-    </style>
+    <link rel="stylesheet" href="/assets/css/pages/manage_comments.css">
 </head>
 <body>
     <h1>Administrar Comentarios del Foro</h1>


### PR DESCRIPTION
## Summary
- add new page CSS for `manage_comments.php`
- include the CSS instead of inline styles

## Testing
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68533fb71a808329855504bc9d48cfd8