### PR TITLE
Refactor inline styles in Historia pages

### DIFF
--- a/assets/css/pages/historia.css
+++ b/assets/css/pages/historia.css
@@ -1,0 +1,34 @@
+.explore-detailed-topics {
+    padding: 20px;
+    background: linear-gradient(135deg, rgba(var(--color-primario-purpura-rgb), 0.05), rgba(var(--epic-gold-main-rgb), 0.1)), var(--epic-alabaster-bg);
+    border-radius: var(--global-border-radius, 8px);
+    margin: 30px 0;
+    border: 1px solid rgba(var(--color-primario-purpura-rgb), 0.3);
+}
+
+.explore-link {
+    display: inline-block;
+    margin-top: 10px;
+    padding: 10px 20px;
+    background-image: linear-gradient(135deg, var(--epic-gold-main), var(--color-primario-purpura));
+    color: var(--color-primario-purpura);
+    text-decoration: none;
+    border-radius: 5px;
+    font-weight: bold;
+    transition: background-color 0.3s ease;
+}
+
+.explore-link:hover {
+    background-image: linear-gradient(135deg, var(--color-primario-purpura), var(--epic-gold-main));
+    color: var(--epic-alabaster-bg);
+}
+
+#resumenIAContenedor {
+    display: none;
+    margin-top: 20px;
+    padding: 20px;
+    border: 1px solid var(--epic-neutral-border);
+    border-radius: 5px;
+    background-color: var(--epic-neutral-bg);
+    box-shadow: var(--global-box-shadow-light);
+}

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/../includes/ai_utils.php';
 <html lang="es">
 <head>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+    <link rel="stylesheet" href="/assets/css/pages/historia.css">
     <title>Atapuerca</title>
 </head>
 <body>
@@ -63,7 +64,7 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                 <div class="text-center" style="margin-top: 30px; margin-bottom: 30px;"> <!-- Contenedor para centrar el botón -->
                     <button id="btnResumenIA" class="cta-button" style="padding: 12px 25px; font-size: 1.1em;">Ver Resumen Inteligente</button>
                 </div>
-                <div id="resumenIAContenedor" style="display:none; margin-top:20px; padding:20px; border:1px solid #ddd; border-radius: 5px; background-color: #f9f9f9; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                <div id="resumenIAContenedor">
                     <!-- El resumen generado por IA se insertará aquí -->
                 </div>
                 <div id="tagsSugeridosIA" class="tags-sugeridos-ia" style="margin-top: 30px; padding-top: 20px; border-top: 1px dashed #ccc;">

--- a/historia/nuestra_historia_nuevo4.php
+++ b/historia/nuestra_historia_nuevo4.php
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+    <link rel="stylesheet" href="/assets/css/pages/historia.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>
@@ -20,10 +21,10 @@
             <div class="container article-content">
                 <h2 class="section-title text-center" style="margin-bottom:1.5em;">Contexto y Reflexiones sobre Nuevo4.md</h2>
 
-                <div class="explore-detailed-topics text-center" style="padding: 20px; background-color: #f0e8ff; border-radius: 8px; margin: 30px 0; border: 1px solid var(--color-primario-purpura-rgb, 0.3);">
+                <div class="explore-detailed-topics text-center">
                     <h3 style="margin-top:0; color: var(--color-primario-purpura);">Explorar Temas en Detalle</h3>
                     <p>Para una exploración más profunda de los temas tratados en este documento, visite nuestro índice de páginas detalladas.</p>
-                    <a href="/historia/historia.php" class="read-more" style="display: inline-block; margin-top: 10px; padding: 10px 20px; background-color: var(--color-secundario-dorado); color: var(--color-primario-purpura); text-decoration: none; border-radius: 5px; font-weight: bold;">Ver Índice Detallado</a>
+                    <a href="/historia/historia.php" class="read-more explore-link">Ver Índice Detallado</a>
                 </div>
 
                 <p>Y ver cómo Pancorvo del Alfoz de cerezo, Valpuesta del Alfoz de cerezo, y Auca se vinculan al origen de Castilla que es el Alcázar de Alabastro puro de Cerasio con sus documentados condes de Castilla y Alava y sus 1200 metros de largo con capacidad para albergar el Palacio o Alcázar su corte condal de funcionarios y sus soldados.</p>


### PR DESCRIPTION
## Summary
- style `nuestra_historia_nuevo4.php` via new `historia.css`
- clean up inline styles in Historia pages
- add stylesheet to Atapuerca page

## Testing
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533fb8cf8c832990dea64d6f36676a