### PR TITLE
Refactor admin styles

### DIFF
--- a/assets/css/admin_pages.css
+++ b/assets/css/admin_pages.css
@@ -1,0 +1,40 @@
+@import url('epic_theme.css');
+
+body.admin-page {
+    background-color: var(--epic-alabaster-bg);
+    padding: 20px;
+    font-family: var(--font-primary);
+}
+
+.admin-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.admin-table th,
+.admin-table td {
+    padding: 8px;
+    border: 1px solid var(--epic-neutral-border);
+}
+
+.admin-table th {
+    background-color: var(--epic-alabaster-medium);
+}
+
+.feedback {
+    padding: 10px;
+    margin: 10px 0;
+    border-radius: 4px;
+}
+
+.feedback.success {
+    background-color: var(--epic-success-bg);
+    color: var(--epic-success-text);
+    border: 1px solid var(--epic-success-border);
+}
+
+.feedback.error {
+    background-color: var(--epic-danger-bg);
+    color: var(--epic-danger-text);
+    border: 1px solid var(--epic-danger-border);
+}

--- a/foro/manage_comments.php
+++ b/foro/manage_comments.php
@@ -47,16 +47,9 @@ if ($pdo) {
 <head>
     <title>Administrar Comentarios</title>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <style>
-        body { background-color: #f4f4f4; padding: 20px; }
-        table { width: 100%; border-collapse: collapse; }
-        th, td { padding: 8px; border: 1px solid #ccc; }
-        .feedback { padding: 10px; margin: 10px 0; border-radius: 4px; }
-        .feedback.success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
-        .feedback.error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
-    </style>
+    <link rel="stylesheet" href="../assets/css/admin_pages.css">
 </head>
-<body>
+<body class="admin-page">
     <h1>Administrar Comentarios del Foro</h1>
     <nav>
         <a href="../index.php">Inicio</a>
@@ -69,7 +62,7 @@ if ($pdo) {
     <?php if (empty($comments)): ?>
         <p>No hay comentarios para mostrar.</p>
     <?php else: ?>
-        <table>
+        <table class="admin-table">
             <tr><th>Agente</th><th>Comentario</th><th>Fecha</th><th>Acciones</th></tr>
             <?php foreach ($comments as $c): ?>
                 <tr>

--- a/museo/editar_pieza.php
+++ b/museo/editar_pieza.php
@@ -58,16 +58,9 @@ try {
 <head>
     <title>Editar Piezas del Museo</title>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <style>
-        body { font-family: Arial, sans-serif; margin:20px; }
-        table { width:100%; border-collapse: collapse; margin-bottom:20px; }
-        th, td { border:1px solid #ccc; padding:8px; text-align:left; }
-        th { background-color:#f2f2f2; }
-        .feedback.success { background:#d4edda; padding:10px; margin-bottom:10px; }
-        .feedback.error { background:#f8d7da; padding:10px; margin-bottom:10px; }
-    </style>
+    <link rel="stylesheet" href="../assets/css/admin_pages.css">
 </head>
-<body>
+<body class="admin-page">
 <nav>
     <a href="../index.php">Inicio</a>
     <a href="../dashboard/index.php">Dashboard</a>
@@ -79,7 +72,7 @@ try {
         <?php echo htmlspecialchars($feedback_message); ?>
     </div>
 <?php endif; ?>
-<table>
+<table class="admin-table">
     <tr><th>ID</th><th>Título</th><th>Pos X</th><th>Pos Y</th><th>Pos Z</th><th>Escala</th><th>Acción</th></tr>
 <?php foreach ($piezas as $p): ?>
     <tr>


### PR DESCRIPTION
## Summary
- centralize admin page styles in `admin_pages.css`
- apply new styles on forum and museum admin pages

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533fbb836483299360ef2383098233