### PR TITLE
Refactor inline styles into theme classes

### DIFF
--- a/404.php
+++ b/404.php
@@ -9,7 +9,7 @@ http_response_code(404);
 </head>
 <body>
 <?php require_once __DIR__ . '/_header.php'; ?>
-<main class="container page-content-block" style="text-align: center; padding: 4em 1em;">
+<main class="container page-content-block error-page">
     <h1>Página no encontrada</h1>
     <p>Lo sentimos, la página que buscas no existe.</p>
     <p><a href="/index.php" class="cta-button">Volver al inicio</a></p>

--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -879,10 +879,9 @@ body.dark-mode .footer .social-links a:focus-visible {
 
 /* --- View Switcher Buttons --- */
 .view-switch-controls {
-    /* Using .container class for width management if needed, or text-align: center; directly */
-    /* text-align: center; is inherited from body but can be explicit */
-    /* margin-bottom: 20px; already applied inline, can be moved here */
-    /* padding-top: 20px; already applied inline, can be moved here */
+    text-align: center;
+    margin-bottom: 20px;
+    padding-top: 20px;
 }
 
 .view-switch-button {
@@ -2633,4 +2632,87 @@ button, input[type="submit"], input[type="button"], .cta-button, .submit-button,
 
 .menu-panel .menu-item-button {
     text-align: center;
+}
+
+/* --- Utility classes migrated from inline styles --- */
+.error-page {
+    text-align: center;
+    padding: 4em 1em;
+}
+
+.ai-translation-box {
+    padding: 15px;
+    background-color: var(--epic-transparent-overlay-light);
+    border: 1px solid var(--epic-gold-secondary);
+    border-radius: var(--global-border-radius);
+    margin-top: 10px;
+}
+
+.ai-translation-box p {
+    font-size: 0.9em;
+    color: var(--epic-purple-emperor);
+}
+
+.ai-translation-box .ai-note {
+    font-size: 0.8em;
+    color: var(--epic-purple-hover);
+    margin-top: 10px;
+}
+
+.photo-preview {
+    max-height: 200px;
+    margin-bottom: 10px;
+    border: 1px solid var(--epic-gold-secondary);
+}
+
+.intro-big {
+    font-size: 1.2em;
+    margin-top: 1em;
+}
+
+.preview-hidden {
+    display: none;
+}
+
+.crosshair {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    width: 6px;
+    height: 6px;
+    background-color: rgba(var(--epic-gold-main-rgb), 0.6);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 9998;
+    pointer-events: none;
+    display: none;
+}
+
+.pointer-lock-instructions {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.85);
+    color: white;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    font-size: 20px;
+    z-index: 10000;
+    cursor: pointer;
+}
+
+.pointer-lock-instructions p {
+    margin-top: 0.5em;
+}
+
+.hero-galeria {
+    background-image: linear-gradient(rgba(var(--epic-purple-emperor-rgb), 0.75), rgba(var(--epic-alabaster-bg-rgb), 0.88)), url('/imagenes/hero_galeria_background.jpg');
+}
+
+.hero-museo {
+    background-image: linear-gradient(rgba(var(--epic-purple-emperor-rgb), 0.75), rgba(var(--epic-alabaster-bg-rgb), 0.88)), url('/imagenes/hero_museo_background.jpg');
 }

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -54,7 +54,7 @@ if (is_dir($gallery_dir)) {
     
     <?php require_once __DIR__ . '/../_header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--condado-primario-rgb), 0.75), rgba(var(--condado-texto-rgb), 0.88)), url('/imagenes/hero_galeria_background.jpg');">
+    <header class="page-header hero hero-galeria">
         <!-- IMPORTANTE: Asegúrate de tener /imagenes/hero_galeria_background.jpg -->
         <div class="hero-content">
             <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
@@ -91,8 +91,8 @@ if (is_dir($gallery_dir)) {
                         <input type="file" id="photoFile" name="photoFile" accept="image/jpeg, image/png, image/gif" required>
                         <small>Formatos permitidos: JPG, PNG, GIF. Tamaño máximo: 2MB.</small>
                     </div>
-                    <div class="form-group preview-container" id="photoPreviewContainer" style="display:none;">
-                        <img id="photoPreview" src="#" alt="Vista previa de la fotografía" style="max-height: 200px; margin-bottom: 10px; border: 1px solid var(--condado-piedra-media);"/>
+                    <div class="form-group preview-container preview-hidden" id="photoPreviewContainer">
+                        <img id="photoPreview" src="#" alt="Vista previa de la fotografía" class="photo-preview"/>
                     </div>
                     <button type="submit" class="cta-button submit-button"><i class="fas fa-share-square"></i> Compartir Fotografía</button>
                 </form>

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -295,8 +295,8 @@ function translate_with_gemini(string $content_id, string $target_language, stri
 
     $original_snippet = !empty($original_sample_text) ? htmlspecialchars(substr(strip_tags($original_sample_text), 0, 70)) . "..." : "el contenido original";
 
-    $outputText = "<div style='padding:15px; background-color:#e3f2fd; border:1px solid #bbdefb; border-radius:4px; margin-top:10px;'>";
-    $outputText .= "<p style='font-size:0.9em; color:#0d47a1;'><em>Traducción IA (Demostración) para: " . htmlspecialchars($content_id) . "</em></p>";
+    $outputText = "<div class='ai-translation-box'>";
+    $outputText .= "<p><em>Traducción IA (Demostración) para: " . htmlspecialchars($content_id) . "</em></p>";
 
     switch ($target_language) {
         case 'en-ai':
@@ -313,7 +313,7 @@ function translate_with_gemini(string $content_id, string $target_language, stri
             break;
         // No hay caso 'default' o 'es' aquí porque ya se manejó al inicio de la función.
     }
-    $outputText .= "<p style='font-size:0.8em; color:#1976d2; margin-top:10px;'><em>(Esta es una simulación. La funcionalidad de traducción real con IA está pendiente de implementación).</em></p>";
+    $outputText .= "<p class='ai-note'><em>(Esta es una simulación. La funcionalidad de traducción real con IA está pendiente de implementación).</em></p>";
     $outputText .= "</div>";
     return $outputText;
 }

--- a/museo/galeria.php
+++ b/museo/galeria.php
@@ -10,7 +10,7 @@
     <div id="linterna-condado"></div>
     <?php require_once __DIR__ . '/../_header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--condado-primario-rgb), 0.75), rgba(var(--condado-texto-rgb), 0.88)), url('/imagenes/hero_museo_background.jpg');">
+    <header class="page-header hero hero-museo">
         <div class="hero-content">
             <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <h1>Galería del Museo</h1>

--- a/museo/museo.php
+++ b/museo/museo.php
@@ -27,12 +27,12 @@
     <!-- Google Fonts, FontAwesome, and epic_theme.css are now in head_common.php -->
 </head>
 <body>
-    <div id="crosshair" style="position: fixed; top: 50%; left: 50%; width: 6px; height: 6px; background-color: rgba(255,255,255,0.6); border-radius: 50%; transform: translate(-50%, -50%); z-index: 9998; pointer-events: none; display: none;"></div>
+    <div id="crosshair" class="crosshair"></div>
     <div id="linterna-condado"></div>
     
     <?php require_once __DIR__ . '/../_header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--condado-primario-rgb), 0.75), rgba(var(--condado-texto-rgb), 0.88)), url('/imagenes/hero_museo_background.jpg');">
+    <header class="page-header hero hero-museo">
         <div class="hero-content">
             <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <h1>Museo Colaborativo del Alfoz</h1>
@@ -68,8 +68,8 @@
                         <input type="file" id="piezaImagen" name="piezaImagen" accept="image/jpeg, image/png, image/gif" required>
                         <small>Formatos permitidos: JPG, PNG, GIF. Tamaño máximo: 2MB.</small>
                     </div>
-                    <div class="form-group preview-container" id="imagePreviewContainer" style="display:none;">
-                        <img id="imagePreview" src="#" alt="Vista previa de la imagen subida" style="max-height: 200px; margin-bottom: 10px; border: 1px solid var(--condado-piedra-media);"/>
+                    <div class="form-group preview-container preview-hidden" id="imagePreviewContainer">
+                        <img id="imagePreview" src="#" alt="Vista previa de la imagen subida" class="photo-preview"/>
                     </div>
 
                     <fieldset class="form-fieldset">
@@ -109,7 +109,7 @@
             </div>
         </section>
 
-        <div class="view-switch-controls container" style="text-align: center; margin-bottom: 20px; padding-top: 20px;">
+        <div class="view-switch-controls container text-center">
             <button id="show-2d-gallery-btn" class="cta-button view-switch-button">Ver Galería 2D</button>
             <button id="show-3d-museum-btn" class="cta-button view-switch-button">Explorar Museo 3D</button>
         </div>
@@ -154,12 +154,12 @@
     <script src="/js/museum-3d/exhibitManager.js"></script>
     <script src="/js/museo-3d-main.js"></script>
 
-    <div id="pointer-lock-instructions" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.85); color: white; display: flex; justify-content: center; align-items: center; text-align: center; font-size: 20px; z-index: 10000; cursor: pointer;">
+    <div id="pointer-lock-instructions" class="pointer-lock-instructions">
         <div>
             <h1>Exploración del Museo</h1>
-            <p style="font-size: 1.2em; margin-top: 1em;">Haz clic en esta pantalla para empezar a explorar.</p>
-            <p style="margin-top: 0.5em;">Usa las teclas <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> para moverte y el <kbd>RATÓN</kbd> para mirar alrededor.</p>
-            <p style="font-size: 0.8em; margin-top: 2em;">Presiona <kbd>ESC</kbd> para liberar el cursor.</p>
+            <p class="intro-big">Haz clic en esta pantalla para empezar a explorar.</p>
+            <p>Usa las teclas <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> para moverte y el <kbd>RATÓN</kbd> para mirar alrededor.</p>
+            <p class="ai-note">Presiona <kbd>ESC</kbd> para liberar el cursor.</p>
         </div>
     </div>
 

--- a/museo/museo_3d.php
+++ b/museo/museo_3d.php
@@ -16,11 +16,11 @@
     <!-- Google Fonts, FontAwesome, and epic_theme.css are now in head_common.php -->
 </head>
 <body>
-    <div id="crosshair" style="position: fixed; top: 50%; left: 50%; width: 6px; height: 6px; background-color: rgba(255,255,255,0.6); border-radius: 50%; transform: translate(-50%, -50%); z-index: 9998; pointer-events: none; display: none;"></div>
+    <div id="crosshair" class="crosshair"></div>
     <div id="linterna-condado"></div>
     <?php require_once __DIR__ . '/../_header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--condado-primario-rgb), 0.75), rgba(var(--condado-texto-rgb), 0.88)), url('/imagenes/hero_museo_background.jpg');">
+    <header class="page-header hero hero-museo">
         <div class="hero-content">
             <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <h1>Explora el Museo en 3D</h1>
@@ -47,12 +47,12 @@
     <script src="/js/museum-3d/exhibitManager.js"></script>
     <script src="/js/museo-3d-main.js"></script>
 
-    <div id="pointer-lock-instructions" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.85); color: white; display: flex; justify-content: center; align-items: center; text-align: center; font-size: 20px; z-index: 10000; cursor: pointer;">
+    <div id="pointer-lock-instructions" class="pointer-lock-instructions">
         <div>
             <h1>Exploración del Museo</h1>
-            <p style="font-size: 1.2em; margin-top: 1em;">Haz clic en esta pantalla para empezar a explorar.</p>
-            <p style="margin-top: 0.5em;">Usa las teclas <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> para moverte y el <kbd>RATÓN</kbd> para mirar alrededor.</p>
-            <p style="font-size: 0.8em; margin-top: 2em;">Presiona <kbd>ESC</kbd> para liberar el cursor.</p>
+            <p class="intro-big">Haz clic en esta pantalla para empezar a explorar.</p>
+            <p>Usa las teclas <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> para moverte y el <kbd>RATÓN</kbd> para mirar alrededor.</p>
+            <p class="ai-note">Presiona <kbd>ESC</kbd> para liberar el cursor.</p>
         </div>
     </div>
 

--- a/museo/subir_pieza.php
+++ b/museo/subir_pieza.php
@@ -18,7 +18,7 @@
         require_once __DIR__ . '/../_header.php';
     ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--condado-primario-rgb), 0.75), rgba(var(--condado-texto-rgb), 0.88)), url('/imagenes/hero_museo_background.jpg');">
+    <header class="page-header hero hero-museo">
         <div class="hero-content">
             <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <h1>Sube una Pieza al Museo</h1>
@@ -54,8 +54,8 @@
                         <input type="file" id="piezaImagen" name="piezaImagen" accept="image/jpeg, image/png, image/gif" required>
                         <small>Formatos permitidos: JPG, PNG, GIF. Tamaño máximo: 2MB.</small>
                     </div>
-                    <div class="form-group preview-container" id="imagePreviewContainer" style="display:none;">
-                        <img id="imagePreview" src="#" alt="Vista previa de la imagen" style="max-height: 200px; margin-bottom: 10px; border: 1px solid var(--condado-piedra-media);"/>
+                    <div class="form-group preview-container preview-hidden" id="imagePreviewContainer">
+                        <img id="imagePreview" src="#" alt="Vista previa de la imagen" class="photo-preview"/>
                     </div>
 
                     <fieldset class="form-fieldset">


### PR DESCRIPTION
## Summary
- move inline styles to CSS utility classes
- apply new classes across gallery and museum pages
- add themed classes for error page and AI translation snippets
- create hero background classes for gallery and museum sections

## Testing
- `pip install -r requirements.txt`
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: puppeteer module missing)*

------
https://chatgpt.com/codex/tasks/task_e_68533fc1040883298de06771a6e25579