### PR TITLE
Refactor CSS to use theme variables

### DIFF
--- a/assets/css/header/ia-chat.css
+++ b/assets/css/header/ia-chat.css
@@ -56,8 +56,8 @@ body.menu-open-right #gemini-ai-panel { /* This selector might need JS to add 'm
 #gemini-chat-area {
     height: 250px;
     overflow-y: auto;
-    border: 1px solid #ddd;
-    background-color: #f9f9f9;
+    border: 1px solid var(--epic-neutral-border);
+    background-color: var(--epic-neutral-bg);
     padding: 10px;
     margin-top: 1rem; /* Space between ia-tools-menu and chat area */
     margin-bottom: 10px;
@@ -76,7 +76,7 @@ body.menu-open-right #gemini-ai-panel { /* This selector might need JS to add 'm
 #gemini-chat-input {
     flex-grow: 1;
     padding: 8px 10px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--epic-input-border);
     border-radius: 4px;
     margin-right: 8px;
 }

--- a/assets/css/pages/historia_galeria_historica_index.css
+++ b/assets/css/pages/historia_galeria_historica_index.css
@@ -8,7 +8,7 @@
         }
         .gallery-item {
             background-color: #fdfaf6; /* Fondo alabastro claro */
-            border: 1px solid #ddd; /* Light grey border */
+            border: 1px solid var(--epic-neutral-border); /* Light grey border */
             border-radius: 8px; /* Rounded corners */
             box-shadow: 0 4px 8px rgba(0,0,0,0.1); /* Subtle shadow */
             width: calc(33.333% - 40px); /* Adjust for 3 items per row, considering gap */
@@ -21,7 +21,7 @@
             height: auto; /* Adjust to image height */
             max-height: 200px;
             object-fit: contain; /* Avoid cropping */
-            border-bottom: 1px solid #ddd;
+            border-bottom: 1px solid var(--epic-neutral-border);
         }
         .gallery-item .file-placeholder {
             display: flex;

--- a/foro/manage_comments.php
+++ b/foro/manage_comments.php
@@ -50,7 +50,7 @@ if ($pdo) {
     <style>
         body { background-color: #f4f4f4; padding: 20px; }
         table { width: 100%; border-collapse: collapse; }
-        th, td { padding: 8px; border: 1px solid #ccc; }
+        th, td { padding: 8px; border: 1px solid var(--epic-input-border); }
         .feedback { padding: 10px; margin: 10px 0; border-radius: 4px; }
         .feedback.success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
         .feedback.error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -35,7 +35,7 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                 <h2 class="section-title"><?php editableText('atapuerca_titulo_seccion', $pdo, 'Un Tesoro de la Prehistoria'); ?></h2>
                 <p class="timeline-intro"><?php editableText('atapuerca_intro_p1', $pdo, 'La Sierra de Atapuerca, ubicada al norte de Ibeas de Juarros en la provincia de Burgos, es un enclave montañoso de modesta altitud que alberga un extraordinario conjunto de yacimientos arqueológicos y paleontológicos. Reconocida como Patrimonio de la Humanidad por la UNESCO, Espacio de Interés Natural y Bien de Interés Cultural, Atapuerca ha proporcionado al mundo testimonios fósiles de al menos cinco especies distintas de homínidos, arrojando luz invaluable sobre la evolución humana en Europa.'); ?></p>
 
-                <div id="languageSelectorContainer" class="text-center" style="margin-bottom: 25px; padding-bottom: 20px; border-bottom: 1px dashed #ccc;">
+                <div id="languageSelectorContainer" class="text-center" style="margin-bottom: 25px; padding-bottom: 20px; border-bottom: 1px dashed var(--epic-input-border);">
                     <h4 style="font-family: 'Cinzel', serif; color: var(--epic-purple-emperor); margin-bottom: 10px;">Seleccionar Idioma (Demostración):</h4>
                     <button class="lang-btn active" data-lang="es" title="Ver contenido en Español (original)">Español (Original)</button>
                     <button class="lang-btn" data-lang="en-ai" title="Simular traducción al Inglés por IA">Inglés (Traducción IA)</button>
@@ -63,10 +63,10 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                 <div class="text-center" style="margin-top: 30px; margin-bottom: 30px;"> <!-- Contenedor para centrar el botón -->
                     <button id="btnResumenIA" class="cta-button" style="padding: 12px 25px; font-size: 1.1em;">Ver Resumen Inteligente</button>
                 </div>
-                <div id="resumenIAContenedor" style="display:none; margin-top:20px; padding:20px; border:1px solid #ddd; border-radius: 5px; background-color: #f9f9f9; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                <div id="resumenIAContenedor" style="display:none; margin-top:20px; padding:20px; border:1px solid var(--epic-neutral-border); border-radius: 5px; background-color: var(--epic-neutral-bg); box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
                     <!-- El resumen generado por IA se insertará aquí -->
                 </div>
-                <div id="tagsSugeridosIA" class="tags-sugeridos-ia" style="margin-top: 30px; padding-top: 20px; border-top: 1px dashed #ccc;">
+                <div id="tagsSugeridosIA" class="tags-sugeridos-ia" style="margin-top: 30px; padding-top: 20px; border-top: 1px dashed var(--epic-input-border);">
                     <h4 class="text-center" style="font-family: 'Cinzel', serif; color: var(--epic-purple-emperor); margin-bottom: 15px;">Etiquetas Sugeridas por IA:</h4>
                     <div id="listaTagsIA" class="lista-tags-ia text-center">
                         <?php

--- a/museo/editar_pieza.php
+++ b/museo/editar_pieza.php
@@ -61,7 +61,7 @@ try {
     <style>
         body { font-family: Arial, sans-serif; margin:20px; }
         table { width:100%; border-collapse: collapse; margin-bottom:20px; }
-        th, td { border:1px solid #ccc; padding:8px; text-align:left; }
+        th, td { border:1px solid var(--epic-input-border); padding:8px; text-align:left; }
         th { background-color:#f2f2f2; }
         .feedback.success { background:#d4edda; padding:10px; margin-bottom:10px; }
         .feedback.error { background:#f8d7da; padding:10px; margin-bottom:10px; }

--- a/personajes/galeria_3d.html
+++ b/personajes/galeria_3d.html
@@ -62,7 +62,7 @@
             overflow-y: auto;
             margin-bottom: 15px;
             padding-right: 10px; /* For scrollbar spacing */
-            color: #cccccc;
+            color: var(--epic-input-border);
         }
         /* Custom scrollbar for bio (optional, WebKit only) */
         #character-info-overlay #info-bio::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- use CSS variables for neutral borders, backgrounds, and inputs
- keep light/dark themes consistent

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ImportError: Failed to import test module)*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68533fcd71d48329b6b3055e4e0d44c9