### PR TITLE
Update README with Flask quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,26 @@ php -S localhost:8000
 
 Esto iniciará el servidor en `http://localhost:8000`.
 
-Para exponer la API Flask primero instala las dependencias de Python y lanza el servicio:
+### Puesta en marcha de la API Flask
+
+1. (Opcional) crea y activa un entorno virtual:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+2. Instala las dependencias definidas en `requirements.txt`:
 
 ```bash
 pip install -r requirements.txt
+```
+
+3. Copia `.env.example` a `.env` y define al menos `GEMINI_API_KEY` y `CONDADO_DB_PASSWORD`.
+
+4. Inicia el servicio:
+
+```bash
 python flask_app.py
 ```
 


### PR DESCRIPTION
## Summary
- add instructions on installing Python requirements and launching `flask_app.py`
- mention using `.env` variables like `GEMINI_API_KEY`

## Testing
- `./scripts/check_alt_texts.sh`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68533fcaba8483298399b6517903b392