### PR TITLE
Add theme and language buttons inside main menu

### DIFF
--- a/_header.php
+++ b/_header.php
@@ -2,11 +2,12 @@
 echo file_get_contents(__DIR__ . "/fragments/header/language-bar.html");
 ?>
 <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
-<button id="theme-toggle" aria-label="Cambiar tema"><i class="fas fa-moon"></i></button>
 
 <!-- Left Sliding Panel for Main Menu -->
 <div id="consolidated-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="consolidated-menu-button">
     <button id="ai-chat-trigger" class="menu-item-button" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA"><i class="fas fa-comments"></i> <span>Chat IA</span></button>
+    <button id="theme-toggle" class="menu-item-button" aria-label="Cambiar tema"><i class="fas fa-moon"></i> <span>Modo</span></button>
+    <button id="lang-bar-toggle" class="menu-item-button" aria-label="Mostrar u ocultar traducción"><i class="fas fa-globe"></i> <span>Idiomas</span></button>
 
     <div class="menu-section">
         <h4 class="gradient-text">Navegación Principal</h4>

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -23,73 +23,6 @@
     z-index: 3000;
 }
 
-/* Theme Toggle Button - Original Position (will be adjusted for mobile) */
-#theme-toggle {
-    position: fixed;
-    top: var(--language-bar-offset);
-    left: 70px; /* Align horizontally with consolidated menu button */
-    transform: none;
-    background-color: var(--epic-transparent-overlay-medium);
-    border: 2px solid var(--epic-gold-secondary);
-    border-radius: var(--global-border-radius);
-    padding: 10px;
-    cursor: pointer;
-    z-index: 3001;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    transition: background-color var(--global-transition-speed) ease,
-                color var(--global-transition-speed) ease;
-}
-
-#theme-toggle i {
-    color: var(--epic-gold-main);
-    font-size: 1.2em;
-    transition: transform var(--global-transition-speed) ease;
-}
-
-#theme-toggle:hover {
-    background-color: var(--epic-gold-main);
-}
-
-#theme-toggle:hover i {
-    color: var(--epic-purple-emperor);
-    transform: rotate(20deg);
-}
-
-/* Language Bar Toggle */
-#lang-bar-toggle {
-    position: fixed;
-    top: var(--language-bar-offset);
-    right: 15px;
-    background-color: var(--epic-purple-emperor);
-    color: var(--epic-gold-main);
-    border: 2px solid var(--epic-gold-secondary);
-    border-radius: var(--global-border-radius);
-    padding: 8px 12px; /* match menu button size */
-    font-size: 1.1em;   /* match menu button size */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    z-index: 3001;
-    transition: background-color var(--global-transition-speed) ease,
-                color var(--global-transition-speed) ease;
-}
-
-#lang-bar-toggle i {
-    color: var(--epic-gold-main);
-}
-
-#lang-bar-toggle:hover {
-    background-color: var(--epic-gold-main);
-}
-
-#lang-bar-toggle:hover i {
-    color: var(--epic-purple-emperor);
-}
 
 
 /* Hide Google translate banner */
@@ -202,48 +135,13 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
 
 /* Dark Mode Icon Colors for Toggles */
 body.dark-mode #theme-toggle i,
-body.dark-mode #ia-chat-toggle i, /* Added for consistency */
+body.dark-mode #ia-chat-toggle i,
 body.dark-mode #homonexus-toggle i {
     color: var(--epic-icon-color);
 }
 
 body.dark-mode #theme-toggle:hover i,
-body.dark-mode #ia-chat-toggle:hover i, /* Added for consistency */
+body.dark-mode #ia-chat-toggle:hover i,
 body.dark-mode #homonexus-toggle:hover i {
     color: var(--epic-icon-hover);
-}
-
-/* Mobile Adjustments for Toggles */
-@media (max-width: 768px) {
-    #theme-toggle {
-        left: 60px;  /* Maintain gap next to menu button */
-        right: auto;
-        top: var(--language-bar-offset);
-    }
-}
-
-/* Consider further adjustments for very small screens if needed, e.g., hiding some toggles */
-
-@media (max-width: 480px) {
-    /* Reduce toggle button size so icons do not overlap */
-    #theme-toggle,
-    #ia-chat-toggle,
-    #homonexus-toggle {
-        width: 36px;
-        height: 36px;
-        padding: 6px;
-        top: var(--language-bar-offset);
-    }
-
-    /* Slightly smaller icons for tiny screens */
-    #theme-toggle i,
-    #ia-chat-toggle i,
-    #homonexus-toggle i {
-        font-size: 0.9em;
-    }
-
-    /* Adjust right offsets so buttons remain separated */
-    #ia-chat-toggle { right: 10px; }
-    #homonexus-toggle { right: 50px; }
-    #theme-toggle { left: 60px; right: auto; }
 }

--- a/fragments/header/language-bar.html
+++ b/fragments/header/language-bar.html
@@ -1,7 +1,3 @@
 <!-- No manual language links. Translation handled automatically via Google Translate -->
 <div id="google_translate_element"></div>
-<button id="lang-bar-toggle" aria-label="Mostrar u ocultar traducción">
-    <i class="fas fa-globe"></i>
-    <span class="visually-hidden">Traducir</span>
-</button>
 


### PR DESCRIPTION
## Summary
- place `theme-toggle` and `lang-bar-toggle` buttons inside the consolidated menu
- remove standalone toggle button in `language-bar.html`
- clean old fixed-position styles in header CSS and keep dark-mode icon rules

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68534584ed9883298fd0be19f040e509