### PR TITLE
Add guide for fixed header elements

### DIFF
--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -39,3 +39,22 @@ Tras cualquier modificación ejecuta las pruebas de PHP y Python si las dependen
 vendor/bin/phpunit
 python -m unittest tests/test_flask_api.py
 ```
+
+## Contenedor `#fixed-header-elements`
+Este bloque fijo aparece al inicio de cada página y mantiene visibles los controles principales.
+Dentro se incluyen los botones:
+- `#consolidated-menu-button` abre el panel deslizante con toda la navegación.
+- `#ai-chat-trigger` muestra el asistente conversacional.
+- `#theme-toggle` alterna entre modo claro y oscuro.
+- `#lang-bar-toggle` despliega la barra de traducción de Google.
+
+Al añadir más elementos al contenedor puede ser necesario ajustar la posición de los paneles deslizantes. Para ello define la variable `--menu-extra-offset` con la altura del contenedor y úsala junto a `--language-bar-offset` en `assets/css/menus/consolidated-menu.css`:
+```css
+:root {
+    --menu-extra-offset: 48px;
+}
+.menu-panel {
+    top: calc(var(--language-bar-offset) + var(--menu-extra-offset));
+}
+```
+Esto evitará que los menús se oculten tras los botones fijos.


### PR DESCRIPTION
## Summary
- document `#fixed-header-elements` container in `docs/index-guide.md`
- explain new header buttons and how to offset panels with `--menu-extra-offset`

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685349f6d8f08329a500c956320d5793