### PR TITLE
Add header toggles for IA chat and Homonexus mode

### DIFF
--- a/_header.php
+++ b/_header.php
@@ -1,7 +1,11 @@
-<?php
-echo file_get_contents(__DIR__ . "/fragments/header/language-bar.html");
-?>
-<button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
+<div id="fixed-header-elements">
+    <?php echo file_get_contents(__DIR__ . '/fragments/header/language-bar.html'); ?>
+    <div class="header-action-buttons">
+        <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
+        <button id="ia-chat-toggle" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA" aria-expanded="false" role="button"><i class="fas fa-comments"></i></button>
+        <button id="homonexus-toggle" aria-label="Activar modo Homonexus" aria-expanded="false" role="button"><i class="fas fa-infinity"></i></button>
+    </div>
+</div>
 
 <!-- Left Sliding Panel for Main Menu -->
 <div id="consolidated-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="consolidated-menu-button">

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -13,6 +13,11 @@
     align-items: center;
 }
 
+.header-action-buttons {
+    display: flex;
+    gap: 8px;
+}
+
 .top-empty-bar {
     position: fixed;
     top: 0;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -90,4 +90,17 @@ document.addEventListener('DOMContentLoaded', () => {
             localStorage.setItem('theme', isDark ? 'dark' : 'light');
         });
     }
+
+    const iaChatToggle = document.getElementById('ia-chat-toggle');
+    if (iaChatToggle) {
+        iaChatToggle.addEventListener('click', () => toggleMenu(iaChatToggle));
+    }
+
+    const homonexusToggle = document.getElementById('homonexus-toggle');
+    if (homonexusToggle) {
+        homonexusToggle.addEventListener('click', () => {
+            const active = document.body.classList.toggle('homonexus-active');
+            document.cookie = `homonexus=${active ? 'on' : 'off'}; path=/;`;
+        });
+    }
 });


### PR DESCRIPTION
## Summary
- add fixed header container with IA chat and Homonexus toggles
- style topbar buttons in `topbar.css`
- hook up IA chat and Homonexus buttons in `main.js`

## Testing
- `python -m unittest tests/test_flask_api.py`
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6853499867488329a182e74af59f90b4