### PR TITLE
Add menu compression puppeteer test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
       "tailwindcss": "^3.4.4"
     },
     "scripts": {
-      "test:puppeteer": "node tests/manual/langBarOffsetTest.js"
+      "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js"
     }
   }

--- a/tests/menuCompressionTest.js
+++ b/tests/menuCompressionTest.js
@@ -1,0 +1,26 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/index.php');
+  await page.waitForSelector('#consolidated-menu-button');
+  await page.click('#consolidated-menu-button');
+  await page.waitForTimeout(500);
+  const hasClass = await page.evaluate(() => document.body.classList.contains('menu-compressed'));
+  if (!hasClass) {
+    console.error('menu-compressed class not added');
+    await browser.close();
+    process.exit(1);
+  }
+  await page.click('#consolidated-menu-button');
+  await page.waitForTimeout(500);
+  const stillHasClass = await page.evaluate(() => document.body.classList.contains('menu-compressed'));
+  if (stillHasClass) {
+    console.error('menu-compressed class not removed');
+    await browser.close();
+    process.exit(1);
+  }
+  console.log('Menu compression class toggled correctly');
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- add puppeteer test for menu-compressed class toggle
- run the new test alongside the existing langBarOffsetTest

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: connection refused to localhost:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68534b4672308329b6297a5e9f71555f