### PR TITLE
Add fixed header guide details

### DIFF
--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -58,3 +58,7 @@ Al añadir más elementos al contenedor puede ser necesario ajustar la posición
 }
 ```
 Esto evitará que los menús se oculten tras los botones fijos.
+
+### Modificar la altura del contenedor
+
+La variable `--menu-extra-offset` puede definirse también en `assets/css/epic_theme.css` o en tu propia hoja de estilos. Ajusta su valor al número de píxeles que ocupa `#fixed-header-elements` para que los paneles deslizantes queden perfectamente alineados bajo los botones.


### PR DESCRIPTION
## Summary
- expand docs on `#fixed-header-elements`
- clarify how to configure `--menu-extra-offset`

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68534a7c2740832999bb8e2322eda63c