### PR TITLE
Remove exposed Gemini API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ GEMINI_API_ENDPOINT=https://api.gemini.example.com/v1/generateContent
 
 `GEMINI_API_KEY` guarda la clave de acceso suministrada por el proveedor. `GEMINI_API_ENDPOINT` permite especificar la URL del punto de entrada, que por defecto es `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent` si la variable se omite.
 
-El valor de la clave se inyecta en la etiqueta `<meta name="gemini-api-key">` generada por `includes/head_common.php` y es utilizado por las funciones del servidor definidas en `includes/ai_utils.php`.
+La clave **solo** se utiliza en el servidor a través de `includes/ai_utils.php`; ya no se expone en el marcado HTML. De este modo se evita compartir credenciales sensibles con el cliente.
 
 Si `GEMINI_API_KEY` no está definida, las funciones de `includes/ai_utils.php` no intentarán contactar con el servicio real: en su lugar usarán un simulador interno que genera respuestas de ejemplo. Esto permite probar el sitio sin consumir cuota ni requerir acceso externo.
 

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -6,7 +6,6 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 ?>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="gemini-api-key" content="<?php echo htmlspecialchars($geminiKey, ENT_QUOTES, 'UTF-8'); ?>">
 <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- drop `<meta name="gemini-api-key">` from `head_common.php`
- document that the Gemini API key is only used server side

## Testing
- `composer install` *(fails: command not found)*
- `pip install -r requirements.txt`
- `vendor/bin/phpunit` *(fails: no such file)*
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685355984f88832996d89b5880d9676a