### PR TITLE
Add HTML skeleton around early includes

### DIFF
--- a/alfoz/indexalfoz.php
+++ b/alfoz/indexalfoz.php
@@ -1,4 +1,9 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+</head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>
   <header>

--- a/camino_santiago/camino_santiago.php
+++ b/camino_santiago/camino_santiago.php
@@ -1,4 +1,9 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+</head>
 <body>
 
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/visitas/visitas.php
+++ b/visitas/visitas.php
@@ -1,4 +1,9 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+<?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+</head>
 <body>
 
     <?php require_once __DIR__ . '/../_header.php'; ?>


### PR DESCRIPTION
## Summary
- add `<!DOCTYPE html>` and opening tags to Camino de Santiago, Visitas, and Alfoz pages
- include page-specific CSS loader and close `<head>` on these pages

## Testing
- `composer install`
- `pip install -r requirements.txt`
- `./vendor/bin/phpunit` *(fails: php-cgi not found)*
- `pytest -q` *(fails: ModuleNotFoundError: flask_app)*

------
https://chatgpt.com/codex/tasks/task_e_6853559307b88329aeefe81e78fca2de