### PR TITLE
Remove extra CSS includes after head_common

### DIFF
--- a/lugares/alfozcerezolantaron/Alcedo/index.php
+++ b/lugares/alfozcerezolantaron/Alcedo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Alcedo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Ameyugo/index.php
+++ b/lugares/alfozcerezolantaron/Ameyugo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Ameyugo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Bachicabo/index.php
+++ b/lugares/alfozcerezolantaron/Bachicabo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Bachicabo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Barrio/index.php
+++ b/lugares/alfozcerezolantaron/Barrio/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Barrio</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Belorado/index.php
+++ b/lugares/alfozcerezolantaron/Belorado/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Belorado</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Berguenda/index.php
+++ b/lugares/alfozcerezolantaron/Berguenda/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Bergüenda</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Caicedo_de_Yuso/index.php
+++ b/lugares/alfozcerezolantaron/Caicedo_de_Yuso/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Caicedo de Yuso</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Carcamo/index.php
+++ b/lugares/alfozcerezolantaron/Carcamo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Cárcamo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Castellum/index.php
+++ b/lugares/alfozcerezolantaron/Castellum/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Castellum</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Cellorigo/index.php
+++ b/lugares/alfozcerezolantaron/Cellorigo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Cellorigo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Cerezo_de_Rio_Tiron/index.php
+++ b/lugares/alfozcerezolantaron/Cerezo_de_Rio_Tiron/index.php
@@ -7,7 +7,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Comunion/index.php
+++ b/lugares/alfozcerezolantaron/Comunion/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Comunión</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Cuzcurrita_de_Rio_Tiron/index.php
+++ b/lugares/alfozcerezolantaron/Cuzcurrita_de_Rio_Tiron/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Cuzcurrita de Río Tirón</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Espejo/index.php
+++ b/lugares/alfozcerezolantaron/Espejo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Espejo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Fontecha/index.php
+++ b/lugares/alfozcerezolantaron/Fontecha/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Fontecha</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Fresno_de_Rio_Tiron/index.php
+++ b/lugares/alfozcerezolantaron/Fresno_de_Rio_Tiron/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Fresno de Río Tirón</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Granon/index.php
+++ b/lugares/alfozcerezolantaron/Granon/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Grañón</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Gurendes/index.php
+++ b/lugares/alfozcerezolantaron/Gurendes/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Gurendes</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Herramelluri/index.php
+++ b/lugares/alfozcerezolantaron/Herramelluri/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Herramélluri</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Ibrillos/index.php
+++ b/lugares/alfozcerezolantaron/Ibrillos/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Ibrillos</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Lecinana_del_Camino/index.php
+++ b/lugares/alfozcerezolantaron/Lecinana_del_Camino/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Leciñana del Camino</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Molinilla/index.php
+++ b/lugares/alfozcerezolantaron/Molinilla/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Molinilla</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Monte/index.php
+++ b/lugares/alfozcerezolantaron/Monte/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Monte</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Nograro/index.php
+++ b/lugares/alfozcerezolantaron/Nograro/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Nograro</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Ochanduri/index.php
+++ b/lugares/alfozcerezolantaron/Ochanduri/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Ochánduri</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Pancorbo/index.php
+++ b/lugares/alfozcerezolantaron/Pancorbo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Pancorbo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Pinedo/index.php
+++ b/lugares/alfozcerezolantaron/Pinedo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Pinedo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Posada/index.php
+++ b/lugares/alfozcerezolantaron/Posada/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Posada</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Poza_de_la_Sal/index.php
+++ b/lugares/alfozcerezolantaron/Poza_de_la_Sal/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Poza de la Sal</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Puentelarra/index.php
+++ b/lugares/alfozcerezolantaron/Puentelarra/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Puentelarrá</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Quejo/index.php
+++ b/lugares/alfozcerezolantaron/Quejo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Quejo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Quintanaloranco/index.php
+++ b/lugares/alfozcerezolantaron/Quintanaloranco/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Quintanaloranco</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Quintanilla_San_Garcia/index.php
+++ b/lugares/alfozcerezolantaron/Quintanilla_San_Garcia/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Quintanilla San García</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Quintanilla_del_Monte/index.php
+++ b/lugares/alfozcerezolantaron/Quintanilla_del_Monte/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Quintanilla del Monte</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Recilla/index.php
+++ b/lugares/alfozcerezolantaron/Recilla/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Recilla</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Redecilla_del_Campo/index.php
+++ b/lugares/alfozcerezolantaron/Redecilla_del_Campo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Redecilla del Campo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Salcedo/index.php
+++ b/lugares/alfozcerezolantaron/Salcedo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Salcedo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/San_Emilianus/index.php
+++ b/lugares/alfozcerezolantaron/San_Emilianus/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>San Emilianus</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/San_Millan_de_Yecora/index.php
+++ b/lugares/alfozcerezolantaron/San_Millan_de_Yecora/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>San Millán de Yécora</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/San_Zadornil/index.php
+++ b/lugares/alfozcerezolantaron/San_Zadornil/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>San Zadornil</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Sobron/index.php
+++ b/lugares/alfozcerezolantaron/Sobron/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Sobrón</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Sotillo_de_Rioja/index.php
+++ b/lugares/alfozcerezolantaron/Sotillo_de_Rioja/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Sotillo de Rioja</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Tirgo/index.php
+++ b/lugares/alfozcerezolantaron/Tirgo/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Tirgo</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Tormantos/index.php
+++ b/lugares/alfozcerezolantaron/Tormantos/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Tormantos</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Trevino/index.php
+++ b/lugares/alfozcerezolantaron/Trevino/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Treviño</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Tuesta/index.php
+++ b/lugares/alfozcerezolantaron/Tuesta/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Tuesta</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Turiso/index.php
+++ b/lugares/alfozcerezolantaron/Turiso/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Turiso</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Valluercanes/index.php
+++ b/lugares/alfozcerezolantaron/Valluercanes/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Valluércanes</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Valpuesta/index.php
+++ b/lugares/alfozcerezolantaron/Valpuesta/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Valpuesta</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Velasco/index.php
+++ b/lugares/alfozcerezolantaron/Velasco/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Velasco</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Villafranca_Montes_de_Oca/index.php
+++ b/lugares/alfozcerezolantaron/Villafranca_Montes_de_Oca/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Villafranca Montes de Oca</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Villafria/index.php
+++ b/lugares/alfozcerezolantaron/Villafria/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Villafría</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Villamaderne/index.php
+++ b/lugares/alfozcerezolantaron/Villamaderne/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Villamaderne</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Villanue/index.php
+++ b/lugares/alfozcerezolantaron/Villanue/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Villanue</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Villanueva_Soportilla/index.php
+++ b/lugares/alfozcerezolantaron/Villanueva_Soportilla/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Villanueva Soportilla</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Villanueva_de_Gurendes/index.php
+++ b/lugares/alfozcerezolantaron/Villanueva_de_Gurendes/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Villanueva de Gurendes</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/Zubillaga/index.php
+++ b/lugares/alfozcerezolantaron/Zubillaga/index.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Zubillaga</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
   <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/alfoz.php
+++ b/lugares/alfozcerezolantaron/alfoz.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/alfozcerezolantaron/indexalfoz.php
+++ b/lugares/alfozcerezolantaron/indexalfoz.php
@@ -3,7 +3,6 @@
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
   <title>Alfoz de Cerezo y Lantarón</title>
-  <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/cerasio.php
+++ b/lugares/cerasio.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/el_culebron.php
+++ b/lugares/el_culebron.php
@@ -4,7 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>El Culebrón - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/lugares/lugares.php
+++ b/lugares/lugares.php
@@ -6,10 +6,7 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
-    <link rel="stylesheet" href="/assets/css/header.css">
     <link rel="stylesheet" href="/assets/css/custom.css">
-    <link rel="stylesheet" href="/assets/vendor/css/bootstrap.min.css">
 
 </head>
 <body>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html
@@ -3,4 +3,3 @@
 <head>
     <title>Fernando Diaz - Condado de Castilla</title>
     <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/constantino.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/constantino.html
@@ -3,4 +3,3 @@
 <head>
     <title>Constantino - Emperadores Romanos en Auca</title>
     <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/personajes/Militares_y_Gobernantes/alba_esposa_corocotta.html
+++ b/personajes/Militares_y_Gobernantes/alba_esposa_corocotta.html
@@ -3,4 +3,3 @@
 <head>
     <title>Alba Esposa Corocotta - Condado de Castilla</title>
     <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/personajes/Militares_y_Gobernantes/turok_nerea_amaia_hijos_corocotta.html
+++ b/personajes/Militares_y_Gobernantes/turok_nerea_amaia_hijos_corocotta.html
@@ -3,4 +3,3 @@
 <head>
     <title>Turok Nerea Amaia Hijos Corocotta - Condado de Castilla</title>
     <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/personajes/Ordenes_y_Legados/monjes_hospitalarios_san_jorge_y_san_anton.html
+++ b/personajes/Ordenes_y_Legados/monjes_hospitalarios_san_jorge_y_san_anton.html
@@ -3,4 +3,3 @@
 <head>
     <title>Monjes Hospitalarios San Jorge Y San Anton - Condado de Castilla</title>
     <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/ruinas/edificaciones_civiles_publicas/circo_romano.php
+++ b/ruinas/edificaciones_civiles_publicas/circo_romano.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/edificaciones_civiles_publicas/foro_romano.php
+++ b/ruinas/edificaciones_civiles_publicas/foro_romano.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/edificaciones_civiles_publicas/index.php
+++ b/ruinas/edificaciones_civiles_publicas/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>
 <body>

--- a/ruinas/edificaciones_civiles_publicas/orfeones_odeones.php
+++ b/ruinas/edificaciones_civiles_publicas/orfeones_odeones.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/edificaciones_civiles_publicas/puerto_fluvial_gurugu.php
+++ b/ruinas/edificaciones_civiles_publicas/puerto_fluvial_gurugu.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/edificaciones_civiles_publicas/teatro_romano.php
+++ b/ruinas/edificaciones_civiles_publicas/teatro_romano.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_defensivas/alcazar_cerasio.php
+++ b/ruinas/estructuras_defensivas/alcazar_cerasio.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_defensivas/campamento_romano_tejera.php
+++ b/ruinas/estructuras_defensivas/campamento_romano_tejera.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_defensivas/index.php
+++ b/ruinas/estructuras_defensivas/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>
 <body>

--- a/ruinas/estructuras_defensivas/murallas_auca.php
+++ b/ruinas/estructuras_defensivas/murallas_auca.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_defensivas/otros_campamentos_romanos.php
+++ b/ruinas/estructuras_defensivas/otros_campamentos_romanos.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_defensivas/otros_castillos.php
+++ b/ruinas/estructuras_defensivas/otros_castillos.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_defensivas/torres_vigia.php
+++ b/ruinas/estructuras_defensivas/torres_vigia.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_funerarias_religiosas/iglesia_la_llana_mezquita_yanna.php
+++ b/ruinas/estructuras_funerarias_religiosas/iglesia_la_llana_mezquita_yanna.php
@@ -4,7 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Iglesia de la Llana (Antigua Mezquita de Yanna) - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_funerarias_religiosas/index.php
+++ b/ruinas/estructuras_funerarias_religiosas/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>
 <body>

--- a/ruinas/estructuras_funerarias_religiosas/mausoleo_circo_auca.php
+++ b/ruinas/estructuras_funerarias_religiosas/mausoleo_circo_auca.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_funerarias_religiosas/mausoleo_magno_clemente_maximo.php
+++ b/ruinas/estructuras_funerarias_religiosas/mausoleo_magno_clemente_maximo.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_funerarias_religiosas/mausoleo_san_nicolas.php
+++ b/ruinas/estructuras_funerarias_religiosas/mausoleo_san_nicolas.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_funerarias_religiosas/necropolis_san_martin.php
+++ b/ruinas/estructuras_funerarias_religiosas/necropolis_san_martin.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/estructuras_residenciales_elite/index.php
+++ b/ruinas/estructuras_residenciales_elite/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>
 <body>

--- a/ruinas/estructuras_residenciales_elite/palacios_romanos_auca.php
+++ b/ruinas/estructuras_residenciales_elite/palacios_romanos_auca.php
@@ -4,7 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Palacios Romanos de Auca Patricia - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/hallazgos_representaciones/alabastro_de_cerasio.php
+++ b/ruinas/hallazgos_representaciones/alabastro_de_cerasio.php
@@ -4,7 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Alabastro de Cerasio - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/hallazgos_representaciones/cuevas_setefenestras.php
+++ b/ruinas/hallazgos_representaciones/cuevas_setefenestras.php
@@ -4,7 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Cuevas de Setefenestras - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/hallazgos_representaciones/descripciones_generales.php
+++ b/ruinas/hallazgos_representaciones/descripciones_generales.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/hallazgos_representaciones/fotos_hallazgos.php
+++ b/ruinas/hallazgos_representaciones/fotos_hallazgos.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/hallazgos_representaciones/index.php
+++ b/ruinas/hallazgos_representaciones/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>
 <body>

--- a/ruinas/hallazgos_representaciones/monedas_antiguas.php
+++ b/ruinas/hallazgos_representaciones/monedas_antiguas.php
@@ -4,7 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Monedas Antiguas de Cerezo/Auca - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/hallazgos_representaciones/tallas_inscripciones.php
+++ b/ruinas/hallazgos_representaciones/tallas_inscripciones.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/index.php
+++ b/ruinas/index.php
@@ -6,10 +6,7 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
-    <link rel="stylesheet" href="/assets/css/header.css">
     <link rel="stylesheet" href="/assets/css/custom.css">
-    <link rel="stylesheet" href="/assets/vendor/css/bootstrap.min.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/infraestructura_general/hitos_miliares.php
+++ b/ruinas/infraestructura_general/hitos_miliares.php
@@ -6,7 +6,6 @@
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/infraestructura_general/hospital_san_jorge.php
+++ b/ruinas/infraestructura_general/hospital_san_jorge.php
@@ -4,7 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Hospital de San Jorge y Talla de San Antón - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/infraestructura_general/index.php
+++ b/ruinas/infraestructura_general/index.php
@@ -2,7 +2,6 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 </head>
 <body>

--- a/ruinas/infraestructura_general/mansio_romana_meson.php
+++ b/ruinas/infraestructura_general/mansio_romana_meson.php
@@ -4,7 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Mansio Romana en el Mesón - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/infraestructura_general/puentes_romanos_cerezo.php
+++ b/ruinas/infraestructura_general/puentes_romanos_cerezo.php
@@ -4,7 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Puentes Romanos de Cerezo de Río Tirón - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/ruinas/infraestructura_general/tunel_antiguo.php
+++ b/ruinas/infraestructura_general/tunel_antiguo.php
@@ -4,7 +4,6 @@
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Túnel Antiguo en Cerezo - Ruinas del Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>


### PR DESCRIPTION
## Summary
- rely on `head_common.php` for CSS imports
- clean up redundant `<link>` tags in ruins, lugares, and certain personajes pages

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6853559427348329b984aab1639b8c56