### PR TITLE
Move menu 200px down

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -50,6 +50,7 @@
     --alabaster-background-image: url('/assets/img/alabastro.jpg');
     --language-bar-offset: 0px; /* default fallback */
     --menu-extra-offset: 60px;
+    --menu-top-offset: 200px;
     /* Additional theme variables for admin dashboard */
     --epic-purple-hover: #663399;
     --epic-gray: #6c757d;

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -2,7 +2,7 @@
 
 #fixed-header-elements {
     position: fixed;
-    top: 0;
+    top: var(--menu-top-offset);
     left: 0;
     right: 0;
     z-index: 4000;
@@ -20,7 +20,7 @@
 
 .top-empty-bar {
     position: fixed;
-    top: 0;
+    top: var(--menu-top-offset);
     left: 0;
     right: 0;
     height: 48px;
@@ -82,7 +82,7 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
 /* IA Chat Toggle */
 #ia-chat-toggle {
     position: fixed;
-    top: 88px; /* moved lower */
+    top: calc(88px + var(--menu-top-offset));
     right: 15px;
     background-color: var(--epic-transparent-overlay-medium);
     border: 2px solid var(--epic-gold-secondary);
@@ -114,7 +114,7 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
 /* Homonexus Toggle */
 #homonexus-toggle {
     position: fixed;
-    top: 88px; /* moved lower */
+    top: calc(88px + var(--menu-top-offset));
     right: 65px; /* (ia-chat-toggle width 44px + right 15px = 59px) + 6px gap */
     background-color: var(--epic-transparent-overlay-medium);
     border: 2px solid var(--epic-gold-secondary);

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -3,7 +3,7 @@
 /* Main toggle button for the consolidated menu */
 #consolidated-menu-button {
     position: fixed !important;
-    top: calc(var(--language-bar-offset) + var(--menu-extra-offset)) !important;
+    top: calc(var(--language-bar-offset) + var(--menu-extra-offset) + var(--menu-top-offset)) !important;
     left: 20px !important;
     right: auto !important;
     z-index: 1005 !important; /* También z-index por si acaso */
@@ -25,7 +25,7 @@
 /* Common styles for both sliding panels */
 .menu-panel {
     position: fixed;
-    top: calc(var(--language-bar-offset) + var(--menu-extra-offset));
+    top: calc(var(--language-bar-offset) + var(--menu-extra-offset) + var(--menu-top-offset));
     bottom: 0; /* Make panel full height */
     width: 300px; /* Adjust width as needed */
     max-width: 80%; /* Max width for smaller screens */
@@ -234,10 +234,10 @@
         width: 280px; /* Slightly narrower for mobile */
         padding: 10px; /* Compacted */
         padding-top: 45px; /* Compacted */
-        top: calc(var(--language-bar-offset) + var(--menu-extra-offset));
+        top: calc(var(--language-bar-offset) + var(--menu-extra-offset) + var(--menu-top-offset));
     }
     #consolidated-menu-button {
-        top: calc(var(--language-bar-offset) + var(--menu-extra-offset)); /* Adjusted for language bar */
+        top: calc(var(--language-bar-offset) + var(--menu-extra-offset) + var(--menu-top-offset)); /* Adjusted for language bar */
         left: 10px; /* Compacted */
         right: auto; /* Compacted */
         font-size: 1em; /* Compacted */


### PR DESCRIPTION
## Summary
- add `--menu-top-offset` CSS variable set to 200px
- offset the fixed header and top buttons using the new variable
- shift sliding menu panels and button down accordingly

## Testing
- `composer install` *(fails: command not found)*
- `pip install -r requirements.txt`
- `vendor/bin/phpunit` *(fails: no such file)*
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: missing puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_6853565c50cc8329a15e6215b4cf95ac