### PR TITLE
Add ia-chat CSS import

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -6,3 +6,4 @@
 @import url('menus/social-menu.css');
 @import url('menus/homonexus.css');
 @import url('menus/consolidated-menu.css');
+@import url('header/ia-chat.css');


### PR DESCRIPTION
## Summary
- import `header/ia-chat.css` from `assets/css/header.css`

## Testing
- `composer install`
- `pip install -r requirements.txt`
- `npm install`
- `vendor/bin/phpunit` *(fails: ToolsMenuLinksTest provider invalid, php-cgi not found)*
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_685356eb91b4832995635622d65810d1