### PR TITLE
Remove unused header action buttons

### DIFF
--- a/_header.php
+++ b/_header.php
@@ -1,10 +1,6 @@
 <div id="fixed-header-elements">
     <?php echo file_get_contents(__DIR__ . '/fragments/header/language-bar.html'); ?>
-    <div class="header-action-buttons">
-        <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
-        <button id="ia-chat-toggle" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA" aria-expanded="false" role="button"><i class="fas fa-comments"></i></button>
-        <button id="homonexus-toggle" aria-label="Activar modo Homonexus" aria-expanded="false" role="button"><i class="fas fa-infinity"></i></button>
-    </div>
+    <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
 </div>
 
 <!-- Left Sliding Panel for Main Menu -->

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -13,10 +13,6 @@
     align-items: center;
 }
 
-.header-action-buttons {
-    display: flex;
-    gap: 8px;
-}
 
 .top-empty-bar {
     position: fixed;
@@ -79,74 +75,11 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
     transform: translateY(-6.5px) rotate(-45deg);
 }
 */
-/* IA Chat Toggle */
-#ia-chat-toggle {
-    position: fixed;
-    top: 88px; /* moved lower */
-    right: 15px;
-    background-color: var(--epic-transparent-overlay-medium);
-    border: 2px solid var(--epic-gold-secondary);
-    border-radius: var(--global-border-radius);
-    padding: 10px;
-    cursor: pointer;
-    z-index: 3001;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    transition: right var(--global-transition-speed) ease-in-out,
-                background-color var(--global-transition-speed) ease;
-}
-
-#ia-chat-toggle i {
-    color: var(--epic-gold-main);
-}
-
-#ia-chat-toggle:hover {
-    background-color: var(--epic-gold-main);
-}
-
-#ia-chat-toggle:hover i {
-    color: var(--epic-purple-emperor);
-}
-
-/* Homonexus Toggle */
-#homonexus-toggle {
-    position: fixed;
-    top: 88px; /* moved lower */
-    right: 65px; /* (ia-chat-toggle width 44px + right 15px = 59px) + 6px gap */
-    background-color: var(--epic-transparent-overlay-medium);
-    border: 2px solid var(--epic-gold-secondary);
-    border-radius: var(--global-border-radius);
-    padding: 10px;
-    cursor: pointer;
-    z-index: 3001;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-}
-#homonexus-toggle i {
-    color: var(--epic-gold-main);
-}
-#homonexus-toggle:hover {
-    background-color: var(--epic-gold-main);
-}
-#homonexus-toggle:hover i {
-    color: var(--epic-purple-emperor);
-}
-
-/* Dark Mode Icon Colors for Toggles */
-body.dark-mode #theme-toggle i,
-body.dark-mode #ia-chat-toggle i,
-body.dark-mode #homonexus-toggle i {
+/* Dark Mode Icon Colors for Theme Toggle */
+body.dark-mode #theme-toggle i {
     color: var(--epic-icon-color);
 }
 
-body.dark-mode #theme-toggle:hover i,
-body.dark-mode #ia-chat-toggle:hover i,
-body.dark-mode #homonexus-toggle:hover i {
+body.dark-mode #theme-toggle:hover i {
     color: var(--epic-icon-hover);
 }


### PR DESCRIPTION
## Summary
- strip out header action buttons from `_header.php`
- delete old styles for `.header-action-buttons`, `#ia-chat-toggle`, and `#homonexus-toggle`

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685356ebbe088329b9fa28f2018d82cb