### PR TITLE
Remove unused chat and homonexus toggles

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -91,16 +91,5 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    const iaChatToggle = document.getElementById('ia-chat-toggle');
-    if (iaChatToggle) {
-        iaChatToggle.addEventListener('click', () => toggleMenu(iaChatToggle));
-    }
-
-    const homonexusToggle = document.getElementById('homonexus-toggle');
-    if (homonexusToggle) {
-        homonexusToggle.addEventListener('click', () => {
-            const active = document.body.classList.toggle('homonexus-active');
-            document.cookie = `homonexus=${active ? 'on' : 'off'}; path=/;`;
-        });
-    }
+    // IA chat toggle and Homonexus functionality removed
 });


### PR DESCRIPTION
## Summary
- clean up `assets/js/main.js` by dropping unused UI toggles
- run Python tests to confirm functionality

## Testing
- `python -m pytest -q tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68535b4bfc4c83299b17261ab6d51f09