### PR TITLE
update docs for removed header-loader

### DIFF
--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -9,7 +9,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `js/config.js` | Defines `API_BASE_URL` and `DEBUG_MODE` globals for other scripts. |
 | `js/layout.js` | Loads external CSS/JS libraries on demand, initializes the flashlight effect and other page-level utilities. |
 | `js/load_menu_parts.js` | Dynamically loads menu fragments into the header when needed. |
-| `js/header-loader.js` | Fetches `/_header.php` and injects it into `#header-placeholder` for static pages. |
+| ~~`js/header-loader.js`~~ | **Deprecated.** The header is now loaded directly without this helper. See the README note on its removal. |
 | `js/ia-tools.js` | Implements AI assistant utilities such as summaries, translations and chat. |
 | `js/lang-bar.js` | Loads Google Translate when a `?lang=` URL parameter is present. |
 | `js/lugares-data.js` | Provides static data used by `lugares-dynamic-list.js`. |
@@ -18,7 +18,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `js/museo-3d-main.js` | Initializes the 3D museum viewer built on Three.js. |
 | `js/museum-3d/` | Additional modules used by the 3D viewer. |
 
-Deprecated or merged scripts such as `js/menu-controller.js` and `js/sliding-menu.js` have been removed in favour of `assets/js/main.js`.
+Deprecated or merged scripts such as `js/menu-controller.js` and `js/sliding-menu.js` have been removed in favour of `assets/js/main.js`. The old `js/header-loader.js` was also dropped as noted in the project README.
 
 ## Simplified Translation
 


### PR DESCRIPTION
## Summary
- mark `header-loader.js` as deprecated in JS module table
- mention README note about its removal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68535f07b62483299b5df017de7c4a9a