### PR TITLE
Remove header-loader.js references

### DIFF
--- a/dashboard/README.html
+++ b/dashboard/README.html
@@ -127,8 +127,8 @@ ORDER BY total_visits DESC;
 </ol>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html
@@ -59,8 +59,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html
@@ -55,8 +55,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/dona_sancha.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/dona_sancha.html
@@ -57,8 +57,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernan_gonzalez.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernan_gonzalez.html
@@ -58,8 +58,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html
@@ -75,8 +75,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
@@ -54,8 +54,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/aureliano.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/aureliano.html
@@ -49,8 +49,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/clemente_magno_maximo.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/clemente_magno_maximo.html
@@ -28,8 +28,8 @@
 <li>Se menciona que el autor de <code>nuevo4.md</code> no ha investigado mucho sobre él: "De Magno Clemente no he investigado mucho...".</li>
 </ul>
     </main>
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_arcadio.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_arcadio.html
@@ -19,8 +19,8 @@
 <p>El documento <code>nuevo4.md</code> lo incluye entre los emperadores nacidos en Auca Patricia: "En el siglo IV nacen 4 emperadores romanos en Auca Patricia capital de Cantabria, Flavio Teodosio I el Grande y su hijo Flavio Arcadio, Magno Clemente Maximo y su hijo Flavio Victor." Esto sugiere, según el autor de <code>nuevo4.md</code>, que Flavio Arcadio nació en Auca/Cerezo.</p>
 <p>No se encontraron otros detalles específicos sobre Flavio Arcadio en <code>nuevo4.md</code>.</p>
     </main>
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_teodosio_i_el_grande.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_teodosio_i_el_grande.html
@@ -63,8 +63,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_victor.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_victor.html
@@ -37,8 +37,8 @@
 *   Se menciona una moneda específica: "Moneda de Flavio Victor (decapitado el 26 de Agosto del 388 en el circo de Oca, Auca Patricia) , con reverso de puerta romana como la del Pendon de Castilla."</p>
 <p>No se encontraron otros detalles específicos sobre Flavio Victor en <code>nuevo4.md</code>.</p>
     </main>
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/magno_clemente_maximo.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/magno_clemente_maximo.html
@@ -71,8 +71,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/teodosio_i.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/teodosio_i.html
@@ -22,8 +22,8 @@
 <h2>Relevancia para Auca/Cerezo</h2>
 <p>El documento <code>nuevo4.md</code> establece una conexión directa de Teodosio I con Auca/Cerezo al afirmar: "Mas tarde nacen tres emperadores romanos en Auka, Teodosio I el Grande su primo Magno Clemente Máximo y su hijo Flavio Victor." Esta afirmación sugiere que Auka fue el lugar de nacimiento de estos emperadores, según la perspectiva del autor de <code>nuevo4.md</code>.</p>
     </main>
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/agripa.html
+++ b/personajes/Militares_y_Gobernantes/agripa.html
@@ -54,8 +54,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/alfonso_ii_el_casto.html
+++ b/personajes/Militares_y_Gobernantes/alfonso_ii_el_casto.html
@@ -55,8 +55,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/cesar_augusto.html
+++ b/personajes/Militares_y_Gobernantes/cesar_augusto.html
@@ -53,8 +53,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html
+++ b/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html
@@ -63,8 +63,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/corocotta.html
+++ b/personajes/Militares_y_Gobernantes/corocotta.html
@@ -52,8 +52,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/leovigildo.html
+++ b/personajes/Militares_y_Gobernantes/leovigildo.html
@@ -53,8 +53,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/ramiro_i_de_asturias.html
+++ b/personajes/Militares_y_Gobernantes/ramiro_i_de_asturias.html
@@ -58,8 +58,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
+++ b/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
@@ -51,8 +51,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Ordenes_y_Legados/paterna_banucasi.html
+++ b/personajes/Ordenes_y_Legados/paterna_banucasi.html
@@ -55,8 +55,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Santos_y_Martires/san_braulio.html
+++ b/personajes/Santos_y_Martires/san_braulio.html
@@ -53,8 +53,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Santos_y_Martires/san_formerio.html
+++ b/personajes/Santos_y_Martires/san_formerio.html
@@ -56,8 +56,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Santos_y_Martires/san_vitores.html
+++ b/personajes/Santos_y_Martires/san_vitores.html
@@ -56,8 +56,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/galeria_3d.html
+++ b/personajes/galeria_3d.html
@@ -522,8 +522,8 @@
 
         animate();
     </script>
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/indice_personajes.html
+++ b/personajes/indice_personajes.html
@@ -149,10 +149,10 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
+    <?php require_once __DIR__ . '/../_footer.php'; ?>
 
 
-    <script src="/js/header-loader.js"></script>
+    
     <script src="/js/layout.js"></script>
     <script src="/js/personajes_loader.js"></script>
 </body>

--- a/secciones_index/historia_tiempo_resumen.html
+++ b/secciones_index/historia_tiempo_resumen.html
@@ -48,8 +48,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/secciones_index/memoria_hispanidad.html
+++ b/secciones_index/memoria_hispanidad.html
@@ -105,8 +105,8 @@
         </section>
     </main>
 
-    <div id="footer-placeholder"></div>
-    <script src="/js/header-loader.js"></script>
+    <?php require_once __DIR__ . '/../_footer.php'; ?>
+    
     <script src="/js/layout.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- strip `<script src="/js/header-loader.js">` from site
- include the PHP footer directly in affected pages

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68535f092bcc832986eedf9ad0dda87d