### PR TITLE
Add Homonexus toggle script

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -19,4 +19,5 @@
 </div>
 </footer>
 <script src="/assets/js/main.js"></script>
+<script src="/assets/js/homonexus-toggle.js"></script>
 <script src="/js/lang-bar.js"></script>

--- a/assets/js/homonexus-toggle.js
+++ b/assets/js/homonexus-toggle.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('homonexus-toggle');
+  if (!toggle) return;
+
+  const updateState = (active) => {
+    document.body.classList.toggle('homonexus-active', active);
+    toggle.setAttribute('aria-expanded', active);
+    document.cookie = `homonexus=${active ? 'on' : 'off'};path=/;max-age=31536000`;
+  };
+
+  // Set initial aria-expanded from body class
+  toggle.setAttribute('aria-expanded', document.body.classList.contains('homonexus-active'));
+
+  toggle.addEventListener('click', () => {
+    const active = !document.body.classList.contains('homonexus-active');
+    updateState(active);
+  });
+});

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -5,6 +5,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | File | Description |
 |------|-------------|
 | `assets/js/main.js` | Handles sliding menu interactions, closing behavior, and the light/dark theme toggle used across all pages. |
+| `assets/js/homonexus-toggle.js` | Toggles Homonexus mode, storing the preference in a cookie. |
 | `assets/js/foro.js` | Simple toggling for the forum agents menu. |
 | `js/config.js` | Defines `API_BASE_URL` and `DEBUG_MODE` globals for other scripts. |
 | `js/layout.js` | Loads external CSS/JS libraries on demand, initializes the flashlight effect and other page-level utilities. |


### PR DESCRIPTION
## Summary
- add small script for Homonexus toggle
- load the script in `_footer.php`
- document new script in JS modules overview

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6853646265008329b4aaf738771603db