### PR TITLE
Remove header-loader.js references

### DIFF
--- a/dashboard/README.html
+++ b/dashboard/README.html
@@ -128,7 +128,6 @@ ORDER BY total_visits DESC;
     </main>
 
     <?php require_once __DIR__.'/../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -9,7 +9,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `js/config.js` | Defines `API_BASE_URL` and `DEBUG_MODE` globals for other scripts. |
 | `js/layout.js` | Loads external CSS/JS libraries on demand, initializes the flashlight effect and other page-level utilities. |
 | `js/load_menu_parts.js` | Dynamically loads menu fragments into the header when needed. |
-| ~~`js/header-loader.js`~~ | **Deprecated.** The header is now loaded directly without this helper. See the README note on its removal. |
+| ~~Header loader script~~ | **Deprecated.** The header is now loaded directly without this helper. See the README note on its removal. |
 | `js/ia-tools.js` | Implements AI assistant utilities such as summaries, translations and chat. |
 | `js/lang-bar.js` | Loads Google Translate when a `?lang=` URL parameter is present. |
 | `js/lugares-data.js` | Provides static data used by `lugares-dynamic-list.js`. |
@@ -18,7 +18,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `js/museo-3d-main.js` | Initializes the 3D museum viewer built on Three.js. |
 | `js/museum-3d/` | Additional modules used by the 3D viewer. |
 
-Deprecated or merged scripts such as `js/menu-controller.js` and `js/sliding-menu.js` have been removed in favour of `assets/js/main.js`. The old `js/header-loader.js` was also dropped as noted in the project README.
+Deprecated or merged scripts such as `js/menu-controller.js` and `js/sliding-menu.js` have been removed in favour of `assets/js/main.js`. The old header loading helper was also dropped as noted in the project README.
 
 ## Simplified Translation
 

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html
@@ -60,7 +60,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html
@@ -56,7 +56,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/dona_sancha.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/dona_sancha.html
@@ -58,7 +58,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernan_gonzalez.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernan_gonzalez.html
@@ -59,7 +59,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html
@@ -76,7 +76,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
@@ -55,7 +55,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/aureliano.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/aureliano.html
@@ -50,7 +50,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/clemente_magno_maximo.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/clemente_magno_maximo.html
@@ -29,7 +29,6 @@
 </ul>
     </main>
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_arcadio.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_arcadio.html
@@ -20,7 +20,6 @@
 <p>No se encontraron otros detalles específicos sobre Flavio Arcadio en <code>nuevo4.md</code>.</p>
     </main>
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_teodosio_i_el_grande.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_teodosio_i_el_grande.html
@@ -64,7 +64,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_victor.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_victor.html
@@ -38,7 +38,6 @@
 <p>No se encontraron otros detalles específicos sobre Flavio Victor en <code>nuevo4.md</code>.</p>
     </main>
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/magno_clemente_maximo.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/magno_clemente_maximo.html
@@ -72,7 +72,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/teodosio_i.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/teodosio_i.html
@@ -23,7 +23,6 @@
 <p>El documento <code>nuevo4.md</code> establece una conexión directa de Teodosio I con Auca/Cerezo al afirmar: "Mas tarde nacen tres emperadores romanos en Auka, Teodosio I el Grande su primo Magno Clemente Máximo y su hijo Flavio Victor." Esta afirmación sugiere que Auka fue el lugar de nacimiento de estos emperadores, según la perspectiva del autor de <code>nuevo4.md</code>.</p>
     </main>
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/agripa.html
+++ b/personajes/Militares_y_Gobernantes/agripa.html
@@ -55,7 +55,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/alfonso_ii_el_casto.html
+++ b/personajes/Militares_y_Gobernantes/alfonso_ii_el_casto.html
@@ -56,7 +56,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/cesar_augusto.html
+++ b/personajes/Militares_y_Gobernantes/cesar_augusto.html
@@ -54,7 +54,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html
+++ b/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html
@@ -64,7 +64,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/corocotta.html
+++ b/personajes/Militares_y_Gobernantes/corocotta.html
@@ -53,7 +53,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/leovigildo.html
+++ b/personajes/Militares_y_Gobernantes/leovigildo.html
@@ -54,7 +54,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Militares_y_Gobernantes/ramiro_i_de_asturias.html
+++ b/personajes/Militares_y_Gobernantes/ramiro_i_de_asturias.html
@@ -59,7 +59,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
+++ b/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
@@ -52,7 +52,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Ordenes_y_Legados/paterna_banucasi.html
+++ b/personajes/Ordenes_y_Legados/paterna_banucasi.html
@@ -56,7 +56,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Santos_y_Martires/san_braulio.html
+++ b/personajes/Santos_y_Martires/san_braulio.html
@@ -54,7 +54,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Santos_y_Martires/san_formerio.html
+++ b/personajes/Santos_y_Martires/san_formerio.html
@@ -57,7 +57,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/Santos_y_Martires/san_vitores.html
+++ b/personajes/Santos_y_Martires/san_vitores.html
@@ -57,7 +57,6 @@
     </main>
 
     <?php require_once __DIR__.'/../../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/galeria_3d.html
+++ b/personajes/galeria_3d.html
@@ -523,7 +523,6 @@
         animate();
     </script>
     <?php require_once __DIR__.'/../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/personajes/indice_personajes.html
+++ b/personajes/indice_personajes.html
@@ -152,7 +152,6 @@
     <?php require_once __DIR__.'/../_footer.php'; ?>
 
 
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
     <script src="/js/personajes_loader.js"></script>
 </body>

--- a/secciones_index/historia_tiempo_resumen.html
+++ b/secciones_index/historia_tiempo_resumen.html
@@ -49,7 +49,6 @@
     </main>
 
     <?php require_once __DIR__.'/../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/secciones_index/memoria_hispanidad.html
+++ b/secciones_index/memoria_hispanidad.html
@@ -106,7 +106,6 @@
     </main>
 
     <?php require_once __DIR__.'/../_footer.php'; ?>
-    <script src="/js/header-loader.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop deprecated header-loader.js script tags
- clean up documentation mention

## Testing
- `grep -R "header-loader.js" -n --exclude-dir=.git`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853646302c883299c62473c7725e8d6