### PR TITLE
Stack header buttons vertically

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -50,7 +50,7 @@
     --alabaster-background-image: url('/assets/img/alabastro.jpg');
     --language-bar-offset: 0px; /* default fallback */
     --menu-extra-offset: 60px;
-    --menu-top-offset: 200px;
+    --menu-top-offset: 240px;
     /* Additional theme variables for admin dashboard */
     --epic-purple-hover: #663399;
     --epic-gray: #6c757d;

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -15,7 +15,8 @@
 
 .header-action-buttons {
     display: flex;
-    gap: 8px;
+    flex-direction: column;
+    gap: 8px; /* vertical spacing between buttons */
 }
 
 .top-empty-bar {
@@ -81,9 +82,8 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
 */
 /* IA Chat Toggle */
 #ia-chat-toggle {
-    position: fixed;
-    top: calc(88px + var(--menu-top-offset));
-    right: 15px;
+    position: relative;
+    right: 0;
     background-color: var(--epic-transparent-overlay-medium);
     border: 2px solid var(--epic-gold-secondary);
     border-radius: var(--global-border-radius);
@@ -95,8 +95,7 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
     justify-content: center;
     width: 44px;
     height: 44px;
-    transition: right var(--global-transition-speed) ease-in-out,
-                background-color var(--global-transition-speed) ease;
+    transition: background-color var(--global-transition-speed) ease;
 }
 
 #ia-chat-toggle i {
@@ -113,9 +112,7 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
 
 /* Homonexus Toggle */
 #homonexus-toggle {
-    position: fixed;
-    top: calc(88px + var(--menu-top-offset));
-    right: 65px; /* (ia-chat-toggle width 44px + right 15px = 59px) + 6px gap */
+    position: relative;
     background-color: var(--epic-transparent-overlay-medium);
     border: 2px solid var(--epic-gold-secondary);
     border-radius: var(--global-border-radius);

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -2,11 +2,8 @@
 
 /* Main toggle button for the consolidated menu */
 #consolidated-menu-button {
-    position: fixed !important;
-    top: calc(var(--language-bar-offset) + var(--menu-extra-offset) + var(--menu-top-offset)) !important;
-    left: 20px !important;
-    right: auto !important;
-    z-index: 1005 !important; /* También z-index por si acaso */
+    position: relative !important;
+    z-index: 1005 !important; /* keep above menu */
     padding: 8px 12px; /* Slightly more compact */
     background-color: var(--epic-gold-main);
     color: var(--epic-purple-emperor);
@@ -237,9 +234,6 @@
         top: calc(var(--language-bar-offset) + var(--menu-extra-offset) + var(--menu-top-offset));
     }
     #consolidated-menu-button {
-        top: calc(var(--language-bar-offset) + var(--menu-extra-offset) + var(--menu-top-offset)); /* Adjusted for language bar */
-        left: 10px; /* Compacted */
-        right: auto; /* Compacted */
         font-size: 1em; /* Compacted */
         padding: 6px 10px; /* Compacted */
     }


### PR DESCRIPTION
## Summary
- arrange header action buttons in a vertical column
- let menu, chat and homonexus toggles follow the flex flow
- bump `--menu-top-offset` for new layout

## Testing
- `npm run test:puppeteer` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685366ae301c8329a72daa56b9fde323