### PR TITLE
Implement real Gemini API usage and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ GEMINI_API_KEY=tu_clave_personal
 GEMINI_API_ENDPOINT=https://api.gemini.example.com/v1/generateContent
 ```
 
+Variables requeridas:
+
+- **`GEMINI_API_KEY`** – clave de acceso proporcionada por el proveedor.
+- **`GEMINI_API_ENDPOINT`** – URL del punto de entrada (opcional; si se omite se
+  usa `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent`).
+
+Asegúrate de exportarlas en tu terminal o definirlas en `.env` para que
+`includes/ai_utils.php` pueda realizar llamadas reales.
+
 `GEMINI_API_KEY` guarda la clave de acceso suministrada por el proveedor. `GEMINI_API_ENDPOINT` permite especificar la URL del punto de entrada, que por defecto es `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent` si la variable se omite.
 
 La clave **solo** se utiliza en el servidor a través de `includes/ai_utils.php`; ya no se expone en el marcado HTML. De este modo se evita compartir credenciales sensibles con el cliente.

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -178,9 +178,10 @@ function _parse_gemini_response(?array $api_response, ?string $call_error): stri
  * @return array|null Respuesta decodificada o null si hay errores.
  */
 function _call_gemini_api(array $payload, ?string &$error = null): ?array {
-    // Use simulator only if the API key is the placeholder "not set" value.
-    // If a key is provided, attempt a real call, regardless of the endpoint value.
-    if (GEMINI_API_KEY === 'YOUR_GEMINI_API_KEY_NOT_SET') {
+    // Use simulator when the API key is missing or still has the placeholder
+    // value. A real HTTP request is only attempted if a non-empty key is
+    // provided via the environment or configuration.
+    if (GEMINI_API_KEY === 'YOUR_GEMINI_API_KEY_NOT_SET' || GEMINI_API_KEY === '') {
         return _call_gemini_api_simulator($payload);
     }
 

--- a/tests/AiDrawerTest.php
+++ b/tests/AiDrawerTest.php
@@ -11,7 +11,9 @@ class AiDrawerTest extends TestCase {
         $env = [
             'PATH' => getenv('PATH'),
             'REDIRECT_STATUS' => '1',
-            'SCRIPT_FILENAME' => $script
+            'SCRIPT_FILENAME' => $script,
+            // Ensure AI utilities use the built-in simulator during tests
+            'GEMINI_API_KEY' => ''
         ];
         $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
         $out = stream_get_contents($pipes[1]);


### PR DESCRIPTION
## Summary
- let `_call_gemini_api` send real HTTP when `GEMINI_API_KEY` is set
- document Gemini environment variables clearly
- avoid real API calls in `AiDrawerTest`

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685369b36c308329badccdb7b739d832