### PR TITLE
Fix Google Translate bar

### DIFF
--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -10,7 +10,8 @@ function loadGoogleTranslate() {
         }, 'google_translate_element');
     };
     var script = document.createElement('script');
-    script.src = '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+    script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+    script.async = true;
     document.head.appendChild(script);
 }
 


### PR DESCRIPTION
## Summary
- ensure google translate loads with https

## Testing
- `composer install` *(fails: command not found)*
- `pip install -r requirements.txt`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest`
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685369facb1083298dd9f0d9c71e36ee