### PR TITLE
Remove deprecated chat toggles

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -19,5 +19,4 @@
 </div>
 </footer>
 <script src="/assets/js/main.js"></script>
-<script src="/assets/js/homonexus-toggle.js"></script>
 <script src="/js/lang-bar.js"></script>

--- a/_header.php
+++ b/_header.php
@@ -2,8 +2,6 @@
     <?php echo file_get_contents(__DIR__ . '/fragments/header/language-bar.html'); ?>
     <div class="header-action-buttons">
         <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
-        <button id="ia-chat-toggle" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA" aria-expanded="false" role="button"><i class="fas fa-comments"></i></button>
-        <button id="homonexus-toggle" aria-label="Activar modo Homonexus" aria-expanded="false" role="button"><i class="fas fa-infinity"></i></button>
     </div>
 </div>
 

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -80,70 +80,13 @@ body { /* This rule might be better in a global CSS if it's for Google Translate
     transform: translateY(-6.5px) rotate(-45deg);
 }
 */
-/* IA Chat Toggle */
-#ia-chat-toggle {
-    position: relative;
-    right: 0;
-    background-color: var(--epic-transparent-overlay-medium);
-    border: 2px solid var(--epic-gold-secondary);
-    border-radius: var(--global-border-radius);
-    padding: 10px;
-    cursor: pointer;
-    z-index: 3001;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    transition: background-color var(--global-transition-speed) ease;
-}
-
-#ia-chat-toggle i {
-    color: var(--epic-gold-main);
-}
-
-#ia-chat-toggle:hover {
-    background-color: var(--epic-gold-main);
-}
-
-#ia-chat-toggle:hover i {
-    color: var(--epic-purple-emperor);
-}
-
-/* Homonexus Toggle */
-#homonexus-toggle {
-    position: relative;
-    background-color: var(--epic-transparent-overlay-medium);
-    border: 2px solid var(--epic-gold-secondary);
-    border-radius: var(--global-border-radius);
-    padding: 10px;
-    cursor: pointer;
-    z-index: 3001;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-}
-#homonexus-toggle i {
-    color: var(--epic-gold-main);
-}
-#homonexus-toggle:hover {
-    background-color: var(--epic-gold-main);
-}
-#homonexus-toggle:hover i {
-    color: var(--epic-purple-emperor);
-}
 
 /* Dark Mode Icon Colors for Toggles */
-body.dark-mode #theme-toggle i,
-body.dark-mode #ia-chat-toggle i,
-body.dark-mode #homonexus-toggle i {
+
+body.dark-mode #theme-toggle i {
     color: var(--epic-icon-color);
 }
 
-body.dark-mode #theme-toggle:hover i,
-body.dark-mode #ia-chat-toggle:hover i,
-body.dark-mode #homonexus-toggle:hover i {
+body.dark-mode #theme-toggle:hover i {
     color: var(--epic-icon-hover);
 }

--- a/assets/css/menus/homonexus.css
+++ b/assets/css/menus/homonexus.css
@@ -14,28 +14,3 @@ body.homonexus-active #sidebar .nav-links a:hover {
     color: var(--epic-purple-emperor);
     transform: scale(1.05) rotate(-1deg);
 }
-/* Toggle button */
-#homonexus-toggle {
-    background-color: var(--epic-alabaster-bg);
-    border: 2px solid var(--epic-gold-secondary);
-    border-radius: var(--global-border-radius);
-    padding: 10px;
-    cursor: pointer;
-    z-index: 3001;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    transition: background-color var(--global-transition-speed) ease;
-}
-#homonexus-toggle i {
-    color: var(--epic-gold-main);
-    font-size: 1.2em;
-}
-#homonexus-toggle:hover {
-    background-color: var(--epic-gold-main);
-}
-#homonexus-toggle:hover i {
-    color: var(--epic-purple-emperor);
-}


### PR DESCRIPTION
## Summary
- clean up header buttons for removed features
- drop unused Homonexus script from footer
- prune old toggle CSS

## Testing
- `phpunit -c phpunit.xml` *(fails: php-cgi not found)*
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68536ad424cc83298f66c00178a85ba6