### PR TITLE
Fix hero title position

### DIFF
--- a/assets/css/pages/index.css
+++ b/assets/css/pages/index.css
@@ -24,3 +24,8 @@ body {
   margin-top: 1em;
   margin-bottom: 1em;
 }
+
+/* Align the hero title with the fixed menu button */
+.align-with-menu {
+    margin-top: var(--menu-top-offset);
+}

--- a/index.php
+++ b/index.php
@@ -30,7 +30,7 @@ require_once __DIR__ . '/_header.php';
         <div class="hero-content">
             <img src="/assets/img/escudo.jpg" alt="Escudo del Condado de Castilla: castillo dorado sobre fondo púrpura con una estrella de 8 puntas dorada encima." class="hero-escudo">
             <div>
-                <?php editableText('hero_titulo_index', $pdo, 'Condado de Castilla: Cuna de Tu Cultura e Idioma', 'h1', ''); ?>
+                <?php editableText('hero_titulo_index', $pdo, 'Condado de Castilla: Cuna de Tu Cultura e Idioma', 'h1', 'align-with-menu'); ?>
                 <?php editableText('hero_parrafo_index', $pdo, 'Explora las ruinas del Alcázar de Casio, la Civitate Auca Patricia y descubre el origen de tu cultura milenaria en Cerezo de Río Tirón.', 'p', 'text-old-gold'); ?>
                 <?php editableText('mission_tagline_index', $pdo, 'Promocionamos el turismo en Cerezo de Río Tirón y cuidamos su patrimonio arqueológico y cultural.', 'p', 'mission-tagline text-old-gold'); ?>
             </div>


### PR DESCRIPTION
## Summary
- align hero tagline with the fixed menu button

## Testing
- `./check_links.sh`
- `./check_links_extended.sh`
- `./scripts/check_alt_texts.sh`
- `python -m unittest`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536da9a9088329bd8ef6e99cdff5cb