### PR TITLE
Update README testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Si `GEMINI_API_KEY` no está definida, las funciones de `includes/ai_utils.php` 
 
 ## Testing
 
-Instala **todas** las dependencias antes de lanzar las suites de pruebas. Las pruebas dependen de PHP, Composer y las extensiones indicadas, por lo que no se ejecutarán si alguno de estos componentes falta. Ejecuta primero:
+Instala **todas** las dependencias antes de lanzar las suites de pruebas. Las pruebas dependen de PHP, Composer y las extensiones indicadas, por lo que no se ejecutarán si alguno de estos componentes falta. En particular es imprescindible tener disponible la interfaz de línea de comandos de PHP (PHP CLI). Ejecuta primero:
 
 ```bash
 composer install
@@ -211,7 +211,12 @@ pip install -r requirements.txt
 
 `composer install` debe ejecutarse **antes** de usar `vendor/bin/phpunit` y
 `pip install -r requirements.txt` debe lanzarse **antes** de ejecutar las
-pruebas de Python.
+pruebas de Python. Comprueba que PHP CLI está disponible antes de ejecutar las
+pruebas de PHP:
+
+```bash
+php -v
+```
 
 Con las dependencias ya presentes, ejecuta cada conjunto de tests de forma explícita:
 


### PR DESCRIPTION
## Summary
- mention PHP CLI requirement and add `php -v` example before PHPUnit

## Testing
- `composer install --no-interaction --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml`
- `pip install -r requirements.txt`
- `vendor/bin/phpunit` *(fails: empty data set, php-cgi not found, missing driver)*
- `python -m unittest`
- `npm install`
- `npm run test:puppeteer` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68536e3454708329bc7399e37d85a52a