### PR TITLE
Add Python environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,12 @@ Instala **todas** las dependencias antes de lanzar las suites de pruebas. Las pr
 
 ```bash
 composer install
-pip install -r requirements.txt
+./scripts/setup_python_env.sh
 ```
 
 `composer install` debe ejecutarse **antes** de usar `vendor/bin/phpunit` y
-`pip install -r requirements.txt` debe lanzarse **antes** de ejecutar las
-pruebas de Python.
+`./scripts/setup_python_env.sh` instalará las dependencias de Python definidas en
+`requirements.txt` antes de ejecutar las pruebas de ese lenguaje.
 
 Con las dependencias ya presentes, ejecuta cada conjunto de tests de forma explícita:
 

--- a/scripts/setup_python_env.sh
+++ b/scripts/setup_python_env.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+# Determine pip executable
+if [[ -x "venv/bin/pip" ]]; then
+    PIP="venv/bin/pip"
+else
+    PIP="$(command -v pip || command -v pip3)"
+fi
+
+if [[ -z "$PIP" ]]; then
+    echo "pip no encontrado" >&2
+    exit 1
+fi
+
+"$PIP" install -r requirements.txt
+
+echo "Dependencias de Python instaladas."


### PR DESCRIPTION
## Summary
- add `setup_python_env.sh` to install `requirements.txt`
- note the helper script in README for running tests

## Testing
- `python -m unittest`
- `./scripts/check_alt_texts.sh`

------
https://chatgpt.com/codex/tasks/task_e_68536e3588ac8329b12f722478276434