### PR TITLE
Remove inline styles with new notice classes

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -2720,3 +2720,65 @@ button, input[type="submit"], input[type="button"], .cta-button, .submit-button,
 .hero-museo {
     background-image: linear-gradient(rgba(var(--epic-purple-emperor-rgb), 0.75), rgba(var(--epic-alabaster-bg-rgb), 0.88)), url('/imagenes/hero_museo_background.jpg');
 }
+
+/* --- Notice and Utility Classes --- */
+.notice-success {
+    color: var(--epic-success-text);
+    background-color: var(--epic-success-bg);
+    border: 1px solid var(--epic-success-border);
+    padding: 0.75em 1em;
+    border-radius: var(--global-border-radius);
+}
+
+.notice-error {
+    color: var(--epic-danger-text);
+    background-color: var(--epic-danger-bg);
+    border: 1px solid var(--epic-danger-border);
+    padding: 0.75em 1em;
+    border-radius: var(--global-border-radius);
+}
+
+.section-divider {
+    margin-top: 30px;
+    margin-bottom: 30px;
+    padding-top: 20px;
+    padding-bottom: 20px;
+    border-top: 1px dashed var(--epic-neutral-border);
+    border-bottom: 1px dashed var(--epic-neutral-border);
+}
+
+.section-divider-bottom {
+    margin-bottom: 25px;
+    padding-bottom: 20px;
+    border-bottom: 1px dashed var(--epic-neutral-border);
+}
+
+.cta-large {
+    padding: 12px 25px;
+    font-size: 1.1em;
+}
+
+.my-30 {
+    margin-top: 30px;
+    margin-bottom: 30px;
+}
+
+.mt-20 {
+    margin-top: 20px;
+}
+
+.hero-atapuerca {
+    background-image: linear-gradient(rgba(var(--epic-purple-emperor-rgb), 0.55), rgba(var(--epic-purple-emperor-rgb), 0.55)), url('/assets/img/placeholder.jpg');
+}
+
+.language-selector {
+    margin-bottom: 25px;
+    padding-bottom: 20px;
+    border-bottom: 1px dashed var(--epic-neutral-border);
+}
+
+.tags-container {
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px dashed var(--epic-neutral-border);
+}

--- a/citas/agenda.php
+++ b/citas/agenda.php
@@ -49,9 +49,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <?php require_once __DIR__ . '/../_header.php'; ?>
     <h1>Programa de Citas para Visitas</h1>
     <?php if ($successMessage): ?>
-        <p style="color:green;"><?php echo htmlspecialchars($successMessage); ?></p>
+        <p class="notice-success"><?php echo htmlspecialchars($successMessage); ?></p>
     <?php elseif ($errorMessage): ?>
-        <p style="color:red;"><?php echo htmlspecialchars($errorMessage); ?></p>
+        <p class="notice-error"><?php echo htmlspecialchars($errorMessage); ?></p>
     <?php endif; ?>
     <form method="POST">
         <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(get_csrf_token()); ?>">

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -25,7 +25,7 @@ require_once __DIR__ . '/../includes/ai_utils.php';
 </head>
 <body>
 <?php require_once __DIR__ . '/../_header.php'; ?>
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(0,0,0, 0.5), rgba(0,0,0, 0.5)), url('../assets/img/placeholder.jpg');"> <!-- Basic hero style -->
+    <header class="page-header hero hero-atapuerca"> <!-- Basic hero style -->
         <div class="hero-content">
             <h1><?php editableText('atapuerca_titulo_hero', $pdo, 'Los Yacimientos de la Sierra de Atapuerca'); ?></h1>
         </div>
@@ -36,8 +36,8 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                 <h2 class="section-title"><?php editableText('atapuerca_titulo_seccion', $pdo, 'Un Tesoro de la Prehistoria'); ?></h2>
                 <p class="timeline-intro"><?php editableText('atapuerca_intro_p1', $pdo, 'La Sierra de Atapuerca, ubicada al norte de Ibeas de Juarros en la provincia de Burgos, es un enclave montañoso de modesta altitud que alberga un extraordinario conjunto de yacimientos arqueológicos y paleontológicos. Reconocida como Patrimonio de la Humanidad por la UNESCO, Espacio de Interés Natural y Bien de Interés Cultural, Atapuerca ha proporcionado al mundo testimonios fósiles de al menos cinco especies distintas de homínidos, arrojando luz invaluable sobre la evolución humana en Europa.'); ?></p>
 
-                <div id="languageSelectorContainer" class="text-center" style="margin-bottom: 25px; padding-bottom: 20px; border-bottom: 1px dashed #ccc;">
-                    <h4 style="font-family: 'Cinzel', serif; color: var(--epic-purple-emperor); margin-bottom: 10px;">Seleccionar Idioma (Demostración):</h4>
+                <div id="languageSelectorContainer" class="text-center language-selector">
+                    <h4>Seleccionar Idioma (Demostración):</h4>
                     <button class="lang-btn active" data-lang="es" title="Ver contenido en Español (original)">Español (Original)</button>
                     <button class="lang-btn" data-lang="en-ai" title="Simular traducción al Inglés por IA">Inglés (Traducción IA)</button>
                     <button class="lang-btn" data-lang="fr-ai" title="Simular traducción al Francés por IA">Francés (Traducción IA)</button>
@@ -61,14 +61,14 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                         <p><?php editableText('atapuerca_importancia_p1', $pdo, 'La Sierra de Atapuerca no es solo un conjunto de cuevas con fósiles; es una ventana directa a la vida de nuestros antepasados. La increíble concentración de restos en buen estado de conservación, abarcando un periodo tan extenso (desde el Pleistoceno Inferior hasta el Holoceno), la convierten en un referente mundial para el estudio de la evolución humana. Los hallazgos han permitido comprender mejor las estrategias de caza, la tecnología lítica, las características físicas e incluso posibles prácticas rituales de las distintas especies de homínidos que habitaron esta sierra.'); ?></p>
                     </div>
                 </article>
-                <div class="text-center" style="margin-top: 30px; margin-bottom: 30px;"> <!-- Contenedor para centrar el botón -->
-                    <button id="btnResumenIA" class="cta-button" style="padding: 12px 25px; font-size: 1.1em;">Ver Resumen Inteligente</button>
+                <div class="text-center my-30"> <!-- Contenedor para centrar el botón -->
+                    <button id="btnResumenIA" class="cta-button cta-large">Ver Resumen Inteligente</button>
                 </div>
                 <div id="resumenIAContenedor">
                     <!-- El resumen generado por IA se insertará aquí -->
                 </div>
-                <div id="tagsSugeridosIA" class="tags-sugeridos-ia" style="margin-top: 30px; padding-top: 20px; border-top: 1px dashed #ccc;">
-                    <h4 class="text-center" style="font-family: 'Cinzel', serif; color: var(--epic-purple-emperor); margin-bottom: 15px;">Etiquetas Sugeridas por IA:</h4>
+                <div id="tagsSugeridosIA" class="tags-sugeridos-ia tags-container">
+                    <h4 class="text-center">Etiquetas Sugeridas por IA:</h4>
                     <div id="listaTagsIA" class="lista-tags-ia text-center">
                         <?php
                         if (function_exists('get_suggested_tags_placeholder')) {

--- a/js/museo-3d-main.js
+++ b/js/museo-3d-main.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error('Three.js not loaded. Museo 3D cannot start.');
         const museumContainer = document.getElementById('museo-3d-container');
         if (museumContainer) {
-            museumContainer.innerHTML = '<p class="text-center" style="color:red; margin-top: 20px;">Error: Three.js library not loaded. The 3D museum cannot be displayed.</p>';
+            museumContainer.innerHTML = '<p class="text-center notice-error mt-20">Error: Three.js library not loaded. The 3D museum cannot be displayed.</p>';
         }
         // Hide pointer lock instructions if Three.js is missing
         const instructions = document.getElementById('pointer-lock-instructions');


### PR DESCRIPTION
## Summary
- add notice-success, notice-error and section-divider utilities to epic_theme.css
- replace inline styles in agenda, Atapuerca page and museum JS with classes

## Testing
- `pip install -r requirements.txt`
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest`
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68536ede23b88329a1de10335be3b026