### PR TITLE
Fix language bar top position

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -48,6 +48,11 @@ body {
 /* Ensure the Google Translate widget itself is not accidentally shown if not already hidden by inline style */
 #google_translate_element {
     display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 5000;
 }
 
 /* Ocultar visualmente pero mantener accesible */


### PR DESCRIPTION
## Summary
- make the Google Translate widget fixed to the very top

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest`
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685370cb33308329bd37d506f008b463