### PR TITLE
Fix sliding menu event handling

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -32,8 +32,13 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    document.querySelectorAll('[data-menu-target]').forEach(btn => {
-        btn.addEventListener('click', () => toggleMenu(btn));
+    // Use event delegation so dynamically injected buttons still work
+    document.addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-menu-target]');
+        if (btn) {
+            e.preventDefault();
+            toggleMenu(btn);
+        }
     });
 
     document.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- handle menu buttons with event delegation so late-loaded headers still work

## Testing
- `pip install -r requirements.txt`
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file)*
- `python -m unittest`
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `./check_links.sh`
- `./check_links_extended.sh`
- `./scripts/check_alt_texts.sh`


------
https://chatgpt.com/codex/tasks/task_e_685374b8d9348329bd8c19377778bfe8