### PR TITLE
Remove language bar offset adjustment

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -48,7 +48,6 @@
     --global-box-shadow-medium: 0 5px 15px rgba(var(--epic-text-color-rgb), 0.15);
     --global-box-shadow-dark: 0 8px 25px rgba(var(--epic-text-color-rgb), 0.2);
     --alabaster-background-image: url('/assets/img/alabastro.jpg');
-    --language-bar-offset: 0px; /* default fallback */
     --menu-extra-offset: 60px;
     --menu-top-offset: 0px;
     /* Additional theme variables for admin dashboard */
@@ -120,7 +119,7 @@ body {
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
     animation: fadeInPage 0.7s ease-out forwards;
-    padding-top: calc(110px + var(--language-bar-offset));
+    padding-top: 110px;
 }
 
 body::before {
@@ -2490,7 +2489,7 @@ body.dark-mode {
     /* background-image is inherited from body::before via cascading */
     background-color: var(--epic-alabaster-bg); /* This will be the dark version of the variable */
     /* filter property is now on body.dark-mode::before */
-    padding-top: calc(110px + var(--language-bar-offset));
+    padding-top: 110px;
 }
 
 body.dark-mode::before {

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -23,7 +23,7 @@
 /* Common styles for both sliding panels */
 .menu-panel {
     position: fixed;
-    top: calc(var(--language-bar-offset) + var(--menu-extra-offset) + var(--menu-top-offset));
+    top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
     bottom: 0; /* Make panel full height */
     width: 300px; /* Adjust width as needed */
     max-width: 80%; /* Max width for smaller screens */
@@ -232,7 +232,7 @@
         width: 280px; /* Slightly narrower for mobile */
         padding: 10px; /* Compacted */
         padding-top: 45px; /* Compacted */
-        top: calc(var(--language-bar-offset) + var(--menu-extra-offset) + var(--menu-top-offset));
+        top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
     }
     #consolidated-menu-button {
         font-size: 1em; /* Compacted */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,9 +1,6 @@
 // assets/js/main.js - simplified menu controller and theme toggle
 
 document.addEventListener('DOMContentLoaded', () => {
-    if (typeof applyLanguageBarOffset === 'function') {
-        applyLanguageBarOffset();
-    }
     const closeMenu = (menu) => {
         menu.classList.remove('active');
         const btn = document.querySelector(`[data-menu-target="${menu.id}"]`);

--- a/js/header-loader.js
+++ b/js/header-loader.js
@@ -9,9 +9,6 @@
                 if (typeof setupLanguageBar === 'function') {
                     setupLanguageBar();
                 }
-                if (typeof applyLanguageBarOffset === 'function') {
-                    applyLanguageBarOffset();
-                }
             })
             .catch(err => console.error('Error loading header:', err));
     });

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -25,23 +25,10 @@ function toggleLanguageBar() {
 
     const isHidden = el.style.display === 'none' || getComputedStyle(el).display === 'none';
 
-    const updateOffset = () => {
-        const waitForHeight = () => {
-            const h = el.offsetHeight;
-            if (h === 0) {
-                requestAnimationFrame(waitForHeight);
-            } else {
-                document.documentElement.style.setProperty('--language-bar-offset', h + 'px');
-                document.body.style.setProperty('--language-bar-offset', h + 'px');
-            }
-        };
-        waitForHeight();
-    };
 
     if (isHidden) {
         const showBar = () => {
             el.style.display = 'block';
-            updateOffset();
         };
 
         if (!window.googleTranslateLoaded) {
@@ -51,8 +38,6 @@ function toggleLanguageBar() {
         }
     } else {
         el.style.display = 'none';
-        document.documentElement.style.setProperty('--language-bar-offset', '0px');
-        document.body.style.setProperty('--language-bar-offset', '0px');
     }
 }
 
@@ -65,8 +50,6 @@ function initLangBarToggle() {
     if (el) {
         el.addEventListener('click', toggleLanguageBar);
         el.style.display = 'none';
-        document.documentElement.style.setProperty('--language-bar-offset', '0px');
-        document.body.style.setProperty('--language-bar-offset', '0px');
     }
 
     const params = new URLSearchParams(window.location.search);
@@ -89,16 +72,6 @@ function setupLanguageBar() {
     initLangBarToggle();
 }
 
-function applyLanguageBarOffset() {
-    const el = document.getElementById('google_translate_element');
-    const isHidden = !el || el.style.display === 'none' || getComputedStyle(el).display === 'none';
-    const offset = (!isHidden && el.offsetHeight) ? el.offsetHeight : 0;
-    document.documentElement.style.setProperty('--language-bar-offset', offset + 'px');
-    document.body.style.setProperty('--language-bar-offset', offset + 'px');
-    const extra = getComputedStyle(document.documentElement).getPropertyValue('--menu-extra-offset') || '60px';
-    document.documentElement.style.setProperty('--menu-extra-offset', extra.trim());
-    document.body.style.setProperty('--menu-extra-offset', extra.trim());
-}
 
 if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', setupLanguageBar);

--- a/tests/manual/langBarOffsetTest.js
+++ b/tests/manual/langBarOffsetTest.js
@@ -17,11 +17,12 @@ const puppeteer = require('puppeteer');
   }));
 
   const offset = bodyStyles.marginTop || bodyStyles.paddingTop;
-  if (offset !== barHeight) {
-    console.error(`Expected body offset ${offset} to equal bar height ${barHeight}`);
+  if (offset !== 0) {
+    console.error(`Expected no body offset but got ${offset}`);
+    await browser.close();
     process.exit(1);
   } else {
-    console.log('Body offset matches language bar height:', barHeight);
+    console.log('Body offset is zero as expected');
   }
   await browser.close();
 })();


### PR DESCRIPTION
## Summary
- simplify language bar toggling
- stop adjusting body padding with `--language-bar-offset`
- rely solely on `--menu-extra-offset` for consolidated menu
- update epic theme padding
- update manual test for language bar

## Testing
- `npm install`
- `node tests/manual/langBarOffsetTest.js` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68537a974ccc8329b6617791d9407d9f