### PR TITLE
Adjust menu offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Promocionar el turismo en **Cerezo de Río Tirón** y gestionar de forma activa 
 
 - Paleta en tonos púrpura y oro viejo sobre fondos de alabastro.
 - Menús deslizantes que comprimen el contenido al abrirse.
+- Menús fijos con un margen superior configurable (240px por defecto) mediante la variable `--menu-top-offset`.
 - Textos con degradados de alto contraste.
 - Foro con cinco agentes expertos para dinamizar la comunidad.
 


### PR DESCRIPTION
## Summary
- restore default header offset at 240px
- explain the offset configuration in the README

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685372af43fc83298d247e43f7020537