### PR TITLE
Adjust menu offset

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -49,7 +49,8 @@
     --global-box-shadow-dark: 0 8px 25px rgba(var(--epic-text-color-rgb), 0.2);
     --alabaster-background-image: url('/assets/img/alabastro.jpg');
     --menu-extra-offset: 60px;
-    --menu-top-offset: 0px;
+    /* Dejar un espacio superior para la barra de idioma u otros elementos */
+    --menu-top-offset: 100px;
     /* Additional theme variables for admin dashboard */
     --epic-purple-hover: #663399;
     --epic-gray: #6c757d;


### PR DESCRIPTION
## Summary
- raise the page "ceiling" by giving sliding menus a 100px top offset

## Testing
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68537d7876448329bef63716dbdd95fb