### PR TITLE
Adjust overlay opacity and menu compression

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -35,8 +35,9 @@
 
     /* Use alabaster tones for all overlay backgrounds */
     --epic-transparent-overlay-dark: rgba(var(--epic-alabaster-bg-rgb), 0.95);
-    --epic-transparent-overlay-medium: rgba(var(--epic-alabaster-bg-rgb), 0.9);
-    --epic-transparent-overlay-light: rgba(var(--epic-alabaster-bg-rgb), 0.90);
+    /* Unified 5% transparency across overlays */
+    --epic-transparent-overlay-medium: rgba(var(--epic-alabaster-bg-rgb), 0.95);
+    --epic-transparent-overlay-light: rgba(var(--epic-alabaster-bg-rgb), 0.95);
     --epic-transparent-black-overlay: rgba(10, 10, 10, 0.75);
 
     --font-primary: 'Lora', serif;
@@ -194,7 +195,8 @@ h6 { font-size: clamp(1em, 2.5vw, 1.4em); }
     background-clip: text;
     color: transparent;
     font-weight: 700;
-    text-shadow: 1px 1px 2px rgba(var(--epic-text-color-rgb), 0.25);
+    /* Stronger shadow for improved contrast */
+    text-shadow: 2px 2px 4px rgba(var(--color-negro-contraste-rgb), 0.8);
 }
 
 /* --- Paragraphs --- */

--- a/assets/css/pages/foro.css
+++ b/assets/css/pages/foro.css
@@ -1,7 +1,7 @@
 /* Page-specific styles for foro/index.php */
 body { background-color: rgba(var(--epic-alabaster-bg-rgb), 0.95); }
 .agent-profile {
-    background-color: rgba(var(--epic-alabaster-bg-rgb), 0.6);
+    background-color: rgba(var(--epic-alabaster-bg-rgb), 0.95);
     padding: 1em;
     margin: 2em 0;
     border-left: 5px solid var(--color-primario-purpura);

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -47,7 +47,8 @@
     top: 0;
     bottom: 0;
     width: 260px;
-    background: rgba(var(--epic-alabaster-bg-rgb, 253,250,246), 0.8);
+    /* Menus use purple emperor with 50% transparency */
+    background: rgba(var(--epic-purple-emperor-rgb, 74,13,103), 0.5);
     backdrop-filter: blur(6px);
     overflow-y: auto;
     transition: transform 0.3s ease;
@@ -60,7 +61,7 @@
 /* Slightly scale down the page when any slide menu is active */
 body.menu-compressed {
     transition: transform 0.3s ease;
-    transform: scale(0.97);
+    transform: scale(0.95);
 }
 
 body.menu-open-left,
@@ -68,10 +69,10 @@ body.menu-open-right {
     transition: transform 0.3s ease;
 }
 body.menu-open-left {
-    transform: translateX(260px) scale(0.97);
+    transform: translateX(260px) scale(0.95);
 }
 body.menu-open-right {
-    transform: translateX(-260px) scale(0.97);
+    transform: translateX(-260px) scale(0.95);
 }
 
 #slide-menu-right ul {


### PR DESCRIPTION
## Summary
- align overlays with 5% transparency across the theme
- strengthen gradient text contrast
- tweak sliding menu compression
- unify forum panel background
- set slide menus to 50% transparent purple emperor background

## Testing
- `composer install` *(fails: command not found)*
- `pip install -r requirements.txt`
- `php -v` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*
- `python -m unittest`
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*


------
https://chatgpt.com/codex/tasks/task_e_6853e361bbd88329b71abbd7daaa6a30