### PR TITLE
Fix responsive sliding menu

### DIFF
--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -92,3 +92,11 @@ body.menu-open-right {
     background: var(--epic-gold-main);
     color: var(--primary-purple);
 }
+
+@media (max-width: 768px) {
+  body.menu-compressed,
+  body.menu-open-left,
+  body.menu-open-right {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure body transform resets when slide menu closes on small screens

## Testing
- `python3 -m unittest`
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f45e7388832985de2148de5ba9b7