### PR TITLE
Clarify test commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Si `GEMINI_API_KEY` no está definida, las funciones de `includes/ai_utils.php` 
 
 ## Testing
 
+**Es obligatorio ejecutar los siguientes comandos antes de cualquier suite de pruebas:**
 Instala **todas** las dependencias antes de lanzar las suites de pruebas. Las pruebas dependen de PHP, Composer y las extensiones indicadas, por lo que no se ejecutarán si alguno de estos componentes falta. En particular es imprescindible tener disponible la interfaz de línea de comandos de PHP (PHP CLI). Ejecuta primero:
 
 ```bash
@@ -219,16 +220,16 @@ pruebas de PHP:
 php -v
 ```
 
-Con las dependencias ya presentes, ejecuta cada conjunto de tests de forma explícita:
+Con las dependencias ya instaladas, ejecuta cada conjunto de tests de forma explícita:
 
 ```bash
 vendor/bin/phpunit
-python -m unittest
+python -m unittest tests/test_flask_api.py
 npm run test:puppeteer
 ```
 
-`vendor/bin/phpunit` lanza las pruebas de PHP definidas en `phpunit.xml`.
-`python -m unittest` ejecuta la batería de tests de Python situada en `tests/`.
+`vendor/bin/phpunit` lanza la suite de PHP definida en `phpunit.xml`.
+`python -m unittest tests/test_flask_api.py` ejecuta el conjunto de pruebas de Python sobre la API Flask.
 `npm run test:puppeteer` inicia los checks de interfaz con Puppeteer.
 
 Además se proporcionan scripts auxiliares para validar el estado del código:


### PR DESCRIPTION
## Summary
- emphasize running `composer install` and `pip install -r requirements.txt` before running tests
- show explicit commands for PHP and Python test suites

## Testing
- `python -m unittest tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_685408a1b3fc8329993713f175ab41ac