### PR TITLE
Add forum agent doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Promocionar el turismo en **Cerezo de Río Tirón** y gestionar de forma activa 
 - Textos con degradados de alto contraste.
 - Foro con cinco agentes expertos para dinamizar la comunidad.
 
+### Agentes del foro
+
+Cinco perfiles virtuales dinamizan las conversaciones y ayudan a resolver dudas:
+
+- **Alicia la Historiadora** – especialista en la historia de Castilla y de Cerezo de Río Tirón.
+- **Bruno el Arqueólogo** – explora y protege el patrimonio arqueológico.
+- **Clara la Guía Turística** – orienta a los visitantes en sus recorridos.
+- **Diego el Gestor Cultural** – coordina eventos y dinamiza la cultura local.
+- **Elena la Tecnóloga** – aplica innovación tecnológica al servicio del patrimonio.
+
+Puedes ajustar sus biografías o añadir nuevos perfiles modificando el archivo `config/forum_agents.php`.
+
 ## Requisitos
 
 - **PHP** 7.4 o superior con soporte CLI y la extensión PDO habilitada.
@@ -291,18 +303,6 @@ Ejecuta el script `check_alt_texts.sh` para detectar imágenes sin atributo `alt
 Esta comprobación se ejecuta automáticamente en cada pull request gracias a la configuración de GitHub Actions.
 
 Puedes indicar una ruta concreta como argumento si solo quieres escanear una carpeta determinada. El comando mostrará las líneas problemáticas y devolverá un código de salida distinto de cero si encuentra imágenes sin descripción.
-
-## Foro y agentes expertos
-
-El proyecto define cinco agentes que participan en el foro para orientar las conversaciones:
-
-- **Alicia la Historiadora** – especialista en la historia de Castilla y de Cerezo de Río Tirón.
-- **Bruno el Arqueólogo** – explora y protege el patrimonio arqueológico.
-- **Clara la Guía Turística** – orienta a los visitantes en sus recorridos.
-- **Diego el Gestor Cultural** – coordina eventos y dinamiza la cultura local.
-- **Elena la Tecnóloga** – aplica innovación tecnológica al servicio del patrimonio.
-
-Para ajustar sus biografías o añadir nuevos perfiles edita el archivo `config/forum_agents.php` y actualiza el array de configuración.
 
 ## Tema predeterminado
 


### PR DESCRIPTION
## Summary
- document each of the five forum experts in README
- explain how to tweak them via `config/forum_agents.php`

## Testing
- `composer install --no-interaction --no-progress`
- `vendor/bin/phpunit` *(fails: MainMenuLinksTest, ToolsMenuLinksTest, and more)*
- `pip install -r requirements.txt`
- `python -m unittest discover tests`
- `npm install`
- `npm run test:puppeteer` *(fails to connect with puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_685408a1d8248329b0fab2590460b11b