### PR TITLE
Add polyfills for older mobile browsers

### DIFF
--- a/assets/js/polyfills.js
+++ b/assets/js/polyfills.js
@@ -1,0 +1,25 @@
+(function(){
+    function loadScript(src, callback){
+        var s = document.createElement('script');
+        s.src = src;
+        s.onload = callback || function(){};
+        document.head.appendChild(s);
+    }
+    if(!window.Promise){
+        loadScript('https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js');
+    }
+    if(!window.fetch){
+        loadScript('https://cdn.jsdelivr.net/npm/whatwg-fetch@3/dist/fetch.umd.js');
+    }
+    if(!('IntersectionObserver' in window)){
+        loadScript('https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver');
+    }
+    if(typeof HTMLDialogElement === 'undefined'){
+        loadScript('https://cdn.jsdelivr.net/npm/dialog-polyfill@0.5/dist/dialog-polyfill.min.js', function(){
+            var link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.href = 'https://cdn.jsdelivr.net/npm/dialog-polyfill@0.5/dist/dialog-polyfill.min.css';
+            document.head.appendChild(link);
+        });
+    }
+})();

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -21,3 +21,4 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-SN33kWx+ihQ/HVbUaz2QmiFjCwXTlzAIXazhbugzuDUFc1l1b/HFB70dNFuPu6j6" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" integrity="sha384-JNHB8zHcoUfOaL+5wtIg9Y9ycYzaO+F6DRKCVh0b07XHtcwPa5RWPLXrI75EetBh" crossorigin="anonymous" />
 <script defer src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js" integrity="sha384-pqaW8ZT6X0hgqP/d9vywgq6Z9erjRzCQXDpUe1koRaSPoaqe7iT730cdpShUMHbV" crossorigin="anonymous"></script>
+<script defer src="/assets/js/polyfills.js"></script>

--- a/js/layout.js
+++ b/js/layout.js
@@ -176,14 +176,28 @@ function loadPageCss() {
     if (!page) { page = 'index'; }
     page = page.split('.')[0];
     const cssPath = `/assets/css/pages/${page}.css`;
-    fetch(cssPath, { method: 'HEAD' }).then(res => {
-        if (res.ok) {
-            const link = document.createElement('link');
-            link.rel = 'stylesheet';
-            link.href = cssPath;
-            document.head.appendChild(link);
-        }
-    }).catch(() => {});
+
+    const appendCss = () => {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = cssPath;
+        document.head.appendChild(link);
+    };
+
+    if (window.fetch) {
+        fetch(cssPath, { method: 'HEAD' }).then(res => {
+            if (res.ok) appendCss();
+        }).catch(() => {});
+    } else if (XMLHttpRequest) {
+        const xhr = new XMLHttpRequest();
+        xhr.open('HEAD', cssPath, true);
+        xhr.onreadystatechange = function(){
+            if (xhr.readyState === 4 && xhr.status >= 200 && xhr.status < 400) {
+                appendCss();
+            }
+        };
+        try { xhr.send(); } catch(e) {}
+    }
 }
 
 function loadHeaderCss() {


### PR DESCRIPTION
## Summary
- add automatic polyfill loader script
- use polyfills in main head include
- make loadPageCss fallback to XMLHttpRequest

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685408c7aa488329acf855ce87c4c75c