### PR TITLE
Document forum agents config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Promocionar el turismo en **Cerezo de Río Tirón** y gestionar de forma activa 
 ## Documentación y Guías
 - [Documentación detallada](docs/README.md)
 - [Guía de Estilo](docs/style-guide.md)
+- [Guía de index.php y menús](docs/index-guide.md)
 
 
 ## Características de diseño
@@ -29,6 +30,21 @@ Cinco perfiles virtuales dinamizan las conversaciones y ayudan a resolver dudas:
 - **Elena la Tecnóloga** – aplica innovación tecnológica al servicio del patrimonio.
 
 Puedes ajustar sus biografías o añadir nuevos perfiles modificando el archivo `config/forum_agents.php`.
+
+#### Estructura del archivo
+
+```php
+return [
+    'historian' => [
+        'name' => 'Alicia la Historiadora',
+        'bio' => 'Con años de investigación tras ella, Alicia relata... ',
+        'expertise' => 'Historia medieval y orígenes de Castilla'
+    ],
+    // ...
+];
+```
+
+Consulta la [guía de index.php](docs/index-guide.md#configuracion-de-los-agentes-del-foro) para más detalles sobre cómo actualizar estos perfiles.
 
 ## Requisitos
 

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -64,3 +64,20 @@ Esto evitará que los menús se oculten tras los botones fijos.
 ### Modificar la altura del contenedor
 
 La variable `--menu-extra-offset` puede definirse también en `assets/css/epic_theme.css` o en tu propia hoja de estilos. Ajusta su valor al número de píxeles que ocupa `#fixed-header-elements` para que los paneles deslizantes queden perfectamente alineados bajo los botones.
+
+## Configuración de los agentes del foro
+
+El archivo `config/forum_agents.php` define los expertos que responden en el foro. Cada entrada del array contiene estos campos:
+
+```php
+return [
+    'historian' => [
+        'name' => 'Alicia la Historiadora',
+        'bio' => 'Con años de investigación tras ella, Alicia relata... ',
+        'expertise' => 'Historia medieval y orígenes de Castilla'
+    ],
+    // ...
+];
+```
+
+Edita sus valores o añade nuevas claves para ampliar el listado de agentes.


### PR DESCRIPTION
## Summary
- document forum agent config structure in README
- link README to index-guide documentation
- add section in docs/index-guide detailing `config/forum_agents.php`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68542e3b519c83299612c333633903aa