### PR TITLE
Update language panel variables

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -50,7 +50,7 @@
     --global-box-shadow-dark: 0 8px 25px rgba(var(--epic-text-color-rgb), 0.2);
     --alabaster-background-image: url('/assets/img/alabastro.jpg');
     --menu-extra-offset: 60px;
-    /* Altura reservada para la barra de idiomas */
+    /* Altura reservada para la barra de idiomas superior (no usada en el panel lateral) */
     --language-bar-height: 40px;
     /* Espacio superior aplicado al menú, ajustado dinámicamente */
     --menu-top-offset: 0px;

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -23,6 +23,7 @@
 /* Common styles for both sliding panels */
 .menu-panel {
     position: fixed;
+    /* Place panel below the header and language bar */
     top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
     bottom: 0; /* Make panel full height */
     width: 300px; /* Adjust width as needed */

--- a/assets/css/menus/language-panel.css
+++ b/assets/css/menus/language-panel.css
@@ -1,0 +1,40 @@
+/* assets/css/menus/language-panel.css */
+
+#language-panel {
+    position: fixed;
+    /* Align panel just below the header and optional language bar */
+    top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
+    right: 0;
+    width: 240px;
+    max-width: 80%;
+    bottom: 0;
+    background-color: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(5px);
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    padding: 15px;
+    transform: translateX(100%);
+    transition: transform 0.4s ease-in-out, opacity 0.4s ease-in-out;
+    opacity: 0;
+    z-index: 1000;
+}
+
+#language-panel.active {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+#language-panel .flag-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#language-panel .flag-list img {
+    width: 32px;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+}
+
+#language-panel .flag-list img:hover {
+    transform: scale(1.1);
+}

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -14,6 +14,7 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <link rel="stylesheet" href="/assets/css/epic_theme.css">
 <link rel="stylesheet" href="/assets/css/header.css">
 <link rel="stylesheet" href="/assets/css/sliding_menu.css">
+<link rel="stylesheet" href="/assets/css/menus/language-panel.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" integrity="sha384-JwsW+0ELqRMx9x6pRP70dNDO7xjoMnIKPQ4j/wcgUp3NE6PFcAckU4iigFsMghvY" crossorigin="anonymous">
 <link rel="stylesheet" href="/assets/css/custom.css">
 <link rel="stylesheet" href="/assets/css/lighting.css">

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
       "tailwindcss": "^3.4.4"
     },
     "scripts": {
-      "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js"
+      "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/manual/languagePanelOffsetTest.js"
     }
   }

--- a/tests/manual/languagePanelOffsetTest.js
+++ b/tests/manual/languagePanelOffsetTest.js
@@ -1,0 +1,22 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/tests/manual/test_language_panel.html');
+  await page.waitForSelector('#flag-toggle');
+  await page.click('#flag-toggle');
+  await page.waitForSelector('#language-panel.active');
+  const top = await page.$eval('#language-panel', el => getComputedStyle(el).top);
+  console.log('Panel top offset:', top);
+  await page.click('#flag-toggle');
+  await page.waitForTimeout(300);
+  const isActive = await page.evaluate(() => document.getElementById('language-panel').classList.contains('active'));
+  if (isActive) {
+    console.error('Panel did not close');
+    await browser.close();
+    process.exit(1);
+  }
+  console.log('Panel toggled correctly');
+  await browser.close();
+})();

--- a/tests/manual/test_language_panel.html
+++ b/tests/manual/test_language_panel.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <title>Test Flag Panel</title>
+    <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+    <link rel="stylesheet" href="/assets/css/menus/consolidated-menu.css">
+</head>
+<body>
+<div id="fixed-header-elements">
+    <button id="flag-toggle" data-menu-target="language-panel">Banderas</button>
+</div>
+<div id="language-panel" class="menu-panel right-panel">
+    <div class="flag-list">
+        <img src="/assets/flags/es.svg" alt="ES">
+        <img src="/assets/flags/gb.svg" alt="EN">
+    </div>
+</div>
+<script src="/assets/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document language bar variable in epic theme CSS
- ensure menu panels align beneath header
- style new language panel and include it globally
- add manual tests for language panel behaviour

## Testing
- `composer install` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `./check_links.sh`
- `./check_links_extended.sh`


------
https://chatgpt.com/codex/tasks/task_e_68542e3c15d0832994832583458a8378