### PR TITLE
Add language flag panel

### DIFF
--- a/_header.php
+++ b/_header.php
@@ -2,6 +2,7 @@
     <?php echo file_get_contents(__DIR__ . '/fragments/header/language-bar.html'); ?>
     <div class="header-action-buttons">
         <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
+        <button id="lang-panel-toggle" aria-label="Seleccionar idioma" aria-expanded="false" role="button" data-menu-target="language-panel"><i class="fas fa-flag"></i></button>
     </div>
 </div>
 
@@ -46,5 +47,16 @@
     } else {
         echo '<p>Error: AI Chat interface not found.</p>';
     }
+    ?>
+</div>
+
+<!-- Right Sliding Panel for Language Flags -->
+<div id="language-panel" class="menu-panel right-panel" role="dialog" aria-label="Selector de idioma">
+    <?php
+        if (file_exists(__DIR__ . '/fragments/header/language-flags.html')) {
+            echo file_get_contents(__DIR__ . '/fragments/header/language-flags.html');
+        } else {
+            echo '<p>Error: Language flags not found.</p>';
+        }
     ?>
 </div>

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -7,3 +7,4 @@
 @import url('menus/homonexus.css');
 @import url('menus/consolidated-menu.css');
 @import url('header/ia-chat.css');
+@import url('language-panel.css');

--- a/assets/css/language-panel.css
+++ b/assets/css/language-panel.css
@@ -1,0 +1,54 @@
+#language-panel {
+    right: 0;
+    transform: translateX(100%);
+    background-color: rgba(var(--epic-alabaster-bg-rgb), 0.95);
+    border-left: 2px solid var(--epic-gold-secondary);
+    box-shadow: -3px 0 15px rgba(var(--epic-purple-emperor-rgb), 0.4);
+}
+
+#language-panel.active {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+.language-flag-container {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}
+
+.language-flag-container .flag-options {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.language-flag-container img {
+    width: 40px;
+    cursor: pointer;
+    border: 2px solid var(--epic-gold-main);
+    border-radius: var(--global-border-radius);
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.language-flag-container img:hover {
+    transform: scale(1.1);
+    border-color: var(--epic-purple-emperor);
+}
+
+#close-language-panel {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: none;
+    border: none;
+    font-size: 1.4rem;
+    color: var(--epic-purple-emperor);
+    cursor: pointer;
+}
+
+#close-language-panel:hover {
+    color: var(--epic-gold-main);
+}

--- a/fragments/header/language-flags.html
+++ b/fragments/header/language-flags.html
@@ -1,0 +1,8 @@
+<div class="language-flag-container">
+    <button id="close-language-panel" aria-label="Cerrar panel de idiomas">&times;</button>
+    <div class="flag-options">
+        <img src="/assets/flags/es.svg" alt="Español" data-lang="es">
+        <img src="/assets/flags/gb.svg" alt="English" data-lang="en">
+        <img src="/assets/flags/gl.svg" alt="Galego" data-lang="gl">
+    </div>
+</div>

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -13,6 +13,7 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 <link rel="stylesheet" href="/assets/css/epic_theme.css">
 <link rel="stylesheet" href="/assets/css/header.css">
+<link rel="stylesheet" href="/assets/css/language-panel.css">
 <link rel="stylesheet" href="/assets/css/sliding_menu.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" integrity="sha384-JwsW+0ELqRMx9x6pRP70dNDO7xjoMnIKPQ4j/wcgUp3NE6PFcAckU4iigFsMghvY" crossorigin="anonymous">
 <link rel="stylesheet" href="/assets/css/custom.css">

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -71,8 +71,34 @@ function initLangBarToggle() {
     }
 }
 
+function toggleLanguagePanel() {
+    const panel = document.getElementById('language-panel');
+    if (!panel) return;
+    const open = panel.classList.toggle('active');
+    document.body.classList.toggle('menu-open-right', open);
+    document.body.classList.toggle('menu-compressed', open);
+    const btn = document.getElementById('lang-panel-toggle');
+    if (btn) btn.setAttribute('aria-expanded', open);
+}
+
+function initFlagPanel() {
+    const toggleBtn = document.getElementById('lang-panel-toggle');
+    const closeBtn = document.getElementById('close-language-panel');
+    if (toggleBtn) toggleBtn.addEventListener('click', toggleLanguagePanel);
+    if (closeBtn) closeBtn.addEventListener('click', toggleLanguagePanel);
+    document.querySelectorAll('#language-panel img[data-lang]').forEach(img => {
+        img.addEventListener('click', () => {
+            const lang = img.getAttribute('data-lang');
+            const params = new URLSearchParams(window.location.search);
+            params.set('lang', lang);
+            window.location.search = params.toString();
+        });
+    });
+}
+
 function setupLanguageBar() {
     initLangBarToggle();
+    initFlagPanel();
 }
 
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
       "tailwindcss": "^3.4.4"
     },
     "scripts": {
-      "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js"
+      "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/flagPanelToggleTest.js"
     }
   }

--- a/tests/flagPanelToggleTest.js
+++ b/tests/flagPanelToggleTest.js
@@ -1,0 +1,26 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/index.php');
+  await page.waitForSelector('#lang-panel-toggle');
+  await page.click('#lang-panel-toggle');
+  await page.waitForTimeout(500);
+  const hasClass = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
+  if (!hasClass) {
+    console.error('menu-open-right class not added');
+    await browser.close();
+    process.exit(1);
+  }
+  await page.click('#close-language-panel');
+  await page.waitForTimeout(500);
+  const stillHasClass = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
+  if (stillHasClass) {
+    console.error('menu-open-right class not removed');
+    await browser.close();
+    process.exit(1);
+  }
+  console.log('Language panel body class toggled correctly');
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- add a sliding panel with flags for language selection
- style the new panel with purple and old-gold accents
- include panel in the header and load its stylesheet
- update language script to control new panel and flag clicks
- add a Puppeteer test to check body class toggle

## Testing
- `npm install`
- `npm run test:puppeteer` *(fails: ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68542e3e1e6c8329a7c3b907a3747252