### PR TITLE
Add sliding language panel

### DIFF
--- a/_header.php
+++ b/_header.php
@@ -2,6 +2,7 @@
     <?php echo file_get_contents(__DIR__ . '/fragments/header/language-bar.html'); ?>
     <div class="header-action-buttons">
         <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
+        <button id="flag-toggle" aria-label="Seleccionar idioma" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>
     </div>
 </div>
 
@@ -48,3 +49,12 @@
     }
     ?>
 </div>
+
+<!-- Right Sliding Panel for Language Flags -->
+<?php
+    if (file_exists(__DIR__ . '/fragments/header/language-flags.html')) {
+        echo file_get_contents(__DIR__ . '/fragments/header/language-flags.html');
+    } else {
+        echo '<div id="language-panel" class="menu-panel right-panel"><p>Flags not found.</p></div>';
+    }
+?>

--- a/assets/css/language-panel.css
+++ b/assets/css/language-panel.css
@@ -1,0 +1,59 @@
+#language-panel {
+    position: fixed;
+    top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
+    right: 0;
+    bottom: 0;
+    width: 260px;
+    max-width: 80%;
+    background: rgba(var(--epic-alabaster-bg-rgb, 253,250,246), 0.95);
+    border-left: 2px solid var(--epic-gold-main);
+    box-shadow: -3px 0 15px rgba(var(--epic-purple-emperor-rgb, 74,13,103), 0.3);
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    transform: translateX(100%);
+    opacity: 0;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+    z-index: 1000;
+}
+
+#language-panel.active {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+#language-panel .flag-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+#language-panel .flag-list img {
+    width: 40px;
+    cursor: pointer;
+    filter: drop-shadow(0 0 3px rgba(var(--epic-purple-emperor-rgb,74,13,103),0.4));
+    transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+#language-panel .flag-list img:hover {
+    transform: scale(1.1);
+    filter: drop-shadow(0 0 6px var(--epic-gold-main));
+}
+
+#flag-toggle {
+    margin-top: 100px;
+    z-index: 1005;
+    padding: 8px 12px;
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1.1em;
+    transition: background-color 0.3s ease;
+}
+
+#flag-toggle:hover {
+    background-color: var(--epic-purple-emperor);
+    color: var(--epic-gold-main);
+}

--- a/fragments/header/language-flags.html
+++ b/fragments/header/language-flags.html
@@ -1,0 +1,7 @@
+<div id="language-panel" class="menu-panel right-panel">
+    <div class="flag-list">
+        <img src="/assets/flags/es.svg" alt="Español" data-lang="es">
+        <img src="/assets/flags/gb.svg" alt="English" data-lang="en">
+        <img src="/assets/flags/gl.svg" alt="Galego" data-lang="gl">
+    </div>
+</div>

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -14,7 +14,7 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <link rel="stylesheet" href="/assets/css/epic_theme.css">
 <link rel="stylesheet" href="/assets/css/header.css">
 <link rel="stylesheet" href="/assets/css/sliding_menu.css">
-<link rel="stylesheet" href="/assets/css/menus/language-panel.css">
+<link rel="stylesheet" href="/assets/css/language-panel.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" integrity="sha384-JwsW+0ELqRMx9x6pRP70dNDO7xjoMnIKPQ4j/wcgUp3NE6PFcAckU4iigFsMghvY" crossorigin="anonymous">
 <link rel="stylesheet" href="/assets/css/custom.css">
 <link rel="stylesheet" href="/assets/css/lighting.css">

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -26,7 +26,6 @@ function toggleLanguageBar() {
 
     const isHidden = el.style.display === 'none' || getComputedStyle(el).display === 'none';
 
-
     if (isHidden) {
         const showBar = () => {
             el.style.display = 'block';
@@ -42,6 +41,38 @@ function toggleLanguageBar() {
         el.style.display = 'none';
         body.classList.remove('lang-bar-visible');
     }
+}
+
+function toggleFlagPanel() {
+    const panel = document.getElementById('language-panel');
+    const btn = document.getElementById('flag-toggle');
+    if (!panel) return;
+    const open = panel.classList.toggle('active');
+    if (btn) btn.setAttribute('aria-expanded', open);
+    document.body.classList.toggle('menu-open-right', open);
+    document.body.classList.toggle('menu-compressed', open);
+}
+
+function initFlagPanel() {
+    const btn = document.getElementById('flag-toggle');
+    if (btn) {
+        btn.addEventListener('click', toggleFlagPanel);
+    }
+    document.querySelectorAll('#language-panel img[data-lang]').forEach(flag => {
+        flag.addEventListener('click', () => {
+            const lang = flag.getAttribute('data-lang');
+            const translate = () => {
+                document.cookie = 'googtrans=/es/' + lang + ';path=/';
+                location.reload();
+            };
+            if (!window.googleTranslateLoaded) {
+                loadGoogleTranslate(translate);
+                window.googleTranslateLoaded = true;
+            } else {
+                translate();
+            }
+        });
+    });
 }
 
 function initLangBarToggle() {
@@ -73,6 +104,7 @@ function initLangBarToggle() {
 
 function setupLanguageBar() {
     initLangBarToggle();
+    initFlagPanel();
 }
 
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
       "tailwindcss": "^3.4.4"
     },
     "scripts": {
-      "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/manual/languagePanelOffsetTest.js"
+      "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js"
     }
   }

--- a/tests/languagePanelBodyClassTest.js
+++ b/tests/languagePanelBodyClassTest.js
@@ -1,0 +1,26 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/tests/manual/test_language_panel.html');
+  await page.waitForSelector('#flag-toggle');
+  await page.click('#flag-toggle');
+  await page.waitForTimeout(300);
+  const hasClass = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
+  if (!hasClass) {
+    console.error('menu-open-right not added');
+    await browser.close();
+    process.exit(1);
+  }
+  await page.click('#flag-toggle');
+  await page.waitForTimeout(300);
+  const stillHas = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
+  if (stillHas) {
+    console.error('menu-open-right not removed');
+    await browser.close();
+    process.exit(1);
+  }
+  console.log('Language panel body class toggled correctly');
+  await browser.close();
+})();

--- a/tests/manual/test_language_panel.html
+++ b/tests/manual/test_language_panel.html
@@ -7,14 +7,14 @@
 </head>
 <body>
 <div id="fixed-header-elements">
-    <button id="flag-toggle" data-menu-target="language-panel">Banderas</button>
+    <button id="flag-toggle">Banderas</button>
 </div>
 <div id="language-panel" class="menu-panel right-panel">
     <div class="flag-list">
-        <img src="/assets/flags/es.svg" alt="ES">
-        <img src="/assets/flags/gb.svg" alt="EN">
+        <img src="/assets/flags/es.svg" alt="ES" data-lang="es">
+        <img src="/assets/flags/gb.svg" alt="EN" data-lang="en">
     </div>
 </div>
-<script src="/assets/js/main.js"></script>
+<script src="/js/lang-bar.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable language selector button in header
- implement sliding language panel with flag icons
- style the panel using alabaster, purple and old-gold colours
- load and toggle Google Translate for each flag
- add Puppeteer test for menu-open-right class

## Testing
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685431707eb483298ed6915980bc83d5