### PR TITLE
Fix top menus layout

### DIFF
--- a/assets/css/language-panel.css
+++ b/assets/css/language-panel.css
@@ -41,7 +41,7 @@
 }
 
 #flag-toggle {
-    margin-top: 100px;
+    margin-top: 0; /* Align button with top header */
     z-index: 1005;
     padding: 8px 12px;
     background-color: var(--epic-gold-main);

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -3,7 +3,7 @@
 /* Main toggle button for the consolidated menu */
 #consolidated-menu-button {
     position: relative !important;
-    margin-top: 100px; /* Move menu button 100px down */
+    margin-top: 0; /* Align button with top header */
     z-index: 1005 !important; /* keep above menu */
     padding: 8px 12px; /* Slightly more compact */
     background-color: var(--epic-gold-main);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -15,12 +15,22 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!targetId) return;
         const menu = document.getElementById(targetId);
         if (!menu) return;
+
+        // Close any other active menus to avoid overlap
+        document.querySelectorAll('.menu-panel.active').forEach(m => {
+            if (m !== menu) closeMenu(m);
+        });
+
         const side = menu.classList.contains('left-panel') ? 'left'
                     : (menu.classList.contains('right-panel') ? 'right' : '');
-        const open = menu.classList.toggle('active');
+        const open = !menu.classList.contains('active');
+        menu.classList.toggle('active', open);
         btn.setAttribute('aria-expanded', open);
         if (side) document.body.classList.toggle(`menu-open-${side}`, open);
-        document.body.classList.toggle('menu-compressed', open);
+
+        const anyOpen = document.querySelectorAll('.menu-panel.active').length > 0;
+        document.body.classList.toggle('menu-compressed', anyOpen);
+
         if (open && menu.id === 'ai-chat-panel') {
             const chatArea = document.getElementById('gemini-chat-area');
             if (chatArea) {


### PR DESCRIPTION
## Summary
- keep menu toggles aligned with the top header
- avoid overlapping slide menus when opening them

## Testing
- `python -m unittest tests/test_flask_api.py`
- `composer install` *(fails: command not found)*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*


------
https://chatgpt.com/codex/tasks/task_e_685433728cf88329bb87b34f502a40c3