### PR TITLE
Remove unused lang-bar toggle

### DIFF
--- a/_header.php
+++ b/_header.php
@@ -10,7 +10,6 @@
 <div id="consolidated-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="consolidated-menu-button">
     <button id="ai-chat-trigger" class="menu-item-button" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA"><i class="fas fa-comments"></i> <span>Chat IA</span></button>
     <button id="theme-toggle" class="menu-item-button" aria-label="Cambiar tema"><i class="fas fa-moon"></i> <span>Modo</span></button>
-    <button id="lang-bar-toggle" class="menu-item-button" aria-label="Mostrar u ocultar traducción"><i class="fas fa-globe"></i> <span>Idiomas</span></button>
 
     <div class="menu-section">
         <h4 class="gradient-text">Navegación Principal</h4>

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -48,7 +48,6 @@ Estos son los accesos que incorpora por defecto:
 - `#consolidated-menu-button` abre el panel lateral con toda la navegación.
 - `#ai-chat-trigger` para iniciar el chat desde el menú.
 - `#theme-toggle` alterna entre modo claro y oscuro.
-- `#lang-bar-toggle` despliega la barra de traducción de Google.
 
 Al añadir más elementos al contenedor puede ser necesario ajustar la posición de los paneles deslizantes. Para ello define la variable `--menu-extra-offset` con la altura del contenedor y úsala junto a `--language-bar-offset` en `assets/css/menus/consolidated-menu.css`:
 ```css

--- a/tests/FixedHeaderElementsTest.php
+++ b/tests/FixedHeaderElementsTest.php
@@ -47,7 +47,6 @@ class FixedHeaderElementsTest extends TestCase {
         $this->assertStringContainsString('id="consolidated-menu-button"', $content);
         $this->assertStringContainsString('id="ai-chat-trigger"', $content);
         $this->assertStringContainsString('id="theme-toggle"', $content);
-        $this->assertStringContainsString('id="lang-bar-toggle"', $content);
     }
 }
 ?>

--- a/tests/manual/langBarOffsetTest.js
+++ b/tests/manual/langBarOffsetTest.js
@@ -4,8 +4,8 @@ const puppeteer = require('puppeteer');
   const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/tests/manual/test_lang.html');
-  await page.waitForSelector('#lang-bar-toggle');
-  await page.click('#lang-bar-toggle');
+  await page.waitForSelector('#flag-toggle');
+  await page.click('#flag-toggle');
   await page.waitForSelector('#google_translate_element', {visible: true});
   // give time for height calculation
   await page.waitForTimeout(500);

--- a/tests/manual/test_lang.html
+++ b/tests/manual/test_lang.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <div id="google_translate_element"></div>
-<button id="lang-bar-toggle">Traducir</button>
+<button id="flag-toggle">Traducir</button>
 <p id="text">Hola Mundo</p>
 <script src="/js/lang-bar.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- drop deprecated `#lang-bar-toggle` button from header
- update docs to match removed ID
- adjust test expectations for header elements
- update manual tests to use `#flag-toggle` instead

## Testing
- `./vendor/bin/phpunit` *(fails: could not find driver)*
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68543e8e6a188329be3011981649f9d8