### PR TITLE
Add crawler and graph DB docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,5 @@ Para otras referencias, visita también:
 - [Guía de index.php y menús](index-guide.md)
 - [Resumen de módulos JavaScript](js-modules-overview.md)
 - [Guía de Estilo](style-guide.md)
+- [Documentación del crawler](crawler.md)
+- [Interfaz de la base de datos de grafo](graph_db.md)

--- a/docs/crawler.md
+++ b/docs/crawler.md
@@ -1,0 +1,24 @@
+# Crawler
+
+Esta página describe el pequeño crawler incluido en `crawler.py`. Su objetivo principal es recorrer páginas de manera controlada y extraer enlaces para poblar la base de datos de conocimiento. Actualmente el código ofrece una versión de demostración.
+
+## ¿Qué hace `crawler.py`?
+- Simula la descarga de páginas web mediante `fetch_page`. Por ahora sólo responde con HTML predeterminado para `http://example.com` y `/another-page`.
+- Analiza el contenido con BeautifulSoup a través de `parse_html` para obtener el título y todos los enlaces válidos.
+- Genera un diccionario `web_resource_data` que almacena la URL, un identificador único y la fecha de rastreo.
+- Devuelve también una lista de enlaces como `links_data`, cada uno con su propio identificador.
+
+Este módulo es un punto de partida para construir un rastreador más completo. En el futuro puede integrarse con comprobaciones de `robots.txt`, manejo de errores HTTP o almacenamiento directo en la base de datos de grafo.
+
+## Uso básico
+1. Instala las dependencias necesarias (ver `requirements.txt`).
+2. Ejecuta el script directamente para probar con `example.com`:
+
+```bash
+python crawler.py
+```
+
+El resultado mostrará ejemplos de `WebResource` y de enlaces extraídos.
+
+## Relación con el proyecto
+El rastreador sirve para recopilar información de diferentes páginas relacionadas con Cerezo de Río Tirón. Los datos generados pueden almacenarse en la base `knowledge_graph_db.json` mediante `graph_db_interface.py`.

--- a/docs/graph_db.md
+++ b/docs/graph_db.md
@@ -1,0 +1,65 @@
+# Base de datos de grafo
+
+`graph_db_interface.py` implementa una interfaz sencilla para almacenar recursos web y enlaces en formato JSON. El archivo de persistencia predeterminado es `knowledge_graph_db.json`.
+
+## Características principales
+- Guarda nodos (recursos) en un diccionario donde la clave es la URL. Cada nodo incluye un `id`, la fecha de rastreo y campos de contenido o metadatos.
+- Los enlaces se almacenan como una lista de diccionarios con `source_url`, `target_url` y un identificador propio.
+- Al agregar enlaces se crean recursos "placeholder" si la fuente o destino no existen aún.
+- Todos los cambios se guardan automáticamente en `knowledge_graph_db.json` para conservar el estado entre ejecuciones.
+
+## Estructura de `knowledge_graph_db.json`
+El archivo contiene dos claves principales:
+
+```json
+{
+  "nodes": {
+    "http://example.com": {
+      "id": "...",
+      "url": "http://example.com",
+      "content": "Texto o título",
+      "last_crawled_at": "fecha ISO",
+      "metadata": {"title": "Example Domain"}
+    }
+  },
+  "edges": [
+    {
+      "id": "...",
+      "source_url": "http://example.com",
+      "target_url": "http://www.iana.org/domains/example",
+      "anchor_text": "More information...",
+      "created_at": "fecha ISO",
+      "source_resource_id": "...",
+      "target_resource_id": "..."
+    }
+  ]
+}
+```
+
+## Uso básico
+1. Instancia la clase en tu aplicación:
+
+```python
+from graph_db_interface import GraphDBInterface
+
+db = GraphDBInterface()
+```
+
+2. Añade recursos o enlaces:
+
+```python
+resource = {"url": "http://example.com", "content": "Example"}
+db.add_or_update_resource(resource)
+
+link = {"source_url": "http://example.com", "target_url": "http://example.net", "anchor_text": "Ejemplo"}
+db.add_link(link)
+```
+
+3. Consulta la base de datos:
+
+```python
+all_resources = db.get_all_resources()
+all_links = db.get_all_links()
+```
+
+Esta herramienta sirve de apoyo para organizar la información relacionada con Cerezo de Río Tirón y facilitar su análisis dentro del proyecto de promoción turística y gestión patrimonial.

--- a/docs/tareas.md
+++ b/docs/tareas.md
@@ -5,6 +5,6 @@
 - [x] Crear un foro con cinco agentes expertos que dinamicen la comunidad.
 
 ## Nuevas tareas
-- [ ] Documentar el crawler y la base de datos de grafo de conocimiento.
+ - [x] Documentar el crawler y la base de datos de grafo de conocimiento.
 - [ ] Revisar la accesibilidad y el rendimiento en dispositivos móviles.
 - [ ] Integrar el modo Homonexus y el chat IA en todas las páginas.


### PR DESCRIPTION
## Summary
- document `crawler.py` basic behavior
- document `graph_db_interface.py` and JSON storage
- reference the docs from the index
- mark the crawler documentation task done

## Testing
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68543fe3ae608329af143fa76d48bab0