### PR TITLE
Add load_page_css function

### DIFF
--- a/alfoz/alfoz.php
+++ b/alfoz/alfoz.php
@@ -17,7 +17,10 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 
 
     <?php include __DIR__ . '/../includes/head_common.php'; ?>
-    <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+    <?php
+    require_once __DIR__ . '/../includes/load_page_css.php';
+    load_page_css();
+    ?>
 </head>
 <body>
 

--- a/alfoz/indexalfoz.php
+++ b/alfoz/indexalfoz.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+<?php
+require_once __DIR__ . '/../includes/load_page_css.php';
+load_page_css();
+?>
 </head>
 <body>
     <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/camino_santiago/camino_santiago.php
+++ b/camino_santiago/camino_santiago.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+<?php
+require_once __DIR__ . '/../includes/load_page_css.php';
+load_page_css();
+?>
 </head>
 <body>
 

--- a/contacto/contacto.php
+++ b/contacto/contacto.php
@@ -17,7 +17,10 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 
 
     <?php include __DIR__ . '/../includes/head_common.php'; ?>
-    <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+    <?php
+    require_once __DIR__ . '/../includes/load_page_css.php';
+    load_page_css();
+    ?>
 </head>
 <body>
 

--- a/cultura/cultura.php
+++ b/cultura/cultura.php
@@ -17,7 +17,10 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 
 
     <?php include __DIR__ . '/../includes/head_common.php'; ?>
-    <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+    <?php
+    require_once __DIR__ . '/../includes/load_page_css.php';
+    load_page_css();
+    ?>
 </head>
 <body>
 

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -47,7 +47,10 @@ if (is_dir($gallery_dir)) {
     <title>Galería Colaborativa - Condado de Castilla</title>
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
 
-    <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+    <?php
+    require_once __DIR__ . '/../includes/load_page_css.php';
+    load_page_css();
+    ?>
 </head>
 <body class="alabaster-bg">
     <div id="linterna-condado"></div> <!-- Para el efecto de linterna -->

--- a/historia/galeria_historica/index.php
+++ b/historia/galeria_historica/index.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../../includes/load_page_css.php'; ?>
+<?php
+require_once __DIR__ . '/../../includes/load_page_css.php';
+load_page_css();
+?>
 </head>
 <body>
 

--- a/historia/subpaginas/alcazar_de_cerasio.php
+++ b/historia/subpaginas/alcazar_de_cerasio.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>El Alcázar de Cerasio: Fortaleza de Castilla</title>
 </head>
 <body>

--- a/historia/subpaginas/alfoz_cerezo_lantaron.php
+++ b/historia/subpaginas/alfoz_cerezo_lantaron.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>El Alfoz de Cerezo y Lantarón: Territorio Histórico</title>
 </head>
 <body>

--- a/historia/subpaginas/auca_patricia_ubicacion.php
+++ b/historia/subpaginas/auca_patricia_ubicacion.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title><?php echo htmlspecialchars($titulo_pagina_actual); ?> - Cerezo de Río Tirón</title>
 </head>
 <body>

--- a/historia/subpaginas/becerro_galicano_origen_castilla.php
+++ b/historia/subpaginas/becerro_galicano_origen_castilla.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>El Becerro Galicano y el Origen de Castilla en Auca</title>
 </head>
 <body>

--- a/historia/subpaginas/condes_castilla_alava_cerasio.php
+++ b/historia/subpaginas/condes_castilla_alava_cerasio.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Condes de Castilla y Álava en el Alcázar de Cerasio</title>
 </head>
 <body>

--- a/historia/subpaginas/evidencia_arqueologica_cerezo.php
+++ b/historia/subpaginas/evidencia_arqueologica_cerezo.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Evidencia Arqueológica en Cerezo de Río Tirón</title>
 </head>
 <body>

--- a/historia/subpaginas/legado_romano_emperadores_estructuras.php
+++ b/historia/subpaginas/legado_romano_emperadores_estructuras.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Legado Romano en Cerezo: Emperadores y Estructuras</title>
 </head>
 <body>

--- a/historia/subpaginas/obispado_auca_cerezo.php
+++ b/historia/subpaginas/obispado_auca_cerezo.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>El Obispado de Auca en Cerezo de Río Tirón</title>
 </head>
 <body>

--- a/historia/subpaginas/obispado_oca_auca.php
+++ b/historia/subpaginas/obispado_oca_auca.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>El Obispado de Oca/Auca y su Papel en la Historia</title>
 </head>
 <body>

--- a/historia/subpaginas/origenes_castellano_vulgar.php
+++ b/historia/subpaginas/origenes_castellano_vulgar.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Orígenes del Castellano Vulgar en el Alfoz de Cerezo</title>
 </head>
 <body>

--- a/historia/subpaginas/san_vitores_san_formerio.php
+++ b/historia/subpaginas/san_vitores_san_formerio.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>San Vitores y San Formerio: Mártires de Cerezo</title>
 </head>
 <body>

--- a/historia/subpaginas_indice.php
+++ b/historia/subpaginas_indice.php
@@ -23,7 +23,10 @@ $temas_detallados = $page_data['temas_detallados'] ?? [];
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+<?php
+require_once __DIR__ . '/../includes/load_page_css.php';
+load_page_css();
+?>
     <title><?php echo htmlspecialchars($titulo_pagina); ?> - Cerezo de Río Tirón</title>
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
     <!-- Google Fonts, FontAwesome, and epic_theme.css are now in head_common.php -->

--- a/historia_cerezo/capitulo1/capitulo1.php
+++ b/historia_cerezo/capitulo1/capitulo1.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Capítulo 1: Auca Patricia, la Ciudad Perdida</title>
 </head>
 <body>

--- a/historia_cerezo/capitulo10.php
+++ b/historia_cerezo/capitulo10.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Capítulo 10: Cerezo en la Edad Moderna (Siglos XVI-XVIII): Entre la Tradición y las Nuevas Corrientes</title>
 </head>
 <body>

--- a/historia_cerezo/capitulo11.php
+++ b/historia_cerezo/capitulo11.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Capítulo 11: Cerezo en la Edad Contemporánea (Siglos XIX-XXI): Desafíos, Transformaciones y Mirada al Futuro</title>
 </head>
 <body>

--- a/historia_cerezo/capitulo2/capitulo2.php
+++ b/historia_cerezo/capitulo2/capitulo2.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Capítulo 2: El Alcázar de Cerasio y los Inicios de Castilla</title>
 </head>
 <body>

--- a/historia_cerezo/capitulo3/capitulo3.php
+++ b/historia_cerezo/capitulo3/capitulo3.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Capítulo 3: Vestigios y Legado en Cerezo de Río Tirón</title>
 </head>
 <body>

--- a/historia_cerezo/capitulo4/capitulo4.php
+++ b/historia_cerezo/capitulo4/capitulo4.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Capítulo 4: Interpretaciones y Debate Histórico (Trazas Cruzadas)</title>
 </head>
 <body>

--- a/historia_cerezo/capitulo5.php
+++ b/historia_cerezo/capitulo5.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Capítulo 5: Cerezo en la Alta Edad Media: Entre Condes y Reyes</title>
 </head>
 <body>

--- a/historia_cerezo/capitulo6.php
+++ b/historia_cerezo/capitulo6.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Capítulo 6: La Vida Cotidiana en Cerasio: Siglos VIII-XI</title>
 </head>
 <body>

--- a/historia_cerezo/capitulo7.php
+++ b/historia_cerezo/capitulo7.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Capítulo 7: Las Huellas de Roma y el Mundo Prerromano en la Comarca de Cerezo</title>
 </head>
 <body>

--- a/historia_cerezo/capitulo8.php
+++ b/historia_cerezo/capitulo8.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Capítulo 8: Mitos Fundacionales y Leyendas de la Vieja Castilla en Cerezo</title>
 </head>
 <body>

--- a/historia_cerezo/capitulo9.php
+++ b/historia_cerezo/capitulo9.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Capítulo 9: Cerezo en la Plena y Baja Edad Media (Siglos XII-XV): Entre el Esplendor y la Crisis</title>
 </head>
 <body>

--- a/historia_cerezo/entidades/fuentes/becerro_galicano_auca.php
+++ b/historia_cerezo/entidades/fuentes/becerro_galicano_auca.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>El Becerro Galicano y la Mención de Auca/Area Paterniani</title>
 </head>
 <body>

--- a/historia_cerezo/entidades/lugares/alcazar_de_cerasio.php
+++ b/historia_cerezo/entidades/lugares/alcazar_de_cerasio.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>El Alcázar de Cerasio</title>
 </head>
 <body>

--- a/historia_cerezo/entidades/personajes/conde_casio.php
+++ b/historia_cerezo/entidades/personajes/conde_casio.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>El Conde Casio</title>
 </head>
 <body>

--- a/historia_cerezo/index.php
+++ b/historia_cerezo/index.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Historia de Cerezo: Cuna y Origen de Castilla</title>
 </head>
 <body>

--- a/historia_cerezo/indices/lugares.php
+++ b/historia_cerezo/indices/lugares.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Índice de Lugares - Historia de Cerezo</title>
 </head>
 <body>

--- a/historia_cerezo/indices/personajes.php
+++ b/historia_cerezo/indices/personajes.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Índice de Personajes - Historia de Cerezo</title>
 </head>
 <body>

--- a/historia_cerezo/indices/temas_clave.php
+++ b/historia_cerezo/indices/temas_clave.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
     <?php include __DIR__ . "/../../includes/head_common.php"; ?>
-    <?php require_once __DIR__ . "/../../includes/load_page_css.php"; ?>
+    <?php
+    require_once __DIR__ . "/../../includes/load_page_css.php";
+    load_page_css();
+    ?>
     <title>Índice de Temas Clave - Historia de Cerezo</title>
 </head>
 <body>

--- a/includes/load_page_css.php
+++ b/includes/load_page_css.php
@@ -1,18 +1,21 @@
 <?php
-$scriptPath = $_SERVER['SCRIPT_NAME'];
-$root = dirname(__DIR__);
+function load_page_css(): void
+{
+    $scriptPath = $_SERVER['SCRIPT_NAME'];
+    $root = dirname(__DIR__);
 
-// Allow CSS files that mirror the script path using underscores
-$sanitized = str_replace('/', '_', ltrim($scriptPath, '/'));
-$sanitized = preg_replace('/\.php$/', '', $sanitized);
-$cssFile = '/assets/css/pages/' . $sanitized . '.css';
+    // Allow CSS files that mirror the script path using underscores
+    $sanitized = str_replace('/', '_', ltrim($scriptPath, '/'));
+    $sanitized = preg_replace('/\.php$/', '', $sanitized);
+    $cssFile = '/assets/css/pages/' . $sanitized . '.css';
 
-if (!file_exists($root . $cssFile)) {
-    // Fallback to using only the basename for backwards compatibility
-    $cssFile = '/assets/css/pages/' . basename($scriptPath, '.php') . '.css';
-}
+    if (!file_exists($root . $cssFile)) {
+        // Fallback to using only the basename for backwards compatibility
+        $cssFile = '/assets/css/pages/' . basename($scriptPath, '.php') . '.css';
+    }
 
-if (file_exists($root . $cssFile)) {
-    echo "<link rel=\"stylesheet\" href=\"{$cssFile}\">\n";
+    if (file_exists($root . $cssFile)) {
+        echo "<link rel=\"stylesheet\" href=\"{$cssFile}\">\n";
+    }
 }
 ?>

--- a/index.php
+++ b/index.php
@@ -15,7 +15,10 @@ require_once __DIR__ . '/includes/homonexus.php';?><!DOCTYPE html>
 <head>
     <title>Condado de Castilla - Cuna de tu Cultura y Lengua</title>
     <?php include __DIR__ . '/includes/head_common.php'; ?>
-    <?php require_once __DIR__ . '/includes/load_page_css.php'; ?>
+    <?php
+    require_once __DIR__ . '/includes/load_page_css.php';
+    load_page_css();
+    ?>
 
 </head>
 <body class="<?php echo homonexus_body_class(); ?>">

--- a/tienda/index.php
+++ b/tienda/index.php
@@ -8,7 +8,10 @@ require_once __DIR__ . '/../includes/auth.php';
 <head>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <title>Tienda</title>
-    <?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+    <?php
+    require_once __DIR__ . '/../includes/load_page_css.php';
+    load_page_css();
+    ?>
 </head>
 <body class="alabaster-bg">
 <?php require_once __DIR__ . '/../_header.php'; ?>

--- a/visitas/visitas.php
+++ b/visitas/visitas.php
@@ -2,7 +2,10 @@
 <html lang="es">
 <head>
 <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-<?php require_once __DIR__ . '/../includes/load_page_css.php'; ?>
+<?php
+require_once __DIR__ . '/../includes/load_page_css.php';
+load_page_css();
+?>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- expose `load_page_css()` helper
- call `load_page_css()` after requiring script on pages

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml`
- `bash scripts/setup_frontend_libs.sh`
- `vendor/bin/phpunit` *(fails: missing PHP extensions)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68543fdf50c083299c1a9772eac63563