### PR TITLE
Fix language panel toggle

### DIFF
--- a/_header.php
+++ b/_header.php
@@ -1,7 +1,7 @@
 <div id="fixed-header-elements">
     <div class="header-action-buttons">
         <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
-        <button id="flag-toggle" aria-label="Seleccionar idioma" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>
+        <button id="flag-toggle" data-menu-target="language-panel" aria-label="Seleccionar idioma" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>
     </div>
 </div>
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -27,6 +27,9 @@ document.addEventListener('DOMContentLoaded', () => {
         menu.classList.toggle('active', open);
         btn.setAttribute('aria-expanded', open);
         if (side) document.body.classList.toggle(`menu-open-${side}`, open);
+        if (open && menu.id === 'language-panel' && typeof primeTranslateLoad === 'function') {
+            primeTranslateLoad();
+        }
 
         const anyOpen = document.querySelectorAll('.menu-panel.active').length > 0;
         document.body.classList.toggle('menu-compressed', anyOpen);

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -20,24 +20,18 @@ function loadGoogleTranslate(callback) {
 }
 
 
-function toggleFlagPanel() {
-    const panel = document.getElementById('language-panel');
-    const btn = document.getElementById('flag-toggle');
-    if (!panel) return;
-    const open = panel.classList.toggle('active');
-    if (open && !window.googleTranslateLoaded) {
+
+function primeTranslateLoad() {
+    if (!window.googleTranslateLoaded) {
         loadGoogleTranslate();
         window.googleTranslateLoaded = true;
     }
-    if (btn) btn.setAttribute('aria-expanded', open);
-    document.body.classList.toggle('menu-open-right', open);
-    document.body.classList.toggle('menu-compressed', open);
 }
 
 function initFlagPanel() {
     const btn = document.getElementById('flag-toggle');
     if (btn) {
-        btn.addEventListener('click', toggleFlagPanel);
+        btn.addEventListener('click', primeTranslateLoad);
     }
     document.querySelectorAll('#language-panel img[data-lang]').forEach(flag => {
         flag.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- ensure language button is handled as other menus
- load Google Translate script when language panel opens

## Testing
- `npm install`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_685446f5bdbc832991bf2556d8a39ff0