### PR TITLE
Fix overflow side scrolling

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -112,6 +112,7 @@ body.lang-bar-visible {
 html {
     font-size: 102.5%;
     scroll-behavior: smooth;
+    overflow-x: hidden; /* Prevent horizontal scroll on the page */
 }
 
 /* --- Body Styling --- */
@@ -126,6 +127,7 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
+    overflow-x: hidden; /* Prevent side scrolling on narrow screens */
     animation: fadeInPage 0.7s ease-out forwards;
     padding-top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
 }


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling on the entire page by hiding overflow on `html`
- hide overflow on `body`

## Testing
- `python -m unittest tests/test_flask_api.py`
- `./check_links.sh`
- `./check_links_extended.sh`


------
https://chatgpt.com/codex/tasks/task_e_68545c33ab9483299f86d61fa16034ac