### PR TITLE
Remove obsolete header layout styles

### DIFF
--- a/assets/css/header/layout.css
+++ b/assets/css/header/layout.css
@@ -1,13 +1,2 @@
 /* Layout styles for header container */
-#main-header {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    z-index: 3000;
-}
-
-#main-header button {
-    z-index: 3001;
-}
 


### PR DESCRIPTION
## Summary
- cleanup `layout.css` by deleting obsolete `#main-header` rules

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68547d07cdf483299bfb3a9c4447b08d