### PR TITLE
Add note about local server for Puppeteer tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Con las dependencias ya instaladas, ejecuta cada conjunto de tests de forma expl
 ```bash
 vendor/bin/phpunit
 python -m unittest tests/test_flask_api.py
+# Asegúrate de tener un servidor local en marcha (por ejemplo `php -S localhost:8080`)
 npm run test:puppeteer
 ```
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
       "tailwindcss": "^3.4.4"
     },
     "scripts": {
+      "pretest:puppeteer": "php -S localhost:8080 >/dev/null 2>&1 &",
       "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js"
     }
   }


### PR DESCRIPTION
## Summary
- document the need for a local server before running Puppeteer tests
- configure `pretest:puppeteer` to start a PHP server automatically

## Testing
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:8080/tests/manual/test_lang.html)*

------
https://chatgpt.com/codex/tasks/task_e_68547dfa54748329849af471d3b82f94