### PR TITLE
Add fallback color for gradient text

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -201,6 +201,7 @@ h6 { font-size: clamp(1em, 2.5vw, 1.4em); }
     background-image: linear-gradient(45deg, var(--epic-purple-emperor), var(--epic-gold-main));
     -webkit-background-clip: text;
     background-clip: text;
+    color: var(--epic-purple-emperor); /* Fallback color */
     color: transparent;
     font-weight: 700;
     /* Stronger shadow for improved contrast */


### PR DESCRIPTION
## Summary
- ensure `.gradient-text` has a solid purple fallback

## Testing
- `phpunit --configuration phpunit.xml` *(fails: could not find driver)*
- `python3 -m unittest tests/test_flask_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68547dfa99f08329b676cf1311a7b060