### PR TITLE
Add minified asset build and env toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ FORUM_COMMENT_COOLDOWN=60
 # Controla la visualización de errores y avisos en PHP. Usar 'true' para
 # entornos de desarrollo y 'false' en producción.
 APP_DEBUG=false
+# Activa el uso de versiones minificadas de CSS y JS
+USE_MINIFIED_ASSETS=false

--- a/_footer.php
+++ b/_footer.php
@@ -2,13 +2,18 @@
     <div class="container-epic">
         <p>© <script>document.write(new Date().getFullYear());</script> CondadoDeCastilla.com - Todos los derechos reservados.</p>
         <p>Un proyecto para la difusión del patrimonio histórico de Cerezo de Río Tirón y el Alfoz de Cerasio y Lantarón.</p>
-        <?php
+<?php
         require_once __DIR__ . '/includes/auth.php';
         if (is_admin_logged_in()) {
             echo '<p><a href="/dashboard/logout.php">Cerrar sesión</a></p>';
         } else {
             echo '<p><a href="/dashboard/login.php">Acceso Administrador</a></p>';
         }
+        ?>
+        <?php
+        require_once __DIR__ . '/includes/env_loader.php';
+        $useMin = filter_var($_ENV['USE_MINIFIED_ASSETS'] ?? false, FILTER_VALIDATE_BOOLEAN);
+        $min = $useMin ? '.min' : '';
         ?>
         <?php
         $social_fragment = __DIR__ . '/fragments/menus/social-menu.html';
@@ -18,5 +23,5 @@
         ?>
 </div>
 </footer>
-<script src="/assets/js/main.js"></script>
+<script src="/assets/js/main{$min}.js"></script>
 <script src="/js/lang-bar.js"></script>

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -3,6 +3,8 @@ require_once __DIR__ . '/session.php';
 ensure_session_started();
 require_once __DIR__ . '/env_loader.php';
 $geminiKey = getenv('GEMINI_API_KEY') ?: '';
+$useMin = filter_var($_ENV['USE_MINIFIED_ASSETS'] ?? false, FILTER_VALIDATE_BOOLEAN);
+$min = $useMin ? '.min' : '';
 ?>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -11,15 +13,15 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-<link rel="stylesheet" href="/assets/css/epic_theme.css">
-<link rel="stylesheet" href="/assets/css/header.css">
-<link rel="stylesheet" href="/assets/css/sliding_menu.css">
-<link rel="stylesheet" href="/assets/css/language-panel.css">
+<link rel="stylesheet" href="/assets/css/epic_theme{$min}.css">
+<link rel="stylesheet" href="/assets/css/header{$min}.css">
+<link rel="stylesheet" href="/assets/css/sliding_menu{$min}.css">
+<link rel="stylesheet" href="/assets/css/language-panel{$min}.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" integrity="sha384-JwsW+0ELqRMx9x6pRP70dNDO7xjoMnIKPQ4j/wcgUp3NE6PFcAckU4iigFsMghvY" crossorigin="anonymous">
-<link rel="stylesheet" href="/assets/css/custom.css">
-<link rel="stylesheet" href="/assets/css/lighting.css">
+<link rel="stylesheet" href="/assets/css/custom{$min}.css">
+<link rel="stylesheet" href="/assets/css/lighting{$min}.css">
 <link rel="stylesheet" href="/assets/vendor/css/tailwind.min.css">
 <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-SN33kWx+ihQ/HVbUaz2QmiFjCwXTlzAIXazhbugzuDUFc1l1b/HFB70dNFuPu6j6" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" integrity="sha384-JNHB8zHcoUfOaL+5wtIg9Y9ycYzaO+F6DRKCVh0b07XHtcwPa5RWPLXrI75EetBh" crossorigin="anonymous" />
 <script defer src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js" integrity="sha384-pqaW8ZT6X0hgqP/d9vywgq6Z9erjRzCQXDpUe1koRaSPoaqe7iT730cdpShUMHbV" crossorigin="anonymous"></script>
-<script defer src="/assets/js/polyfills.js"></script>
+<script defer src="/assets/js/polyfills{$min}.js"></script>

--- a/includes/load_page_css.php
+++ b/includes/load_page_css.php
@@ -3,19 +3,25 @@ function load_page_css(): void
 {
     $scriptPath = $_SERVER['SCRIPT_NAME'];
     $root = dirname(__DIR__);
+    $useMin = filter_var($_ENV['USE_MINIFIED_ASSETS'] ?? false, FILTER_VALIDATE_BOOLEAN);
 
-    // Allow CSS files that mirror the script path using underscores
     $sanitized = str_replace('/', '_', ltrim($scriptPath, '/'));
     $sanitized = preg_replace('/\.php$/', '', $sanitized);
-    $cssFile = '/assets/css/pages/' . $sanitized . '.css';
 
-    if (!file_exists($root . $cssFile)) {
-        // Fallback to using only the basename for backwards compatibility
-        $cssFile = '/assets/css/pages/' . basename($scriptPath, '.php') . '.css';
-    }
+    $bases = [
+        '/assets/css/pages/' . $sanitized,
+        '/assets/css/pages/' . basename($scriptPath, '.php'),
+    ];
 
-    if (file_exists($root . $cssFile)) {
-        echo "<link rel=\"stylesheet\" href=\"{$cssFile}\">\n";
+    foreach ($bases as $base) {
+        if ($useMin && file_exists($root . $base . '.min.css')) {
+            echo "<link rel=\"stylesheet\" href=\"{$base}.min.css\">\n";
+            return;
+        }
+        if (file_exists($root . $base . '.css')) {
+            echo "<link rel=\"stylesheet\" href=\"{$base}.css\">\n";
+            return;
+        }
     }
 }
 ?>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
         "sass": "^1.89.2"
       },
       "devDependencies": {
+        "clean-css-cli": "^5.6.3",
         "puppeteer": "^24.10.2",
-        "tailwindcss": "^3.4.4"
+        "tailwindcss": "^3.4.4",
+        "terser": "^5.43.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -101,6 +103,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -517,6 +530,19 @@
         "@types/node": "*"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -748,6 +774,13 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -795,6 +828,145 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/clean-css": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
+    },
+    "node_modules/clean-css-cli": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/clean-css-cli/-/clean-css-cli-5.6.3.tgz",
+      "integrity": "sha512-MUAta8pEqA/d2DKQwtZU5nm0Og8TCyAglOx3GlWwjhGdKBwY4kVF6E5M6LU/jmmuswv+HbYqG/dKKkq5p1dD0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "clean-css": "^5.3.3",
+        "commander": "7.x",
+        "glob": "^7.1.6"
+      },
+      "bin": {
+        "cleancss": "bin/cleancss"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/clean-css-cli/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/clean-css-cli/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/clean-css-cli/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/clean-css-cli/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/clean-css-cli/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/clean-css-cli/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/clean-css-cli/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/cliui": {
@@ -920,6 +1092,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
@@ -1271,6 +1450,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1434,6 +1620,25 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "9.0.5",
@@ -1845,6 +2050,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -2412,7 +2627,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2424,6 +2638,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -2702,6 +2927,32 @@
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.43.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.14.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/text-decoder": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "dependencies": {
     "sass": "^1.89.2"
   },
-    "devDependencies": {
-      "puppeteer": "^24.10.2",
-      "tailwindcss": "^3.4.4"
-    },
-    "scripts": {
-      "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js"
-    }
+  "devDependencies": {
+    "puppeteer": "^24.10.2",
+    "tailwindcss": "^3.4.4",
+    "clean-css-cli": "^5.6.3",
+    "terser": "^5.43.1"
+  },
+  "scripts": {
+    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js",
+    "build:minify": "bash scripts/minify_assets.sh"
   }
+}

--- a/scripts/minify_assets.sh
+++ b/scripts/minify_assets.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+CSS_DIR="assets/css"
+JS_DIR="assets/js"
+
+echo "Minifying CSS files..."
+find "$CSS_DIR" -type f -name '*.css' ! -name '*.min.css' | while read -r css; do
+  out="${css%.css}.min.css"
+  npx cleancss -o "$out" "$css"
+  echo "  Created $out"
+done
+
+echo "Minifying JS files..."
+find "$JS_DIR" -type f -name '*.js' ! -name '*.min.js' | while read -r js; do
+  out="${js%.js}.min.js"
+  npx terser "$js" -c -m -o "$out"
+  echo "  Created $out"
+done
+
+echo "Minification complete."


### PR DESCRIPTION
## Summary
- provide `scripts/minify_assets.sh` to create `.min.css` and `.min.js`
- add `clean-css-cli` and `terser` dev dependencies
- wire a `build:minify` npm script
- allow using minified assets through `USE_MINIFIED_ASSETS`
- reference minified versions in `head_common.php`, `_footer.php`, and auto page CSS loader

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml`
- `pip install -r requirements.txt`
- `vendor/bin/phpunit` *(fails: requires DOM/XML extensions)*
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68547dfb28388329b74097aa7ee5dac6