### PR TITLE
Add Imperial Timeline section with Tailwind

### DIFF
--- a/historia/timeline/imperial.html
+++ b/historia/timeline/imperial.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="alabaster-bg">
+<?php require_once __DIR__ . '/../../_header.php'; ?>
+<main>
+<section id="imperial-timeline" class="relative bg-gray-900 bg-opacity-50 py-16 px-6 flex flex-col items-center">
+    <div class="absolute left-1/2 top-0 bottom-0 w-1 bg-yellow-700 md:hidden"></div>
+    <div class="absolute hidden md:block top-1/2 left-0 right-0 h-1 bg-yellow-700"></div>
+    <div class="w-full max-w-4xl flex flex-col md:flex-row md:flex-wrap">
+
+        <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
+            <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg max-w-md">
+                <h3 class="text-2xl font-serif text-yellow-300">53 d.C.</h3>
+                <h4 class="text-xl font-bold text-white mt-2">Nacimiento de Trajano</h4>
+                <p class="text-gray-200 text-sm mt-2">El primer emperador romano nacido en Hispania ve la luz en Itálica, cerca de la actual Sevilla.</p>
+                <img src="/assets/img/placeholder.jpg" alt="Busto del emperador Trajano" class="mt-4 rounded shadow">
+            </div>
+        </div>
+
+        <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
+            <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg max-w-md">
+                <h3 class="text-2xl font-serif text-yellow-300">76 d.C.</h3>
+                <h4 class="text-xl font-bold text-white mt-2">Nacimiento de Adriano</h4>
+                <p class="text-gray-200 text-sm mt-2">Continuador del legado hispano en Roma, también originario de Itálica.</p>
+                <img src="/assets/img/placeholder.jpg" alt="Busto del emperador Adriano" class="mt-4 rounded shadow">
+            </div>
+        </div>
+
+        <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
+            <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg max-w-md">
+                <h3 class="text-2xl font-serif text-yellow-300">347 d.C.</h3>
+                <h4 class="text-xl font-bold text-white mt-2">Nacimiento de Teodosio I</h4>
+                <p class="text-gray-200 text-sm mt-2">Fuentes como <code>nuevo4.md</code> lo vinculan a Auca Patricia (Cerezo de Río Tirón), cuna de emperadores tardorromanos.</p>
+                <img src="/assets/img/placeholder.jpg" alt="Busto del emperador Teodosio I" class="mt-4 rounded shadow">
+            </div>
+        </div>
+
+        <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
+            <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg max-w-md">
+                <h3 class="text-2xl font-serif text-yellow-300">383 d.C.</h3>
+                <h4 class="text-xl font-bold text-white mt-2">Magno Clemente Máximo</h4>
+                <p class="text-gray-200 text-sm mt-2">Proclamado emperador en Britania, la tradición local señala su nacimiento en Auca Patricia.</p>
+                <img src="/assets/img/placeholder.jpg" alt="Busto del emperador Magno Máximo" class="mt-4 rounded shadow">
+            </div>
+        </div>
+
+        <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
+            <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg max-w-md">
+                <h3 class="text-2xl font-serif text-yellow-300">388 d.C.</h3>
+                <h4 class="text-xl font-bold text-white mt-2">Flavio Victor</h4>
+                <p class="text-gray-200 text-sm mt-2">Hijo de Máximo, según <code>nuevo4.md</code> fue ejecutado en el circo de Auca Patricia el 26 de agosto.</p>
+                <img src="/assets/img/placeholder.jpg" alt="Busto del emperador Flavio Victor" class="mt-4 rounded shadow">
+            </div>
+        </div>
+
+        <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
+            <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg max-w-md">
+                <h3 class="text-2xl font-serif text-yellow-300">574 d.C.</h3>
+                <h4 class="text-xl font-bold text-white mt-2">Conquista visigoda</h4>
+                <p class="text-gray-200 text-sm mt-2">Leovigildo toma Auca Patricia y derriba sus murallas de hormigón romano, marcando el final de la ciudad clásica.</p>
+                <img src="/assets/img/placeholder.jpg" alt="Representación de la ciudad visigoda" class="mt-4 rounded shadow">
+            </div>
+        </div>
+
+        <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
+            <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg max-w-md">
+                <h3 class="text-2xl font-serif text-yellow-300">Actualidad</h3>
+                <h4 class="text-xl font-bold text-white mt-2">Promoción de Cerezo de Río Tirón</h4>
+                <p class="text-gray-200 text-sm mt-2">Nuestra web impulsa el turismo y gestiona el patrimonio arqueológico y cultural de la zona, manteniendo vivo el legado de Castilla.</p>
+                <img src="/assets/img/placeholder.jpg" alt="Paisaje de Cerezo de Río Tirón" class="mt-4 rounded shadow">
+            </div>
+        </div>
+
+    </div>
+</section>
+</main>
+<?php require_once __DIR__ . '/../../_footer.php'; ?>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const items = document.querySelectorAll('#imperial-timeline .animate-on-scroll');
+        if(items.length){
+            const observer = new IntersectionObserver((entries, obs) => {
+                entries.forEach(entry => {
+                    if(entry.isIntersecting){
+                        entry.target.classList.add('opacity-100','translate-y-0');
+                        obs.unobserve(entry.target);
+                    }
+                });
+            }, { threshold: 0.1 });
+            items.forEach(el => observer.observe(el));
+        }
+    });
+</script>
+<script src="/js/layout.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `historia/timeline/imperial.html` with a responsive timeline section

## Testing
- `vendor/bin/phpunit`
- `python -m unittest tests/test_flask_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6854854a4e4083298f80d0bc432fdcda