### PR TITLE
Implement file locking for graph DB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4
 requests
 Flask
+filelock


### PR DESCRIPTION
## Summary
- use `filelock` to ensure exclusive access to `knowledge_graph_db.json`
- instantiate `FileLock` in `GraphDBInterface`
- read JSON using the same lock
- document `filelock` in `requirements.txt`

## Testing
- `npm install`
- `npm test` *(fails: Missing script 'test')*
- `python3 -m unittest tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_685486d6177c832997108a42fb9b8438