### PR TITLE
Apply blend modes to gallery and ruin headers

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -208,6 +208,17 @@ h6 { font-size: clamp(1em, 2.5vw, 1.4em); }
     text-shadow: 2px 2px 4px rgba(var(--color-negro-contraste-rgb), 0.8);
 }
 
+/* Utility classes to apply blend modes on text */
+.blend-screen {
+    mix-blend-mode: screen;
+    display: inline-block;
+}
+
+.blend-overlay {
+    mix-blend-mode: overlay;
+    display: inline-block;
+}
+
 /* --- Paragraphs --- */
 p {
     margin-bottom: 1.25em; /* Adjusted margin */

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -305,6 +305,7 @@ if (is_dir($gallery_dir)) {
                     
                     const titleH4 = document.createElement('h4');
                     titleH4.textContent = photo.titulo;
+                    titleH4.classList.add('blend-screen');
                     captionDiv.appendChild(titleH4);
 
                     if (photo.descripcion) {

--- a/ruinas/index.php
+++ b/ruinas/index.php
@@ -13,7 +13,7 @@
 
     <header class="page-header">
         <div class="container-epic">
-            <h1>Ruinas y Vestigios del Condado de Castilla</h1>
+            <h1 class="blend-overlay">Ruinas y Vestigios del Condado de Castilla</h1>
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- add utility CSS classes `.blend-screen` and `.blend-overlay`
- highlight the Ruinas page header using a blend overlay
- accentuate gallery photo titles with a screen blend

## Testing
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854877ef7b0832987e86ff991887a63