### PR TITLE
Use Tailwind radial gradient

### DIFF
--- a/assets/css/lighting.css
+++ b/assets/css/lighting.css
@@ -2,9 +2,6 @@
     --mouse-x: 50%;
     --mouse-y: 50%;
     --linterna-radio: 220px;
-    --linterna-color-centro: rgba(190, 210, 255, 0.35);
-    --linterna-color-medio: rgba(170, 190, 235, 0.15);
-    --linterna-color-borde: rgba(160, 180, 220, 0.02);
     --linterna-opacity: 0;
 }
 
@@ -17,15 +14,8 @@
     height: 100vh;
     z-index: 9998;
     mix-blend-mode: lighten;
-    background-image:
-        radial-gradient(
-            circle var(--linterna-radio) at var(--mouse-x) var(--mouse-y),
-            var(--linterna-color-centro) 0%,
-            var(--linterna-color-medio) 35%,
-            var(--linterna-color-borde) 65%,
-            transparent 75%
-        ),
-        url('/assets/img/alabastro.jpg');
+    @apply bg-gradient-radial from-yellow-200 via-transparent;
+    background-image: radial-gradient(circle var(--linterna-radio) at var(--mouse-x) var(--mouse-y), var(--tw-gradient-stops)), url('/assets/img/alabastro.jpg');
     background-size: var(--linterna-radio) var(--linterna-radio), cover;
     background-repeat: no-repeat;
     background-position: center center;

--- a/assets/css/tailwind_base.css
+++ b/assets/css/tailwind_base.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .bg-linterna-gradient {
+    @apply bg-gradient-radial from-yellow-200 via-transparent;
+  }
+}

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -53,7 +53,7 @@ if (is_dir($gallery_dir)) {
     ?>
 </head>
 <body class="alabaster-bg">
-    <div id="linterna-condado"></div> <!-- Para el efecto de linterna -->
+    <div id="linterna-condado" class="bg-linterna-gradient"></div> <!-- Para el efecto de linterna -->
     
     <?php require_once __DIR__ . '/../_header.php'; ?>
 

--- a/museo/galeria.php
+++ b/museo/galeria.php
@@ -7,7 +7,7 @@
     <!-- Google Fonts, FontAwesome, and epic_theme.css are now in head_common.php -->
 </head>
 <body class="alabaster-bg">
-    <div id="linterna-condado"></div>
+    <div id="linterna-condado" class="bg-linterna-gradient"></div>
     <?php require_once __DIR__ . '/../_header.php'; ?>
 
     <header class="page-header hero hero-museo">

--- a/museo/museo.php
+++ b/museo/museo.php
@@ -28,7 +28,7 @@
 </head>
 <body class="alabaster-bg">
     <div id="crosshair" class="crosshair"></div>
-    <div id="linterna-condado"></div>
+    <div id="linterna-condado" class="bg-linterna-gradient"></div>
     
     <?php require_once __DIR__ . '/../_header.php'; ?>
 

--- a/museo/museo_3d.php
+++ b/museo/museo_3d.php
@@ -17,7 +17,7 @@
 </head>
 <body class="alabaster-bg">
     <div id="crosshair" class="crosshair"></div>
-    <div id="linterna-condado"></div>
+    <div id="linterna-condado" class="bg-linterna-gradient"></div>
     <?php require_once __DIR__ . '/../_header.php'; ?>
 
     <header class="page-header hero hero-museo">

--- a/museo/subir_pieza.php
+++ b/museo/subir_pieza.php
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body class="alabaster-bg">
-    <div id="linterna-condado"></div>
+    <div id="linterna-condado" class="bg-linterna-gradient"></div>
     <?php
         require_once __DIR__ . '/../includes/csrf.php';
         require_once __DIR__ . '/../_header.php';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,11 @@ module.exports = {
     './assets/js/**/*.js',
   ],
   theme: {
-    extend: {},
+    extend: {
+      backgroundImage: {
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- enable radial background utility in Tailwind config
- add new `bg-linterna-gradient` utility
- simplify `#linterna-condado` CSS to use Tailwind gradient
- apply the new class on pages that use the light effect

## Testing
- `python -m unittest tests/test_flask_api.py`
- `npm install` *(installs packages for JS tests)*
- `npm run pretest:puppeteer` *(fails: `php` not installed)*
- `npm run test:puppeteer` *(fails: connection refused because server couldn't start)*

------
https://chatgpt.com/codex/tasks/task_e_6854877f9b38832998d77f438fcf4e2b