### PR TITLE
Add integrity attributes for CDN resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,3 +356,11 @@ python tree_builder.py
 
 El script explora las distintas secciones y crea un fichero JSON con las URLs
 ordenadas jerárquicamente.
+
+## CDN Checksums
+
+Los siguientes resúmenes se utilizan en los atributos `integrity` para los archivos cargados desde CDN. Se calcularon con `openssl dgst -sha384 -binary | openssl base64 -A`.
+
+- **GSAP 3.13.0**: `sha384-HOvlOYPIs/zjoIkWUGXkVmXsjr8GuZLV+Q+rcPwmJOVZVpvTSXQChiN4t9Euv9Vc`
+- **AOS 2.3.4 CSS**: `sha384-/rJKQnzOkEo+daG0jMjU1IwwY9unxt1NBw3Ef2fmOJ3PW/TfAg2KXVoWwMZQZtw9`
+- **AOS 2.3.4 JS**: `sha384-n1AULnKdMJlK1oQCLNDL9qZsDgXtH6jRYFCpBtWFc+a9Yve0KSoMn575rk755NJZ`

--- a/js/layout.js
+++ b/js/layout.js
@@ -231,6 +231,8 @@ function loadGsap() {
     if (!window.gsap) {
         const script = document.createElement('script');
         script.src = 'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.13.0/gsap.min.js';
+        script.integrity = 'sha384-HOvlOYPIs/zjoIkWUGXkVmXsjr8GuZLV+Q+rcPwmJOVZVpvTSXQChiN4t9Euv9Vc';
+        script.crossOrigin = 'anonymous';
         document.head.appendChild(script);
     }
 }
@@ -240,9 +242,13 @@ function loadAos() {
         const link = document.createElement('link');
         link.rel = 'stylesheet';
         link.href = 'https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css';
+        link.integrity = 'sha384-/rJKQnzOkEo+daG0jMjU1IwwY9unxt1NBw3Ef2fmOJ3PW/TfAg2KXVoWwMZQZtw9';
+        link.crossOrigin = 'anonymous';
         document.head.appendChild(link);
         const script = document.createElement('script');
         script.src = 'https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js';
+        script.integrity = 'sha384-n1AULnKdMJlK1oQCLNDL9qZsDgXtH6jRYFCpBtWFc+a9Yve0KSoMn575rk755NJZ';
+        script.crossOrigin = 'anonymous';
         script.onload = () => { if (window.AOS) AOS.init({ once: true }); };
         document.head.appendChild(script);
     } else {


### PR DESCRIPTION
## Summary
- add Subresource Integrity to CDN libraries in `layout.js`
- document checksum values in README for maintainers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68548780ec6083299215ae7014fdf97d