### PR TITLE
Add basic audio controller

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -20,4 +20,5 @@
 </footer>
 <script src="/assets/js/main.js"></script>
 <script src="/assets/js/hero.js"></script>
+<script src="/assets/js/audio-controller.js"></script>
 <script src="/js/lang-bar.js"></script>

--- a/assets/js/audio-controller.js
+++ b/assets/js/audio-controller.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const AudioContext = window.AudioContext || window.webkitAudioContext;
+  const audioCtx = new AudioContext();
+
+  const createTrack = (src, loop = false, volume = 0.5) => {
+    const element = new Audio(src);
+    element.loop = loop;
+    element.crossOrigin = 'anonymous';
+    const source = audioCtx.createMediaElementSource(element);
+    const gain = audioCtx.createGain();
+    gain.gain.value = volume;
+    source.connect(gain).connect(audioCtx.destination);
+    return { element, gain };
+  };
+
+  const ambient = createTrack('https://samplelib.com/lib/preview/mp3/sample-15s.mp3', true, 0.4);
+  ambient.element.play().catch(() => {/* autoplay restrictions */});
+
+  if (document.body.classList.contains('interactivo')) {
+    const secondary = createTrack('https://samplelib.com/lib/preview/mp3/sample-3s.mp3', true, 0.6);
+    secondary.element.play().catch(() => {/* autoplay restrictions */});
+  }
+});

--- a/contenido/lugares/cerezo_de_rio_tiron/interactivo.php
+++ b/contenido/lugares/cerezo_de_rio_tiron/interactivo.php
@@ -3,7 +3,7 @@
 <head>
 <?php require_once __DIR__ . '/../../../includes/head_common.php'; ?>
 </head>
-<body>
+<body class="interactivo">
     <?php require_once __DIR__ . '/../../../_header.php'; ?>
 
     <main class="container page-content-block">
@@ -40,7 +40,8 @@
 </div>
     </main>
 
-    <?php require_once __DIR__ . '/../../../_footer.php'; ?>
+<?php require_once __DIR__ . '/../../../_footer.php'; ?>
+    <script src="/assets/js/audio-controller.js"></script>
     <script src="/js/layout.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add audio controller script that plays background and interactive audio
- load audio controller from footer and interactive page
- mark interactive page with `interactivo` class

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685487f560648329a202c03a16a07531