### PR TITLE
Handle menu volume with audio controller

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -18,6 +18,7 @@
         ?>
 </div>
 </footer>
+<script src="/assets/js/audio-controller.js"></script>
 <script src="/assets/js/main.js"></script>
 <script src="/assets/js/hero.js"></script>
 <script src="/js/lang-bar.js"></script>

--- a/assets/js/audio-controller.js
+++ b/assets/js/audio-controller.js
@@ -1,0 +1,22 @@
+// assets/js/audio-controller.js - simple volume controller
+(function(window, document) {
+    function adjustVolume(lowered) {
+        document.querySelectorAll('audio, video').forEach(el => {
+            if (!el.dataset.originalVolume) {
+                el.dataset.originalVolume = el.volume;
+            }
+            const orig = parseFloat(el.dataset.originalVolume);
+            el.volume = lowered ? Math.max(0, orig * 0.3) : orig;
+        });
+    }
+
+    function handleMenuToggle(anyOpen) {
+        adjustVolume(anyOpen);
+    }
+
+    document.addEventListener('menu-toggled', e => {
+        handleMenuToggle(!!e.detail.open);
+    });
+
+    window.audioController = { handleMenuToggle };
+})(window, document);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -33,6 +33,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const anyOpen = document.querySelectorAll('.menu-panel.active').length > 0;
         document.body.classList.toggle('menu-compressed', anyOpen);
+        if (window.audioController && typeof window.audioController.handleMenuToggle === 'function') {
+            window.audioController.handleMenuToggle(anyOpen);
+        }
+        document.dispatchEvent(new CustomEvent('menu-toggled', { detail: { open: anyOpen } }));
 
         if (open && menu.id === 'ai-chat-panel') {
             const chatArea = document.getElementById('gemini-chat-area');


### PR DESCRIPTION
## Summary
- add a small audio-controller script
- call audioController from main.js after menu compression toggle
- load audio-controller.js in footer

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685487f77de08329a19b6d5e980129fe