### PR TITLE
Update dark mode h1 text shadow

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -2521,7 +2521,6 @@ body.dark-mode::before {
     filter: grayscale(80%) brightness(85%); /* Original dark mode filter */
 }
 
-body.dark-mode h1,
 body.dark-mode h2,
 body.dark-mode h3,
 body.dark-mode h4,
@@ -2531,13 +2530,13 @@ body.dark-mode h6 {
     text-shadow: 1px 1px 3px rgba(0,0,0, 0.5); /* Dark mode text shadow for smaller headings */
 }
 
-body.dark-mode h1,
 body.dark-mode h2,
 body.dark-mode h3 {
     text-shadow: 1px 1px 3px rgba(0,0,0, 0.5); /* Dark mode text shadow for larger headings */
 }
 
 body.dark-mode h1 {
+    text-shadow: 2px 2px 6px rgba(253,184,67,0.4);
     color: var(--epic-gold-main);
 }
 


### PR DESCRIPTION
## Summary
- update dark mode heading styles in `epic_theme.css`
- keep default text-shadow for other headings

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685487fe0d7c8329ab1c73bc7c210ae4