### PR TITLE
Implement time-based palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Promocionar el turismo en **Cerezo de Río Tirón** y gestionar de forma activa 
 - Menús deslizantes que comprimen el contenido al abrirse.
 - Menús fijos en la parte superior gracias a la variable `--menu-top-offset`.
 - Textos con degradados de alto contraste.
+- Paleta que cambia automáticamente según la hora del visitante (amanecer, mediodía, atardecer o noche) con opción manual.
 - Foro con cinco agentes expertos para dinamizar la comunidad.
 
 ### Agentes del foro

--- a/_header.php
+++ b/_header.php
@@ -9,6 +9,7 @@
 <div id="consolidated-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="consolidated-menu-button">
     <button id="ai-chat-trigger" class="menu-item-button" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA"><i class="fas fa-comments"></i> <span>Chat IA</span></button>
     <button id="theme-toggle" class="menu-item-button" aria-label="Cambiar tema"><i class="fas fa-moon"></i> <span>Modo</span></button>
+    <button id="palette-toggle" class="menu-item-button" aria-label="Cambiar paleta"><i class="fas fa-palette"></i> <span>Paleta</span></button>
 
     <div class="menu-section">
         <h4 class="gradient-text">Navegación Principal</h4>

--- a/assets/css/time_palettes.css
+++ b/assets/css/time_palettes.css
@@ -1,0 +1,41 @@
+/* Tailwind palette classes based on time of day */
+
+body.palette-dawn {
+    --epic-alabaster-bg: #e5e5e5;
+    --epic-gold-main: #f3e5ab;
+    background-color: var(--epic-alabaster-bg);
+}
+
+body.palette-day {
+    --epic-alabaster-bg: #fdfaf6;
+    --epic-purple-emperor: #6b46c1;
+    background-color: var(--epic-alabaster-bg);
+}
+
+body.palette-dusk {
+    --epic-alabaster-bg: #efe2d2;
+    --epic-gold-main: #f0b429;
+    background-image: linear-gradient(to bottom, #f97316, #f0b429);
+}
+
+body.palette-night {
+    --epic-alabaster-bg: #1a1a1a;
+    --epic-text-color: #e0e0e0;
+    background-color: var(--epic-alabaster-bg);
+    color: var(--epic-text-color);
+}
+
+body.palette-night::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-image: url('/assets/img/estrella.png');
+    background-size: 120px 120px;
+    background-repeat: repeat;
+    opacity: 0.1;
+    pointer-events: none;
+    z-index: -1;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,6 +1,27 @@
 // assets/js/main.js - simplified menu controller and theme toggle
 
 document.addEventListener('DOMContentLoaded', () => {
+    const paletteClasses = ['palette-dawn','palette-day','palette-dusk','palette-night'];
+
+    const detectPalette = () => {
+        const h = new Date().getHours();
+        if (h >= 5 && h < 10) return 'dawn';
+        if (h >= 10 && h < 17) return 'day';
+        if (h >= 17 && h < 21) return 'dusk';
+        return 'night';
+    };
+
+    const applyPalette = (p) => {
+        document.body.classList.remove(...paletteClasses);
+        document.body.classList.add(`palette-${p}`);
+    };
+
+    const storedPalette = localStorage.getItem('palette');
+    if (storedPalette && storedPalette !== 'auto') {
+        applyPalette(storedPalette);
+    } else {
+        applyPalette(detectPalette());
+    }
     const closeMenu = (menu) => {
         menu.classList.remove('active');
         const btn = document.querySelector(`[data-menu-target="${menu.id}"]`);
@@ -103,6 +124,23 @@ document.addEventListener('DOMContentLoaded', () => {
                 icon.classList.toggle('fa-sun', isDark);
             }
             localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        });
+    }
+
+    const paletteToggle = document.getElementById('palette-toggle');
+    if (paletteToggle) {
+        const order = ['auto','dawn','day','dusk','night'];
+        let index = order.indexOf(storedPalette || 'auto');
+        paletteToggle.addEventListener('click', () => {
+            index = (index + 1) % order.length;
+            const p = order[index];
+            if (p === 'auto') {
+                localStorage.removeItem('palette');
+                applyPalette(detectPalette());
+            } else {
+                localStorage.setItem('palette', p);
+                applyPalette(p);
+            }
         });
     }
 

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -17,6 +17,7 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <link rel="stylesheet" href="/assets/css/language-panel.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" integrity="sha384-JwsW+0ELqRMx9x6pRP70dNDO7xjoMnIKPQ4j/wcgUp3NE6PFcAckU4iigFsMghvY" crossorigin="anonymous">
 <link rel="stylesheet" href="/assets/css/custom.css">
+<link rel="stylesheet" href="/assets/css/time_palettes.css">
 <link rel="stylesheet" href="/assets/css/lighting.css">
 <link rel="stylesheet" href="/assets/vendor/css/tailwind.min.css">
 <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-SN33kWx+ihQ/HVbUaz2QmiFjCwXTlzAIXazhbugzuDUFc1l1b/HFB70dNFuPu6j6" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- add automatic time-based palette detection in JS
- store manual palette preference and allow cycling through palettes
- include new palette toggle button in the header
- provide CSS definitions for dawn, day, dusk and night
- document the feature in README

## Testing
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854862d029c8329908a7f5f778e064d