### PR TITLE
Add audio mute control

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -21,3 +21,4 @@
 <script src="/assets/js/main.js"></script>
 <script src="/assets/js/hero.js"></script>
 <script src="/js/lang-bar.js"></script>
+<script src="/js/audio-controller.js"></script>

--- a/_header.php
+++ b/_header.php
@@ -2,6 +2,7 @@
     <div class="header-action-buttons">
         <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
         <button id="flag-toggle" data-menu-target="language-panel" aria-label="Seleccionar idioma" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>
+        <button id="mute-toggle" aria-pressed="false" aria-label="Silenciar">🔊</button>
     </div>
 </div>
 

--- a/assets/css/header/nav.css
+++ b/assets/css/header/nav.css
@@ -305,3 +305,20 @@ body.sidebar-active {
     /* body.sidebar-active #sidebar-toggle { left: 15px; } */
     /* Right panel handled via body.menu-open-right in sliding_menu.css */
 }
+
+/* Mute Toggle Button */
+#mute-toggle {
+    padding: 6px 10px;
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 0.9em;
+    transition: background-color 0.3s ease;
+}
+
+#mute-toggle:hover {
+    background-color: var(--epic-purple-emperor);
+    color: var(--epic-gold-main);
+}

--- a/js/audio-controller.js
+++ b/js/audio-controller.js
@@ -1,0 +1,21 @@
+(function(){
+    document.addEventListener('DOMContentLoaded', function(){
+        const btn = document.getElementById('mute-toggle');
+        if(!btn) return;
+
+        let muted = false;
+        const updateState = () => {
+            btn.setAttribute('aria-pressed', muted ? 'true' : 'false');
+            btn.textContent = muted ? '🔇' : '🔊';
+        };
+        updateState();
+
+        btn.addEventListener('click', () => {
+            muted = !muted;
+            document.querySelectorAll('audio, video').forEach(el => {
+                el.muted = muted;
+            });
+            updateState();
+        });
+    });
+})();


### PR DESCRIPTION
## Summary
- add mute toggle button in header
- load new audio controller script
- style `#mute-toggle` to match the purple and gold palette
- implement `audio-controller.js` to toggle mute state for media

## Testing
- `./scripts/check_alt_texts.sh`
- `vendor/bin/phpstan` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: command not found)*
- `npm run test:puppeteer` *(fails: ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_685487f66bac8329bd5ca65e17dea28b