### PR TITLE
Add ambient audio controller feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Promocionar el turismo en **Cerezo de Río Tirón** y gestionar de forma activa 
 - Menús fijos en la parte superior gracias a la variable `--menu-top-offset`.
 - Textos con degradados de alto contraste.
 - Foro con cinco agentes expertos para dinamizar la comunidad.
+- Bucle de música ambiental con botón de silencio `#mute-toggle`.
+
+### Personalización del audio
+
+El archivo `assets/js/audio-controller.js` reproduce por defecto
+`assets/audio/ambient.mp3` en bucle. Reemplaza ese fichero por tu
+propia pista o ajusta la ruta en el script. El botón identificado como
+`#mute-toggle` permite silenciar o reanudar la música y guarda la
+preferencia en `localStorage`.
 
 ### Agentes del foro
 

--- a/_footer.php
+++ b/_footer.php
@@ -20,4 +20,5 @@
 </footer>
 <script src="/assets/js/main.js"></script>
 <script src="/assets/js/hero.js"></script>
+<script src="/assets/js/audio-controller.js"></script>
 <script src="/js/lang-bar.js"></script>

--- a/_header.php
+++ b/_header.php
@@ -2,6 +2,7 @@
     <div class="header-action-buttons">
         <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
         <button id="flag-toggle" data-menu-target="language-panel" aria-label="Seleccionar idioma" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>
+        <button id="mute-toggle" aria-label="Silenciar música"><i class="fas fa-volume-up"></i></button>
     </div>
 </div>
 

--- a/assets/js/audio-controller.js
+++ b/assets/js/audio-controller.js
@@ -1,0 +1,36 @@
+// assets/js/audio-controller.js
+// Plays an ambient audio loop and toggles mute state via #mute-toggle
+
+document.addEventListener('DOMContentLoaded', () => {
+    const button = document.getElementById('mute-toggle');
+    if (!button) return;
+
+    const audio = new Audio('/assets/audio/ambient.mp3');
+    audio.loop = true;
+    audio.volume = 0.5;
+
+    const wasMuted = localStorage.getItem('ambientMuted') === 'true';
+    if (!wasMuted) {
+        audio.play().catch(() => {});
+        button.classList.remove('muted');
+    } else {
+        button.classList.add('muted');
+    }
+
+    function updateState(muted) {
+        if (muted) {
+            audio.pause();
+            button.classList.add('muted');
+            localStorage.setItem('ambientMuted', 'true');
+        } else {
+            audio.play().catch(() => {});
+            button.classList.remove('muted');
+            localStorage.setItem('ambientMuted', 'false');
+        }
+    }
+
+    button.addEventListener('click', () => {
+        const currentlyMuted = audio.paused || button.classList.contains('muted');
+        updateState(!currentlyMuted);
+    });
+});

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -7,6 +7,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `assets/js/main.js` | Handles sliding menu interactions, closing behavior, and the light/dark theme toggle used across all pages. |
 | `assets/js/homonexus-toggle.js` | Toggles Homonexus mode, storing the preference in a cookie. |
 | `assets/js/foro.js` | Simple toggling for the forum agents menu. |
+| `assets/js/audio-controller.js` | Plays the ambient loop and handles muting via `#mute-toggle`. |
 | `js/config.js` | Defines `API_BASE_URL` and `DEBUG_MODE` globals for other scripts. |
 | `js/layout.js` | Loads external CSS/JS libraries on demand, initializes the flashlight effect and other page-level utilities. |
 | `js/load_menu_parts.js` | Dynamically loads menu fragments into the header when needed. |


### PR DESCRIPTION
## Summary
- add ambient audio controller script
- load script in the footer and expose a mute button
- document audio controller and how to customize the track
- mention ambient loop in design features

## Testing
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685487f7969c8329a3f0b97977cee6bf