### PR TITLE
Add Puppeteer mute toggle test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
       - name: Run PHPUnit
         run: vendor/bin/phpunit --coverage-clover build/coverage.xml
 
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Run Puppeteer tests
+        run: npm run test:puppeteer
+
       - name: Upload coverage artifact
         if: success() && always()
         uses: actions/upload-artifact@v3

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     },
     "scripts": {
       "pretest:puppeteer": "php -S localhost:8080 >/dev/null 2>&1 &",
-      "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js"
+      "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js"
     }
   }

--- a/tests/muteToggleTest.js
+++ b/tests/muteToggleTest.js
@@ -1,0 +1,19 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/index.php');
+  await page.waitForSelector('#mute-toggle');
+  const initial = await page.$eval('#mute-toggle', el => el.getAttribute('aria-pressed'));
+  await page.click('#mute-toggle');
+  await page.waitForTimeout(300);
+  const afterClick = await page.$eval('#mute-toggle', el => el.getAttribute('aria-pressed'));
+  if (initial === afterClick) {
+    console.error('aria-pressed did not toggle');
+    await browser.close();
+    process.exit(1);
+  }
+  console.log('Mute button toggled correctly');
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- add Puppeteer test for `#mute-toggle`
- include test in npm script
- run Node tests in CI

## Testing
- `npm run test:puppeteer` *(fails: TimeoutError waiting for #google_translate_element)*
- `python3 -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685487f861e08329b426c8cf9d030616