### PR TITLE
Add Playfair Display font and sheen effect

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -41,7 +41,7 @@
     --epic-transparent-black-overlay: rgba(10, 10, 10, 0.75);
 
     --font-primary: 'Lora', serif;
-    --font-headings: 'Cinzel', serif;
+    --font-headings: 'Playfair Display Variable', serif;
 
     --global-border-radius: 8px;
     --global-transition-speed: 0.3s;
@@ -164,6 +164,11 @@ body::before {
     }
 }
 
+@keyframes sheen {
+    from { background-position: -200% 0; }
+    to   { background-position: 200% 0; }
+}
+
 /* --- Headings --- */
 h1, h2, h3, h4, h5, h6 {
     font-family: var(--font-headings);
@@ -206,6 +211,13 @@ h6 { font-size: clamp(1em, 2.5vw, 1.4em); }
     font-weight: 700;
     /* Stronger shadow for improved contrast */
     text-shadow: 2px 2px 4px rgba(var(--color-negro-contraste-rgb), 0.8);
+}
+
+h1:hover {
+    background-image: linear-gradient(90deg,var(--epic-gold-main),var(--epic-purple-emperor),var(--epic-gold-main));
+    background-clip: text;
+    background-size: 200% 100%;
+    animation: sheen 3s linear infinite;
 }
 
 /* --- Paragraphs --- */
@@ -2242,7 +2254,7 @@ ul li, ol li { text-align: center; } // Broader rule from estilos.css
     /* text-align: left; is default for p in epic_theme.css, so this is fine */
 }
 .article-content h3 {
-    font-family: 'Cinzel', serif; /* Matches --font-headings */
+    font-family: 'Playfair Display Variable', serif; /* Matches --font-headings */
     color: var(--color-secundario-dorado, #B8860B); /* Mapped to --epic-gold-secondary or similar */
     margin-top: 1.5em;
     margin-bottom: 0.5em;

--- a/dashboard/README.html
+++ b/dashboard/README.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PHP Visit Statistics Dashboard</title>

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -10,6 +10,7 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 <link rel="stylesheet" href="/assets/css/epic_theme.css">
 <link rel="stylesheet" href="/assets/css/header.css">

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/dona_sancha.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/dona_sancha.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernan_gonzalez.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernan_gonzalez.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/aureliano.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/aureliano.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/clemente_magno_maximo.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/clemente_magno_maximo.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Magno Clemente Máximo</title>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_arcadio.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_arcadio.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Flavio Arcadio</title>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_teodosio_i_el_grande.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_teodosio_i_el_grande.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="../../assets/css/epic_theme.css"> <!-- Referencia al CSS común de personajes -->
 </head>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_victor.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_victor.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Flavio Victor</title>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/magno_clemente_maximo.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/magno_clemente_maximo.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="../../assets/css/epic_theme.css"> <!-- Referencia al CSS común de personajes -->
 </head>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/teodosio_i.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/teodosio_i.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Flavio Teodosio I el Grande</title>

--- a/personajes/Militares_y_Gobernantes/agripa.html
+++ b/personajes/Militares_y_Gobernantes/agripa.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/alfonso_ii_el_casto.html
+++ b/personajes/Militares_y_Gobernantes/alfonso_ii_el_casto.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/cesar_augusto.html
+++ b/personajes/Militares_y_Gobernantes/cesar_augusto.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html
+++ b/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/corocotta.html
+++ b/personajes/Militares_y_Gobernantes/corocotta.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/leovigildo.html
+++ b/personajes/Militares_y_Gobernantes/leovigildo.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/ramiro_i_de_asturias.html
+++ b/personajes/Militares_y_Gobernantes/ramiro_i_de_asturias.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
+++ b/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Ordenes_y_Legados/paterna_banucasi.html
+++ b/personajes/Ordenes_y_Legados/paterna_banucasi.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Santos_y_Martires/san_braulio.html
+++ b/personajes/Santos_y_Martires/san_braulio.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Santos_y_Martires/san_formerio.html
+++ b/personajes/Santos_y_Martires/san_formerio.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Santos_y_Martires/san_vitores.html
+++ b/personajes/Santos_y_Martires/san_vitores.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/galeria_3d.html
+++ b/personajes/galeria_3d.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Galería 3D de Personajes</title>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <style>
         html, body {
             margin: 0;

--- a/personajes/indice_personajes.html
+++ b/personajes/indice_personajes.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/secciones_index/historia_tiempo_resumen.html
+++ b/secciones_index/historia_tiempo_resumen.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/secciones_index/memoria_hispanidad.html
+++ b/secciones_index/memoria_hispanidad.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/tailwind_index.html
+++ b/tailwind_index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:opsz,wght@5..1200,400..900&display=swap" rel="stylesheet">
     <style>
         .font-epic-title { font-family: 'Cinzel', serif; }
         .font-epic-body { font-family: 'Lora', serif; }


### PR DESCRIPTION
## Summary
- load Playfair Display Variable font in common head
- use Playfair Display for heading font
- add `sheen` animation and hover effect for `<h1>`
- load new font in standalone HTML pages

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `./check_links.sh`
- `./check_links_extended.sh`
- ❌ `composer install` *(command not found)*
- ❌ `php -v` *(command not found)*
- ❌ `vendor/bin/phpunit` *(command not found)*
- ❌ `npm run test:puppeteer` *(missing puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_685487fd3a7083298a546a637ca71b07