### PR TITLE
Add glow filter for timeline markers

### DIFF
--- a/assets/css/glow_filter.css
+++ b/assets/css/glow_filter.css
@@ -1,0 +1,7 @@
+/* Utility styles for embedded SVG filters */
+#svg-filters {
+    position: absolute;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+}

--- a/fragments/header/svg_filters.html
+++ b/fragments/header/svg_filters.html
@@ -1,0 +1,9 @@
+<svg id="svg-filters" width="0" height="0" class="hidden" style="position:absolute">
+  <filter id="glow">
+    <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+    <feMerge>
+      <feMergeNode in="coloredBlur"/>
+      <feMergeNode in="SourceGraphic"/>
+    </feMerge>
+  </filter>
+</svg>

--- a/historia/timeline/imperial.html
+++ b/historia/timeline/imperial.html
@@ -102,6 +102,7 @@
         }
     });
 </script>
+<script src="/js/influencia_romana.js"></script>
 <script src="/js/layout.js"></script>
 </body>
 </html>

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -25,3 +25,10 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <script defer src="/assets/js/polyfills.js"></script>
 <link rel="stylesheet" href="/assets/css/torch_cursor.css">
 <script defer src="/assets/js/torch_cursor.js"></script>
+<link rel="stylesheet" href="/assets/css/glow_filter.css">
+<?php
+$svgFilterPath = __DIR__ . '/../fragments/header/svg_filters.html';
+if (file_exists($svgFilterPath)) {
+    echo file_get_contents($svgFilterPath);
+}
+?>

--- a/js/influencia_romana.js
+++ b/js/influencia_romana.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const markers = document.querySelectorAll('#imperial-timeline span.rounded-full');
+    markers.forEach(m => {
+        m.style.filter = 'url(#glow)';
+    });
+});


### PR DESCRIPTION
## Summary
- include global SVG filter markup
- load filter CSS and JS via `head_common.php`
- highlight imperial timeline markers with new JS

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854883f97148329b29bb648cabed3f4