### PR TITLE
Add Roman influence page to navigation

### DIFF
--- a/config/main_menu.php
+++ b/config/main_menu.php
@@ -21,4 +21,5 @@ return [
     ['label' => 'Foro', 'url' => '/foro/index.php'],
     ['label' => 'Blog', 'url' => '/blog.php'],
     ['label' => 'Contacto', 'url' => '/contacto/contacto.php'],
+    ['label' => 'Influencia Romana', 'url' => '/historia/influencia_romana.php'],
 ];


### PR DESCRIPTION
## Summary
- include new "Influencia Romana" link in `config/main_menu.php`

## Testing
- `vendor/bin/phpunit` *(fails: php-cgi not found)*
- `python3 -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: timeout waiting for google_translate_element)*

------
https://chatgpt.com/codex/tasks/task_e_6854883f99ec8329b6e5b5962b74fa87