### PR TITLE
Add Roman Influence chart docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,3 +13,8 @@ Para otras referencias, visita también:
 - [Guía de Estilo](style-guide.md)
 - [Documentación del crawler](crawler.md)
 - [Interfaz de la base de datos de grafo](graph_db.md)
+- [Gráfica de Influencia Romana](index-guide.md#grafica-de-influencia-romana)
+
+La guía también explica cómo se genera la **Gráfica de Influencia Romana** con
+D3.js, respetando el modo oscuro para una visualización coherente en todo el
+sitio.

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -64,6 +64,14 @@ Esto evitará que los menús se oculten tras los botones fijos.
 
 La variable `--menu-extra-offset` puede definirse también en `assets/css/epic_theme.css` o en tu propia hoja de estilos. Ajusta su valor al número de píxeles que ocupa `#fixed-header-elements` para que los paneles deslizantes queden perfectamente alineados bajo los botones.
 
+## Gráfica de Influencia Romana
+
+El índice incorpora una gráfica interactiva que muestra la huella de Roma en
+la región. Esta visualización se implementa con **D3.js** y cambia de paleta de
+colores automáticamente cuando el usuario activa el modo oscuro mediante el
+botón `#theme-toggle`.
+
+
 ## Configuración de los agentes del foro
 
 El archivo `config/forum_agents.php` define los expertos que responden en el foro. Cada entrada del array contiene estos campos:

--- a/docs/tareas.md
+++ b/docs/tareas.md
@@ -9,3 +9,4 @@
 - [ ] Revisar la accesibilidad y el rendimiento en dispositivos móviles.
 - [ ] Integrar el modo Homonexus y el chat IA en todas las páginas.
 - [ ] Garantizar que los menús y botones permanezcan fijos al hacer scroll para que solo el contenido sea desplazable.
+- [ ] Documentar la nueva gráfica de Influencia Romana realizada con D3 y compatible con modo oscuro.


### PR DESCRIPTION
## Summary
- document Roman Influence chart using D3.js with dark-mode support
- link to the new section from the docs index
- note the new task about documenting the chart

## Testing
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68548840d2808329a917f599c0fa4a83