### PR TITLE
Add moon theme with toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Promocionar el turismo en **Cerezo de Río Tirón** y gestionar de forma activa 
 - Menús deslizantes que comprimen el contenido al abrirse.
 - Menús fijos en la parte superior gracias a la variable `--menu-top-offset`.
 - Textos con degradados de alto contraste.
+- Soporte de **Modo luna**, una variante con tonos azul oscuro y plata que se activa desde el menú principal.
 - Foro con cinco agentes expertos para dinamizar la comunidad.
 
 ### Agentes del foro

--- a/_header.php
+++ b/_header.php
@@ -9,6 +9,7 @@
 <div id="consolidated-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="consolidated-menu-button">
     <button id="ai-chat-trigger" class="menu-item-button" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA"><i class="fas fa-comments"></i> <span>Chat IA</span></button>
     <button id="theme-toggle" class="menu-item-button" aria-label="Cambiar tema"><i class="fas fa-moon"></i> <span>Modo</span></button>
+    <button id="moon-toggle" class="menu-item-button" aria-label="Modo luna">🌙 Modo luna</button>
 
     <div class="menu-section">
         <h4 class="gradient-text">Navegación Principal</h4>

--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -2562,6 +2562,40 @@ body.dark-mode #theme-toggle:hover i {
     color: var(--epic-icon-hover);
 }
 
+/* ===== Moon Mode ===== */
+body.luna {
+    --epic-purple-emperor: #1e2749;
+    --epic-purple-emperor-rgb: 30, 39, 73;
+    --epic-gold-main: #c0c0c0; /* silver tones */
+    --epic-gold-main-rgb: 192, 192, 192;
+    --epic-gold-secondary: #a9a9a9;
+    --epic-gold-secondary-rgb: 169, 169, 169;
+    --epic-alabaster-bg: #0d1b2a; /* deep night blue */
+    --epic-alabaster-bg-rgb: 13, 27, 42;
+    --epic-text-color: #e0e6ed;
+    --epic-text-color-rgb: 224, 230, 237;
+    --epic-text-light: #cbd5e1;
+    --epic-text-light-rgb: 203, 213, 225;
+    --epic-icon-color: #a0aec0;
+    --epic-icon-hover: #f1f5f9;
+    --global-box-shadow-dark: 0 8px 25px rgba(30, 58, 138, 0.5); /* shadow-blue-900/50 */
+    background-color: var(--epic-alabaster-bg);
+}
+
+body.luna .particle {
+    position: absolute;
+    width: 4px;
+    height: 4px;
+    background-color: rgba(255, 255, 255, 0.8);
+    border-radius: 50%;
+    animation: drift 8s linear infinite;
+}
+
+@keyframes drift {
+    from { transform: translateY(0) scale(1); opacity: 1; }
+    to { transform: translateY(-100px) scale(0.5); opacity: 0; }
+}
+
 /* === IA Tools Menu === */
 #ia-tools-menu {
     margin: 0;

--- a/assets/css/header/nav.css
+++ b/assets/css/header/nav.css
@@ -287,6 +287,14 @@ body.dark-mode #sidebar .nav-links a:hover i {
     color: var(--epic-icon-hover);
 }
 
+body.luna #sidebar .nav-links a i {
+    color: var(--epic-icon-color);
+}
+
+body.luna #sidebar .nav-links a:hover i {
+    color: var(--epic-icon-hover);
+}
+
 /* Adjust main content when left sidebar is active */
 body.sidebar-active {
     margin-left: 280px; /* Match sidebar width */

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -91,3 +91,11 @@ body.dark-mode #theme-toggle i {
 body.dark-mode #theme-toggle:hover i {
     color: var(--epic-icon-hover);
 }
+
+body.luna #theme-toggle i {
+    color: var(--epic-icon-color);
+}
+
+body.luna #theme-toggle:hover i {
+    color: var(--epic-icon-hover);
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -82,27 +82,56 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const themeToggle = document.getElementById('theme-toggle');
-    if (themeToggle) {
-        const icon = themeToggle.querySelector('i');
-        const storedTheme = localStorage.getItem('theme');
-        if (storedTheme === 'dark' || !storedTheme) {
-            document.body.classList.add('dark-mode');
-            if (icon) {
-                icon.classList.remove('fa-moon');
-                icon.classList.add('fa-sun');
-            }
-            if (!storedTheme) {
-                localStorage.setItem('theme', 'dark');
-            }
+    const moonToggle = document.getElementById('moon-toggle');
+
+    const icon = themeToggle ? themeToggle.querySelector('i') : null;
+    const applyIcon = (isDark) => {
+        if (!icon) return;
+        icon.classList.toggle('fa-moon', !isDark);
+        icon.classList.toggle('fa-sun', isDark);
+    };
+
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'moon') {
+        document.body.classList.add('luna');
+        applyIcon(false);
+    } else {
+        const isDark = storedTheme === 'dark' || !storedTheme;
+        document.body.classList.toggle('dark-mode', isDark);
+        applyIcon(isDark);
+        if (!storedTheme) {
+            localStorage.setItem('theme', 'dark');
         }
+    }
+
+    if (themeToggle) {
         themeToggle.addEventListener('click', () => {
+            if (localStorage.getItem('theme') === 'moon') {
+                document.body.classList.remove('luna');
+                document.body.classList.add('dark-mode');
+                localStorage.setItem('theme', 'dark');
+                applyIcon(true);
+                return;
+            }
             document.body.classList.toggle('dark-mode');
             const isDark = document.body.classList.contains('dark-mode');
-            if (icon) {
-                icon.classList.toggle('fa-moon', !isDark);
-                icon.classList.toggle('fa-sun', isDark);
-            }
             localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            applyIcon(isDark);
+        });
+    }
+
+    if (moonToggle) {
+        moonToggle.addEventListener('click', () => {
+            const isMoon = document.body.classList.toggle('luna');
+            if (isMoon) {
+                document.body.classList.remove('dark-mode');
+                localStorage.setItem('theme', 'moon');
+                applyIcon(false);
+            } else {
+                document.body.classList.add('dark-mode');
+                localStorage.setItem('theme', 'dark');
+                applyIcon(true);
+            }
         });
     }
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -27,3 +27,10 @@ definida en `assets/css/epic_theme.css`. Esta clase aplica un degradado
 diagonal que combina el morado principal (`--epic-purple-emperor`) y el
 oro viejo (`--epic-gold-main`) y aprovecha `background-clip: text` para
 dejar a la vista los colores de la paleta.
+
+## Modo luna
+
+El nuevo modo **luna** emplea tonos azul oscuro y plata. Se activa con el botón
+`Modo luna` del panel principal y aplica la clase `.luna` al elemento `<body>`.
+Las variables de color se redefinen para reflejar esta paleta y se añaden
+partículas blancas animadas que simulan luciérnagas.


### PR DESCRIPTION
## Summary
- add "Modo luna" button in `_header.php`
- enable `.luna` theme toggle and storage logic in `main.js`
- define moon palette and firefly particles in `epic_theme.css`
- style header icons for `.luna` theme
- document new mode in README and style guide

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68548845bcc88329aa0737a1abfc313c