### PR TITLE
Add moon toggle test

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ vendor/bin/phpunit
 python -m unittest tests/test_flask_api.py
 # Asegúrate de tener un servidor local en marcha (por ejemplo `php -S localhost:8080`)
 npm run test:puppeteer
+node tests/moonToggleTest.js
 ```
 
 `vendor/bin/phpunit` lanza la suite de PHP definida en `phpunit.xml`.

--- a/tests/moonToggleTest.js
+++ b/tests/moonToggleTest.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const {JSDOM} = require('jsdom');
+
+const headerHtml = fs.readFileSync('_header.php', 'utf8');
+const scriptJs = fs.readFileSync('assets/js/main.js', 'utf8');
+
+const dom = new JSDOM(`<body>${headerHtml}</body>`, {
+  runScripts: "dangerously",
+  resources: "usable",
+  url: "https://example.com"
+});
+
+const {window} = dom;
+window.localStorage.setItem('theme', 'moon');
+
+const scriptEl = window.document.createElement('script');
+scriptEl.textContent = scriptJs;
+window.document.body.appendChild(scriptEl);
+
+window.addEventListener('DOMContentLoaded', () => {
+  const moonToggle = window.document.getElementById('moon-toggle');
+  if (!moonToggle) {
+    console.error('moon-toggle button not found');
+    process.exit(1);
+  }
+  const icon = moonToggle.querySelector('i');
+  moonToggle.click();
+  const firstHas = window.document.body.classList.contains('luna');
+  const firstIcon = icon.classList.contains('fa-sun');
+  const firstStore = window.localStorage.getItem('theme');
+  moonToggle.click();
+  const secondHas = window.document.body.classList.contains('luna');
+  const secondIcon = icon.classList.contains('fa-moon');
+  const secondStore = window.localStorage.getItem('theme');
+
+  if (!firstHas || !firstIcon || firstStore !== 'moon') {
+    console.error('Activation failed');
+    process.exit(1);
+  }
+  if (secondHas || !secondIcon || secondStore !== 'light') {
+    console.error('Deactivation failed');
+    process.exit(1);
+  }
+  console.log('Moon toggle class and storage toggled correctly');
+});


### PR DESCRIPTION
## Summary
- add new moonToggleTest.js to verify lunar mode
- document how to run moon toggle tests

## Testing
- `composer install` *(fails: command not found)*
- `pip install -r requirements.txt`
- `vendor/bin/phpunit` *(fails: no such file or directory)*
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: moon-toggle button not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548847d5048329bfbc93ea0a743a2c