### PR TITLE
Add parallax effect with reduced-motion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,14 @@ body.menu-open-right {
 
 El contenido se desplaza ligeramente y se escala al 97%, dando la sensación de que el sitio se comprime por el lateral desde el que aparece el menú. Al cerrarlo, las clases se eliminan y la página vuelve a su posición original.
 
+## Parallax
+
+Se incluyen capas de parallax que se mueven con el desplazamiento de la página.
+Cada capa define su velocidad mediante el atributo `data-speed` y el script
+`assets/js/parallax.js` aplica la transformación `translateY` correspondiente.
+Si el usuario tiene activada la preferencia de movimiento reducido, el efecto se
+deshabilita automáticamente.
+
 ## Actualizar el árbol de páginas
 
 Para regenerar el archivo `condensed_website_tree.json` que resume la estructura

--- a/_footer.php
+++ b/_footer.php
@@ -23,5 +23,6 @@
 <script src="/assets/js/cave_mask.js"></script>
 <script src="/assets/js/hero.js"></script>
 <script src="/assets/js/scroll-fade.js"></script>
+<script src="/assets/js/parallax.js"></script>
 <script src="/js/lang-bar.js"></script>
 <script src="/js/audio-controller.js"></script>

--- a/assets/css/parallax.css
+++ b/assets/css/parallax.css
@@ -1,0 +1,32 @@
+/* assets/css/parallax.css - styles for parallax layers */
+
+.parallax-layer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  background-size: cover;
+  background-position: center;
+  pointer-events: none;
+  will-change: transform;
+}
+
+#layer-sky {
+  z-index: -3;
+  background: linear-gradient(to bottom, rgba(var(--epic-purple-emperor-rgb),0.6), rgba(var(--epic-gold-main-rgb),0.4));
+  opacity: 0.7;
+}
+
+#layer-ruins {
+  z-index: -2;
+  background-image: url('/assets/img/Muralla.jpg');
+  background-size: cover;
+  opacity: 0.8;
+}
+
+#layer-grass {
+  z-index: -1;
+  background: linear-gradient(to top, rgba(var(--epic-gold-main-rgb),0.7), rgba(var(--epic-gold-main-rgb),0.3));
+  opacity: 0.8;
+}

--- a/assets/js/parallax.js
+++ b/assets/js/parallax.js
@@ -1,0 +1,46 @@
+// assets/js/parallax.js - simple parallax effect based on scroll
+
+document.addEventListener('DOMContentLoaded', () => {
+  const layers = document.querySelectorAll('[data-speed]');
+  if (!layers.length) return;
+
+  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  let active = !mediaQuery.matches;
+
+  const update = () => {
+    const offset = window.pageYOffset;
+    layers.forEach(el => {
+      const speed = parseFloat(el.dataset.speed || '0');
+      el.style.transform = `translateY(${offset * speed}px)`;
+    });
+  };
+
+  const enable = () => {
+    if (!active) {
+      active = true;
+      window.addEventListener('scroll', update, { passive: true });
+      update();
+    }
+  };
+
+  const disable = () => {
+    if (active) {
+      active = false;
+      window.removeEventListener('scroll', update);
+      layers.forEach(el => (el.style.transform = ''));
+    }
+  };
+
+  mediaQuery.addEventListener('change', () => {
+    if (mediaQuery.matches) {
+      disable();
+    } else {
+      enable();
+    }
+  });
+
+  if (active) {
+    window.addEventListener('scroll', update, { passive: true });
+    update();
+  }
+});

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -17,6 +17,7 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <link rel="stylesheet" href="/assets/css/language-panel.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" integrity="sha384-JwsW+0ELqRMx9x6pRP70dNDO7xjoMnIKPQ4j/wcgUp3NE6PFcAckU4iigFsMghvY" crossorigin="anonymous">
 <link rel="stylesheet" href="/assets/css/custom.css">
+<link rel="stylesheet" href="/assets/css/parallax.css">
 <link rel="stylesheet" href="/assets/css/time_palettes.css">
 <link rel="stylesheet" href="/assets/css/lighting.css">
 <link rel="stylesheet" href="/assets/css/cave_mask.css">

--- a/index.php
+++ b/index.php
@@ -22,6 +22,9 @@ require_once __DIR__ . '/includes/homonexus.php';?><!DOCTYPE html>
 
 </head>
 <body class="alabaster-bg <?php echo homonexus_body_class(); ?>">
+    <div id="layer-sky" class="parallax-layer" data-speed="0.2"></div>
+    <div id="layer-ruins" class="parallax-layer" data-speed="0.4"></div>
+    <div id="layer-grass" class="parallax-layer" data-speed="0.6"></div>
 <?php echo $db_warning; ?>
 <?php
 // Use dynamic PHP header if available so menu fragments can contain


### PR DESCRIPTION
## Summary
- create simple parallax script
- add parallax CSS with purple and gold tones
- insert parallax layers on the homepage
- load parallax assets globally
- document the new effect

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `pip install -r requirements.txt`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_68548dc70f9c832982a2a501acb61c49