### PR TITLE
Add blend-mode utility docs

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -43,3 +43,12 @@ dorado y un efecto de desplazamiento al pasar el ratón.
 
 En el estado _hover_ el botón gana contraste y su sombra interna se
 acentúa, proporcionando un aspecto de relieve y realce.
+
+## Mezcla de color en textos
+
+Para integrar titulares sobre fondos complejos se disponen las clases `.blend-screen` y `.blend-overlay` en `assets/css/epic_theme.css`. Ambas usan la propiedad `mix-blend-mode` para fusionar el color del texto con el fondo.
+
+```html
+<h1 class="blend-overlay">Título</h1>
+<p class="blend-screen">Texto destacado</p>
+```


### PR DESCRIPTION
## Summary
- document `.blend-screen` and `.blend-overlay` utilities for text blend modes
- show example HTML for the new classes

## Testing
- `python -m pytest tests/test_flask_api.py -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68548dbf5dec8329b7da22228ed408d9