### PR TITLE
Fix header class in collaborative gallery

### DIFF
--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -61,7 +61,7 @@ if (is_dir($gallery_dir)) {
         <!-- IMPORTANTE: Asegúrate de tener /imagenes/hero_galeria_background.jpg -->
         <div class="hero-content">
             <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <?php editableText('galeria_colab_header_titulo', $pdo, 'Galería Colaborativa del Condado', 'h1', ''); ?>
+            <?php editableText('galeria_colab_header_titulo', $pdo, 'Galería Colaborativa del Condado', 'h1', 'blend-overlay'); ?>
             <?php editableText('galeria_colab_header_parrafo', $pdo, 'Un mosaico de miradas sobre la belleza, historia y rincones de nuestra tierra, creado por todos.', 'p', ''); ?>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- use the `blend-overlay` class for the collaborative gallery title

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter`
- `pip install -r requirements.txt`
- `vendor/bin/phpunit` *(fails: dom/xml extensions missing)*
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68548dc136048329a96b3daaa1d11319