### PR TITLE
Add hero light sweep animation

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -170,6 +170,10 @@ body::before {
         opacity: 1;
     }
 }
+@keyframes heroLightSweep {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(100%); }
+}
 
 /* --- Headings --- */
 h1, h2, h3, h4, h5, h6 {
@@ -559,6 +563,18 @@ body.dark-mode .footer .social-links a:focus-visible {
     top: 0; left: 0; right: 0; bottom: 0;
     background-color: transparent !important; /* Default dark purple overlay */
     z-index: 1; /* Below content, above background image */
+}
+.hero::after, .page-header::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 200%;
+    height: 100%;
+    pointer-events: none;
+    background: linear-gradient(45deg, rgba(255,255,200,0.1), rgba(255,255,255,0));
+    animation: heroLightSweep 15s linear infinite;
+    z-index: 1;
 }
 /* If a specific background image is set via inline style, this ensures the overlay is still there */
 [style*="background-image"]::before {


### PR DESCRIPTION
## Summary
- add new after pseudo-element for hero with sweeping light effect
- include heroLightSweep keyframes
- confirm hero-content overlays new effect

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854961b6f748329bf0a92cbd6c14c1b