### PR TITLE
Add fallback color for blend classes

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -219,11 +219,13 @@ h6 { font-size: clamp(1em, 2.5vw, 1.4em); }
 .blend-screen {
     mix-blend-mode: screen;
     display: inline-block;
+    color: var(--epic-gold-main); /* Ensure visibility when blend modes are unsupported */
 }
 
 .blend-overlay {
     mix-blend-mode: overlay;
     display: inline-block;
+    color: var(--epic-gold-main); /* Ensure visibility when blend modes are unsupported */
 }
 
 /* --- Paragraphs --- */


### PR DESCRIPTION
## Summary
- ensure `.blend-screen` and `.blend-overlay` have a visible text color

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python3 -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_6854969723608329909e6bc7875d90bf