### PR TITLE
Add GraphDBInterface unit tests

### DIFF
--- a/docs/tareas.md
+++ b/docs/tareas.md
@@ -10,3 +10,4 @@
 - [ ] Integrar el modo Homonexus y el chat IA en todas las páginas.
 - [ ] Garantizar que los menús y botones permanezcan fijos al hacer scroll para que solo el contenido sea desplazable.
 - [ ] Documentar la nueva gráfica de Influencia Romana realizada con D3 y compatible con modo oscuro.
+- [x] Añadir tests de `GraphDBInterface` para `add_or_update_resource`, `resource_exists` y `add_link`.

--- a/tests/test_graph_db_interface.py
+++ b/tests/test_graph_db_interface.py
@@ -1,0 +1,47 @@
+import os
+import tempfile
+import unittest
+
+from graph_db_interface import GraphDBInterface
+
+
+class GraphDBInterfaceTestCase(unittest.TestCase):
+    def setUp(self):
+        # create temporary directory and switch into it so the DB file is isolated
+        self.orig_cwd = os.getcwd()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        os.chdir(self.temp_dir.name)
+        self.db = GraphDBInterface()
+
+    def tearDown(self):
+        os.chdir(self.orig_cwd)
+        self.temp_dir.cleanup()
+
+    def test_add_or_update_resource_and_resource_exists(self):
+        url = "http://example.com/page1"
+        data = {"url": url, "content": "contenido"}
+        self.db.add_or_update_resource(data)
+        # verify the resource was added
+        self.assertTrue(self.db.resource_exists(url))
+        self.assertEqual(self.db.get_resource(url)["content"], "contenido")
+        # update existing resource
+        updated = {"url": url, "content": "actualizado"}
+        self.db.add_or_update_resource(updated)
+        self.assertEqual(self.db.get_resource(url)["content"], "actualizado")
+
+    def test_add_link_creates_placeholders_and_prevents_duplicates(self):
+        link = {"source_url": "http://src.com", "target_url": "http://dst.com"}
+        self.db.add_link(link)
+        # file should exist after save
+        self.assertTrue(os.path.exists(self.db.db_filepath))
+        self.assertEqual(len(self.db.get_all_links()), 1)
+        # placeholders were created
+        self.assertTrue(self.db.resource_exists("http://src.com"))
+        self.assertTrue(self.db.resource_exists("http://dst.com"))
+        # adding same link again should not create a duplicate
+        self.db.add_link(link)
+        self.assertEqual(len(self.db.get_all_links()), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add isolated tests for GraphDBInterface
- mark GraphDBInterface test task as done in docs

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_graph_db_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_685496a76b308329ac0a0e3b1049a6d0