### PR TITLE
Remove duplicate menu entry

### DIFF
--- a/config/main_menu.php
+++ b/config/main_menu.php
@@ -22,5 +22,4 @@ return [
     ['label' => 'Foro', 'url' => '/foro/index.php'],
     ['label' => 'Blog', 'url' => '/blog.php'],
     ['label' => 'Contacto', 'url' => '/contacto/contacto.php'],
-    ['label' => 'Influencia Romana', 'url' => '/historia/influencia_romana.php'],
 ];


### PR DESCRIPTION
## Summary
- remove duplicate "Influencia Romana" item from `config/main_menu.php`

## Testing
- `pip install -r requirements.txt`
- `python3 -m unittest tests/test_flask_api.py`
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685496a8a8c483299e54a61a47360caa