### PR TITLE
Remove duplicate linterna init

### DIFF
--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -125,9 +125,6 @@ if (is_dir($gallery_dir)) {
     
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            if (typeof initializeLinterna === "function") {
-                initializeLinterna();
-            }
 
             // --- Lógica de la Galería Colaborativa ---
             const uploadForm = document.getElementById('uploadPhotoForm');

--- a/js/museo-2d-gallery.js
+++ b/js/museo-2d-gallery.js
@@ -1,11 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-    // Initialize global spotlight effect
-    if (typeof initializeLinterna === 'function') {
-        initializeLinterna();
-    }
-
-    // --- Lógica del Museo Colaborativo (2D Gallery) ---
-
     // --- Variables y DOM Element Selections ---
     const uploadForm = document.getElementById('uploadForm');
     const gallery2DSection = document.getElementById('gallery-2d-section');


### PR DESCRIPTION
## Summary
- remove inline initializeLinterna call from galeria_colaborativa.php
- clean museo-2d-gallery.js top section to rely on layout.js for linterna

## Testing
- `python3 -m unittest discover -v`
- `npm install`
- `npm test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685496b553848329b3a9a723cea85394