### PR TITLE
Add test for linterna gradient

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
   "scripts": {
     "pretest:puppeteer": "php -S localhost:8080 >/dev/null 2>&1 &",
-    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js",
+    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/linternaGradientTest.js",
     "test": "npm run test:puppeteer"
   }
 }

--- a/tests/linternaGradientTest.js
+++ b/tests/linternaGradientTest.js
@@ -1,0 +1,16 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/galeria/galeria_colaborativa.php');
+  await page.waitForSelector('#linterna-condado');
+  const hasClass = await page.$eval('#linterna-condado', el => el.classList.contains('bg-linterna-gradient'));
+  if (!hasClass) {
+    console.error('bg-linterna-gradient class not found');
+    await browser.close();
+    process.exit(1);
+  }
+  console.log('Linterna gradient class present');
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- add Puppeteer test for linterna gradient background
- run this test in the Puppeteer test script

## Testing
- `npm install`
- `npm run test:puppeteer` *(fails: `Error: net::ERR_CONNECTION_REFUSED`)*

------
https://chatgpt.com/codex/tasks/task_e_685496b8766c8329b9c93c80ec845f8b