### PR TITLE
Update npm test script docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ node tests/moonToggleTest.js
 
 `vendor/bin/phpunit` lanza la suite de PHP definida en `phpunit.xml`.
 `python -m unittest tests/test_flask_api.py` ejecuta el conjunto de pruebas de Python sobre la API Flask.
-`npm test` (o `npm run test:puppeteer`) inicia los checks de interfaz con Puppeteer.
+`npm test` ejecuta la suite de Puppeteer (alias de `npm run test:puppeteer`).
 
 Además se proporcionan scripts auxiliares para validar el estado del código:
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
       "tailwindcss": "^3.4.4"
     },
   "scripts": {
+    "test": "npm run test:puppeteer",
     "pretest:puppeteer": "php -S localhost:8080 >/dev/null 2>&1 &",
-    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js",
-    "test": "npm run test:puppeteer"
+    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js"
   }
 }


### PR DESCRIPTION
## Summary
- reorder npm scripts to put `test` first
- clarify in README that `npm test` runs the Puppeteer suite

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685496ce799c8329abe490e2a350ebfd