### PR TITLE
Add requirements script and clarify tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Asegúrate primero de tener instalado **PHP CLI** y **Composer**. En sistemas ba
 sudo apt-get install php-cli composer
 ```
 
+Puedes comprobar que `php`, `composer` y `npm` están disponibles ejecutando `./scripts/check_requirements.sh`. Si falta alguna de estas herramientas, el script mostrará un aviso.
 Una vez clonado el repositorio instala todas las dependencias de PHP y descarga las
 bibliotecas de JavaScript necesarias ejecutando:
 
@@ -272,6 +273,7 @@ node tests/moonToggleTest.js
 `vendor/bin/phpunit` lanza la suite de PHP definida en `phpunit.xml`.
 `python -m unittest tests/test_flask_api.py` ejecuta el conjunto de pruebas de Python sobre la API Flask.
 `npm test` (o `npm run test:puppeteer`) inicia los checks de interfaz con Puppeteer.
+Si no cuentas con `php`, `composer` o `npm`, puedes omitir las suites de PHP y las pruebas de interfaz con Puppeteer. Ejecuta solo los tests de Python en ese caso.
 
 Además se proporcionan scripts auxiliares para validar el estado del código:
 

--- a/scripts/check_requirements.sh
+++ b/scripts/check_requirements.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+missing=()
+
+if ! command -v php >/dev/null 2>&1; then
+  missing+=("php")
+fi
+
+if ! command -v composer >/dev/null 2>&1; then
+  missing+=("composer")
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  missing+=("npm")
+fi
+
+if [ ${#missing[@]} -ne 0 ]; then
+  echo "Faltan los siguientes comandos: ${missing[*]}" >&2
+  echo "Instálalos para poder ejecutar todas las pruebas y scripts" >&2
+  exit 1
+else
+  echo "php, composer y npm están disponibles"
+fi


### PR DESCRIPTION
## Summary
- clarify optional PHP and Puppeteer test suites
- add helper script to check for `php`, `composer` and `npm`

## Testing
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `./scripts/check_requirements.sh`

------
https://chatgpt.com/codex/tasks/task_e_685496d9bba4832990eba0f147967ca2