### PR TITLE
Update Tailwind config comment and clarify build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ El script descarga las bibliotecas **jQuery**, **Bootstrap** y **Tailwind CSS**
 en `assets/vendor`. Tras ello genera la hoja `assets/vendor/css/tailwind.min.css`
 si ejecutas:
 
-Debes lanzar este comando cada vez que modifiques `tailwind.config.js` o
-`assets/css/tailwind_base.css` para que los cambios de diseño se reflejen en la
-hoja final:
+Debes lanzar este comando al instalar el proyecto y cada vez que modifiques
+`tailwind.config.js` o `assets/css/tailwind_base.css` para que los cambios de
+diseño se reflejen en la hoja final:
 
 ```bash
 npx tailwindcss@3.4.4 -i assets/css/tailwind_base.css -o assets/vendor/css/tailwind.min.css --minify

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  // Include tailwind_base.css so @layer directives inside it are processed
   content: [
     './**/*.{php,html}',
     './assets/js/**/*.js',


### PR DESCRIPTION
## Summary
- document when to compile Tailwind assets
- clarify that `tailwind_base.css` is part of Tailwind's content

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685496d9fc7c8329bf5eb3ccd37d9398