### PR TITLE
Fix timeline card hover focus

### DIFF
--- a/historia/timeline/imperial.html
+++ b/historia/timeline/imperial.html
@@ -14,7 +14,7 @@
 
         <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
             <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
-            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md">
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md" tabindex="0">
                 <h3 class="text-2xl font-serif text-yellow-300">53 d.C.</h3>
                 <h4 class="text-xl font-bold text-white mt-2">Nacimiento de Trajano</h4>
                 <p class="text-gray-200 text-sm mt-2">El primer emperador romano nacido en Hispania ve la luz en Itálica, cerca de la actual Sevilla.</p>
@@ -24,7 +24,7 @@
 
         <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
             <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
-            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md">
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md" tabindex="0">
                 <h3 class="text-2xl font-serif text-yellow-300">76 d.C.</h3>
                 <h4 class="text-xl font-bold text-white mt-2">Nacimiento de Adriano</h4>
                 <p class="text-gray-200 text-sm mt-2">Continuador del legado hispano en Roma, también originario de Itálica.</p>
@@ -34,7 +34,7 @@
 
         <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
             <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
-            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md">
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md" tabindex="0">
                 <h3 class="text-2xl font-serif text-yellow-300">347 d.C.</h3>
                 <h4 class="text-xl font-bold text-white mt-2">Nacimiento de Teodosio I</h4>
                 <p class="text-gray-200 text-sm mt-2">Fuentes como <code>nuevo4.md</code> lo vinculan a Auca Patricia (Cerezo de Río Tirón), cuna de emperadores tardorromanos.</p>
@@ -44,7 +44,7 @@
 
         <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
             <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
-            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md">
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md" tabindex="0">
                 <h3 class="text-2xl font-serif text-yellow-300">383 d.C.</h3>
                 <h4 class="text-xl font-bold text-white mt-2">Magno Clemente Máximo</h4>
                 <p class="text-gray-200 text-sm mt-2">Proclamado emperador en Britania, la tradición local señala su nacimiento en Auca Patricia.</p>
@@ -54,7 +54,7 @@
 
         <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
             <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
-            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md">
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md" tabindex="0">
                 <h3 class="text-2xl font-serif text-yellow-300">388 d.C.</h3>
                 <h4 class="text-xl font-bold text-white mt-2">Flavio Victor</h4>
                 <p class="text-gray-200 text-sm mt-2">Hijo de Máximo, según <code>nuevo4.md</code> fue ejecutado en el circo de Auca Patricia el 26 de agosto.</p>
@@ -64,7 +64,7 @@
 
         <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
             <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
-            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md">
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md" tabindex="0">
                 <h3 class="text-2xl font-serif text-yellow-300">574 d.C.</h3>
                 <h4 class="text-xl font-bold text-white mt-2">Conquista visigoda</h4>
                 <p class="text-gray-200 text-sm mt-2">Leovigildo toma Auca Patricia y derriba sus murallas de hormigón romano, marcando el final de la ciudad clásica.</p>
@@ -74,7 +74,7 @@
 
         <div class="relative flex flex-col md:flex-row items-center md:items-start mb-12 md:w-1/2 animate-on-scroll opacity-0 translate-y-10 transition duration-700 ease-out">
             <span class="absolute left-1/2 md:left-auto md:top-1/2 md:-ml-2 w-4 h-4 bg-yellow-500 rounded-full border-4 border-purple-900"></span>
-            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md">
+            <div class="md:ml-8 bg-gray-800 bg-opacity-70 p-6 rounded-lg shadow-lg purple-shadow transition-shadow hover:shadow-2xl focus:shadow-2xl max-w-md" tabindex="0">
                 <h3 class="text-2xl font-serif text-yellow-300">Actualidad</h3>
                 <h4 class="text-xl font-bold text-white mt-2">Promoción de Cerezo de Río Tirón</h4>
                 <p class="text-gray-200 text-sm mt-2">Nuestra web impulsa el turismo y gestiona el patrimonio arqueológico y cultural de la zona, manteniendo vivo el legado de Castilla.</p>


### PR DESCRIPTION
## Summary
- support keyboard focus on Imperial timeline cards with `tabindex`

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685496da92d08329b2f60246622bd6b1