### PR TITLE
Clean up unused variable in head_common.php

### DIFF
--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -2,7 +2,6 @@
 require_once __DIR__ . '/session.php';
 ensure_session_started();
 require_once __DIR__ . '/env_loader.php';
-$geminiKey = getenv('GEMINI_API_KEY') ?: '';
 ?>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- remove obsolete `$geminiKey` assignment from `includes/head_common.php`

## Testing
- `composer install` *(fails: required PHP extensions not enabled)*
- `vendor/bin/phpunit` *(fails: missing php-cgi and other extensions)*
- `python -m unittest tests/test_flask_api.py`
- `npm test` *(fails: timeout waiting for selector)*
- `node tests/moonToggleTest.js`

------
https://chatgpt.com/codex/tasks/task_e_685496fc2d1483299ad50aa4fa0240e8