### PR TITLE
Remove redundant audio controller script

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -25,4 +25,3 @@
 <script src="/assets/js/scroll-fade.js"></script>
 <script src="/assets/js/parallax.js"></script>
 <script src="/js/lang-bar.js"></script>
-<script src="/js/audio-controller.js"></script>


### PR DESCRIPTION
## Summary
- keep preferred audio controller path in `_footer.php`
- run composer/npm/pip installs
- run unit tests and link check scripts

## Testing
- `vendor/bin/phpunit` *(fails: could not find php-cgi, etc.)*
- `python -m unittest tests/test_flask_api.py`
- `npm test` *(fails: TimeoutError waiting for selector)*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*
- `./check_links.sh`
- `./check_links_extended.sh`


------
https://chatgpt.com/codex/tasks/task_e_6854972b1adc8329989dd860d6877173