### PR TITLE
Add Playfair Display font and sheen hover effect

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -41,7 +41,7 @@
     --epic-transparent-black-overlay: rgba(10, 10, 10, 0.75);
 
     --font-primary: 'Lora', serif;
-    --font-headings: 'Cinzel', serif;
+    --font-headings: 'Playfair Display Variable', serif;
 
     --global-border-radius: 8px;
     --global-transition-speed: 0.3s;
@@ -2848,4 +2848,15 @@ button, input[type="submit"], input[type="button"], .cta-button, .submit-button,
     margin-top: 30px;
     padding-top: 20px;
     border-top: 1px dashed var(--epic-neutral-border);
+}
+@keyframes sheen {
+    from { background-position: -200% 0; }
+    to   { background-position: 200% 0; }
+}
+
+h1:hover {
+    background-image: linear-gradient(90deg,var(--epic-gold-main),var(--epic-purple-emperor),var(--epic-gold-main));
+    background-clip: text;
+    background-size: 200% 100%;
+    animation: sheen 3s linear infinite;
 }

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -10,6 +10,7 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500..900;1,500..900&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 <link rel="stylesheet" href="/assets/css/epic_theme.css">
 <link rel="stylesheet" href="/assets/css/header.css">


### PR DESCRIPTION
## Summary
- load Google Playfair Display Variable font in head
- use Playfair Display Variable for heading CSS variable
- add sheen animation for `h1:hover`

## Testing
- `vendor/bin/phpunit` *(fails: data providers invalid, php-cgi not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6854972cf070832985164cc830964afd