### PR TITLE
Add moon mode toggle

### DIFF
--- a/_header.php
+++ b/_header.php
@@ -11,6 +11,7 @@
 <div id="consolidated-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="consolidated-menu-button">
     <button id="ai-chat-trigger" class="menu-item-button" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA"><i class="fas fa-comments"></i> <span>Chat IA</span></button>
     <button id="theme-toggle" class="menu-item-button" aria-label="Cambiar tema"><i class="fas fa-moon"></i> <span>Modo</span></button>
+    <button id="moon-toggle" class="menu-item-button">🌙 Modo luna</button>
     <button id="palette-toggle" class="menu-item-button" aria-label="Cambiar paleta"><i class="fas fa-palette"></i> <span>Paleta</span></button>
 
     <div class="menu-section">


### PR DESCRIPTION
## Summary
- add `#moon-toggle` button next to the theme toggle

## Testing
- `python -m unittest tests/test_flask_api.py` *(passes)*
- `npm test` *(fails: `net::ERR_CONNECTION_REFUSED`)*
- `node tests/moonToggleTest.js` *(fails: `Cannot read properties of null` error)*

------
https://chatgpt.com/codex/tasks/task_e_68549734cb9083298881705e5690a929