### PR TITLE
Add fireflies night effect

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -2849,3 +2849,30 @@ button, input[type="submit"], input[type="button"], .cta-button, .submit-button,
     padding-top: 20px;
     border-top: 1px dashed var(--epic-neutral-border);
 }
+
+/* --- Fireflies effect --- */
+.fireflies-container {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 1;
+    overflow: hidden;
+}
+
+.firefly {
+    position: absolute;
+    top: 0;
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 50%;
+    box-shadow: 0 0 6px rgba(255, 255, 255, 0.9);
+    animation: drift linear infinite;
+}
+
+@keyframes drift {
+    from {
+        transform: translateY(100vh) translateX(-50%);
+    }
+    to {
+        transform: translateY(-10vh) translateX(-50%);
+    }
+}

--- a/assets/js/fireflies.js
+++ b/assets/js/fireflies.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+    if (!document.body.classList.contains('luna')) return;
+
+    const container = document.createElement('div');
+    container.className = 'fireflies-container';
+
+    const total = 40;
+    for (let i = 0; i < total; i++) {
+        const f = document.createElement('div');
+        f.className = 'firefly';
+        const size = 1 + Math.random() * 2;
+        f.style.width = `${size}px`;
+        f.style.height = `${size}px`;
+        f.style.left = `${Math.random() * 100}%`;
+        f.style.animationDelay = `${Math.random() * 10}s`;
+        f.style.animationDuration = `${10 + Math.random() * 10}s`;
+        container.appendChild(f);
+    }
+
+    document.body.appendChild(container);
+});

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -8,6 +8,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `assets/js/homonexus-toggle.js` | Toggles Homonexus mode, storing the preference in a cookie. |
 | `assets/js/foro.js` | Simple toggling for the forum agents menu. |
 | `assets/js/audio-controller.js` | Lowers audio/video volume when sliding menus open and exposes `handleMenuToggle` for other scripts. |
+| `assets/js/fireflies.js` | Spawns subtle white particles when the page is in `luna` mode for an ambient night effect. |
 | `js/config.js` | Defines `API_BASE_URL` and `DEBUG_MODE` globals for other scripts. |
 | `js/layout.js` | Loads external CSS/JS libraries on demand, initializes the flashlight effect and other page-level utilities. |
 | `js/load_menu_parts.js` | Dynamically loads menu fragments into the header when needed. |

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -29,6 +29,7 @@ $geminiKey = getenv('GEMINI_API_KEY') ?: '';
 <link rel="stylesheet" href="/assets/css/torch_cursor.css">
 <script defer src="/assets/js/torch_cursor.js"></script>
 <link rel="stylesheet" href="/assets/css/glow_filter.css">
+<script defer src="/assets/js/fireflies.js"></script>
 <?php
 $svgFilterPath = __DIR__ . '/../fragments/header/svg_filters.html';
 if (file_exists($svgFilterPath)) {


### PR DESCRIPTION
## Summary
- spawn drifting fireflies in `luna` mode
- style fireflies in epic theme
- load fireflies script from the head
- document the module in the JS overview

## Testing
- `python -m unittest tests/test_flask_api.py`
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6854973e07208329b5b7950e373c9698