### PR TITLE
Update testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Si `GEMINI_API_KEY` no está definida, las funciones de `includes/ai_utils.php` 
 ## Testing
 
 **Es obligatorio ejecutar los siguientes comandos antes de cualquier suite de pruebas:**
+Asegúrate de tener **Composer** y **PHPUnit** instalados en tu sistema antes de ejecutar las pruebas. `PHPUnit` puede instalarse de manera global o utilizar el binario que se genera en `vendor/bin/phpunit` tras ejecutar `composer install`.
 Instala **todas** las dependencias antes de lanzar las suites de pruebas. Las pruebas dependen de PHP, Composer y las extensiones indicadas, por lo que no se ejecutarán si alguno de estos componentes falta. En particular es imprescindible tener disponible la interfaz de línea de comandos de PHP (PHP CLI). Ejecuta primero:
 
 ```bash
@@ -272,6 +273,8 @@ node tests/moonToggleTest.js
 `vendor/bin/phpunit` lanza la suite de PHP definida en `phpunit.xml`.
 `python -m unittest tests/test_flask_api.py` ejecuta el conjunto de pruebas de Python sobre la API Flask.
 `npm test` (o `npm run test:puppeteer`) inicia los checks de interfaz con Puppeteer.
+
+Si cualquiera de estos comandos devuelve un error de "command not found" lo más probable es que **PHP**, **Composer** o **PHPUnit** no estén instalados correctamente.
 
 Además se proporcionan scripts auxiliares para validar el estado del código:
 


### PR DESCRIPTION
## Summary
- clarify that Composer and PHPUnit must be installed
- note that missing PHP/Composer may cause failing commands

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6854973c54d88329af1c48d4d755245d