### PR TITLE
Fix duplicate audio-controller script

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -25,4 +25,3 @@
 <script src="/assets/js/scroll-fade.js"></script>
 <script src="/assets/js/parallax.js"></script>
 <script src="/js/lang-bar.js"></script>
-<script src="/js/audio-controller.js"></script>

--- a/assets/js/audio-controller.js
+++ b/assets/js/audio-controller.js
@@ -1,5 +1,5 @@
 // assets/js/audio-controller.js - simple volume controller
-(function(window, document) {
+(function (window, document) {
     function adjustVolume(lowered) {
         document.querySelectorAll('audio, video').forEach(el => {
             if (!el.dataset.originalVolume) {
@@ -13,6 +13,30 @@
     function handleMenuToggle(anyOpen) {
         adjustVolume(anyOpen);
     }
+
+    let muted = false;
+
+    function updateMuteState(btn) {
+        if (!btn) return;
+        btn.setAttribute('aria-pressed', muted ? 'true' : 'false');
+        btn.textContent = muted ? '🔇' : '🔊';
+    }
+
+    function toggleMute(btn) {
+        muted = !muted;
+        document.querySelectorAll('audio, video').forEach(el => {
+            el.muted = muted;
+        });
+        updateMuteState(btn);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const btn = document.getElementById('mute-toggle');
+        if (btn) {
+            updateMuteState(btn);
+            btn.addEventListener('click', () => toggleMute(btn));
+        }
+    });
 
     document.addEventListener('menu-toggled', e => {
         handleMenuToggle(!!e.detail.open);


### PR DESCRIPTION
## Summary
- clean up `_footer.php` by removing the duplicate `<script>` tag
- merge mute-toggle logic into `assets/js/audio-controller.js`

## Testing
- `npm install`
- `npm test` *(fails: `net::ERR_CONNECTION_REFUSED` because `php` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68549723bea08329b64c0705bcb942c6