### PR TITLE
Add PHP server cleanup for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,14 +264,18 @@ Con las dependencias ya instaladas, ejecuta cada conjunto de tests de forma expl
 ```bash
 vendor/bin/phpunit
 python -m unittest tests/test_flask_api.py
-# Asegúrate de tener un servidor local en marcha (por ejemplo `php -S localhost:8080`)
 npm test
 node tests/moonToggleTest.js
 ```
 
+`npm test` inicia un servidor PHP temporal en `localhost:8080` y lo detiene al
+finalizar las pruebas. Este script usa sintaxis POSIX, por lo que en Windows se
+recomienda ejecutarlo desde **Git Bash** o **WSL** para que la limpieza del
+proceso funcione correctamente.
+
 `vendor/bin/phpunit` lanza la suite de PHP definida en `phpunit.xml`.
 `python -m unittest tests/test_flask_api.py` ejecuta el conjunto de pruebas de Python sobre la API Flask.
-`npm test` (o `npm run test:puppeteer`) inicia los checks de interfaz con Puppeteer.
+`npm test` inicia los checks de interfaz con Puppeteer.
 
 Además se proporcionan scripts auxiliares para validar el estado del código:
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
       "tailwindcss": "^3.4.4"
     },
   "scripts": {
-    "pretest:puppeteer": "php -S localhost:8080 >/dev/null 2>&1 &",
-    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js",
-    "test": "npm run test:puppeteer"
+    "test": "sh -c 'php -S localhost:8080 >/dev/null 2>&1 & PHP_PID=$!; trap \"kill $PHP_PID\" EXIT; node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js'"
   }
 }


### PR DESCRIPTION
## Summary
- launch PHP test server in `npm test` and kill it automatically with a shell trap
- document how the new test script works and note POSIX shell requirement

## Testing
- `pip install -r requirements.txt`
- `npm install`
- `npm test` *(fails: `TimeoutError: Waiting for selector`)*
- `sudo apt-get install -y php-cli`
- `php -v`

------
https://chatgpt.com/codex/tasks/task_e_68549840d528832999cf16de7d7a4c33