### PR TITLE
Document moon mode usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Promocionar el turismo en **Cerezo de Río Tirón** y gestionar de forma activa 
 - Paleta que cambia automáticamente según la hora del visitante (amanecer, mediodía, atardecer o noche) con opción manual.
 - Foro con cinco agentes expertos para dinamizar la comunidad.
 
+### Modo luna
+
+Una variante oscura que reduce la luminosidad general. Pulsa el botón `moon-toggle`
+para activar el modo luna; el script añadirá la clase `luna` al `<body>` y guardará
+el valor `"moon"` en `localStorage`. Vuelve a pulsar para restaurar la apariencia
+clara.
+
 ### Agentes del foro
 
 Cinco perfiles virtuales dinamizan las conversaciones y ayudan a resolver dudas:
@@ -268,6 +275,9 @@ python -m unittest tests/test_flask_api.py
 npm test
 node tests/moonToggleTest.js
 ```
+
+`node tests/moonToggleTest.js` verifica que el botón `moon-toggle` añada la clase
+`luna` y guarde `"moon"` en `localStorage`.
 
 `vendor/bin/phpunit` lanza la suite de PHP definida en `phpunit.xml`.
 `python -m unittest tests/test_flask_api.py` ejecuta el conjunto de pruebas de Python sobre la API Flask.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -20,6 +20,17 @@ Esta guía resume la paleta de colores usada de forma consistente en todo el pro
 
 Los equivalentes `-rgb` se encuentran en la misma hoja de estilos para crear transparencias con `rgba()`.
 
+## Paleta Modo luna
+
+El modo luna ofrece un aspecto nocturno con gran contraste. Se activa añadiendo la clase
+`luna` al elemento `<body>` y define las siguientes variables:
+
+| Variable | Descripción | Valor |
+|----------|-------------|-------|
+| `--moon-bg` | Fondo principal oscuro | `#0d1117` |
+| `--moon-text` | Texto claro de alto contraste | `#e0e0e0` |
+| `--moon-accent` | Detalle en púrpura intenso | `#663399` |
+
 ## Texto con degradado
 
 Para destacar títulos y cabeceras se utiliza la clase `.gradient-text`,


### PR DESCRIPTION
## Summary
- document how to toggle *modo luna* in README
- note the `moon-toggle` button and `"moon"` entry in `localStorage`
- list moon-mode variables in the style guide
- include a line on running `node tests/moonToggleTest.js`

## Testing
- `node tests/moonToggleTest.js` *(fails: moon-toggle button not found)*

------
https://chatgpt.com/codex/tasks/task_e_685497333efc83299985adaeac7e74d9