### PR TITLE
Remove unused variable

### DIFF
--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -2,7 +2,6 @@
 require_once __DIR__ . '/session.php';
 ensure_session_started();
 require_once __DIR__ . '/env_loader.php';
-$geminiKey = getenv('GEMINI_API_KEY') ?: '';
 ?>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- remove unused `$geminiKey` definition in `includes/head_common.php`

## Testing
- `npm install`
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED; php server missing)*

------
https://chatgpt.com/codex/tasks/task_e_685497985ab08329ab13cb141b4d7aff