### PR TITLE
Add Puppeteer test for linterna gradient

### DIFF
--- a/docs/tareas.md
+++ b/docs/tareas.md
@@ -11,3 +11,4 @@
 - [ ] Garantizar que los menús y botones permanezcan fijos al hacer scroll para que solo el contenido sea desplazable.
 - [ ] Documentar la nueva gráfica de Influencia Romana realizada con D3 y compatible con modo oscuro.
 - [x] Añadir tests de `GraphDBInterface` para `add_or_update_resource`, `resource_exists` y `add_link`.
+- [x] Añadir test de Puppeteer `linternaGradientTest.js` para verificar `bg-linterna-gradient` en la galería.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
   "scripts": {
     "pretest:puppeteer": "php -S localhost:8080 >/dev/null 2>&1 &",
-    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js",
+    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js",
     "test": "npm run test:puppeteer"
   }
 }

--- a/tests/linternaGradientTest.js
+++ b/tests/linternaGradientTest.js
@@ -1,0 +1,16 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/galeria/galeria_colaborativa.php');
+  await page.waitForSelector('#linterna-condado');
+  const hasClass = await page.$eval('#linterna-condado', el => el.classList.contains('bg-linterna-gradient'));
+  if (!hasClass) {
+    console.error('#linterna-condado missing bg-linterna-gradient');
+    await browser.close();
+    process.exit(1);
+  }
+  console.log('bg-linterna-gradient class found');
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- add new puppeteer test `linternaGradientTest.js`
- run this test via `npm run test:puppeteer`
- note the new test in task list documentation

## Testing
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854ac05b2448329988acff646252252