### PR TITLE
Improve Puppeteer pretest script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
       "tailwindcss": "^3.4.4"
     },
   "scripts": {
-    "pretest:puppeteer": "php -S localhost:8080 >/dev/null 2>&1 &",
+    "pretest:puppeteer": "php -S localhost:8080 >/tmp/php-server.log 2>&1 & PHP_PID=$!; echo $PHP_PID > /tmp/php-server.pid; for i in {1..10}; do curl -s http://localhost:8080 >/dev/null 2>&1 && break || sleep 1; done; if ! kill -0 $PHP_PID >/dev/null 2>&1; then cat /tmp/php-server.log; exit 1; fi",
     "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js",
+    "posttest:puppeteer": "if [ -f /tmp/php-server.pid ]; then kill $(cat /tmp/php-server.pid); rm /tmp/php-server.pid; fi",
     "test": "npm run test:puppeteer"
   }
 }

--- a/testing_evaluation_strategy.md
+++ b/testing_evaluation_strategy.md
@@ -126,3 +126,13 @@ class TestContentProcessor(unittest.TestCase):
 
 This strategy will evolve as the system grows in complexity and features. Regular review and adaptation of the testing and evaluation approach will be necessary.
 ```
+
+## Troubleshooting
+
+If `npm run test:puppeteer` exits immediately or shows a connection error, the embedded PHP server may not have started correctly.
+
+1. Check `/tmp/php-server.log` for startup messages or errors.
+2. Make sure no other service is using port `8080`.
+3. Stop stray PHP processes with `pkill -f 'php -S'` and rerun the tests.
+
+You can also launch the server manually with `php -S localhost:8080` and confirm it responds at <http://localhost:8080> before executing the test suite.


### PR DESCRIPTION
## Summary
- verify PHP starts before running Puppeteer tests
- kill the server after the test run
- document how to troubleshoot failing Puppeteer tests

## Testing
- `npm install`
- `npm run test:puppeteer` *(fails: `php` not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: `ModuleNotFoundError: No module named 'flask'`)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ac072f308329aa6e086588b832d5