### PR TITLE
Remove unused Flask demo function

### DIFF
--- a/js/ia-tools.js
+++ b/js/ia-tools.js
@@ -177,12 +177,12 @@ function handleWebSearch(output) {
 
 // Simple demo request to the Flask API.
 // Example: call demoFlaskRequest() from the browser console to test connectivity.
-function demoFlaskRequest() {
-    fetch(`${API_BASE_URL}/api/resource`)
-        .then(res => res.json())
-        .then(data => console.log('API resources', data))
-        .catch(err => console.error('API error', err));
-}
+// function demoFlaskRequest() {
+//     fetch(`${API_BASE_URL}/api/resource`)
+//         .then(res => res.json())
+//         .then(data => console.log('API resources', data))
+//         .catch(err => console.error('API error', err));
+// }
 
 // --- AI Chat helper functions ---
 


### PR DESCRIPTION
## Summary
- comment out `demoFlaskRequest` in `ia-tools.js`

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*
- `pytest -q` *(fails: ModuleNotFoundError for `flask_app`)*

------
https://chatgpt.com/codex/tasks/task_e_6854ac1c7bd48329b3667ea52d64dd0a