### PR TITLE
Remove unused insertHtmlWithScripts helper

### DIFF
--- a/js/layout.js
+++ b/js/layout.js
@@ -256,19 +256,6 @@ function loadAos() {
     }
 }
 
-function insertHtmlWithScripts(container, html) {
-    container.innerHTML = html;
-    const scripts = container.querySelectorAll('script');
-    scripts.forEach(oldScript => {
-        const newScript = document.createElement('script');
-        Array.from(oldScript.attributes).forEach(attr => {
-            newScript.setAttribute(attr.name, attr.value);
-        });
-        newScript.textContent = oldScript.textContent;
-        document.head.appendChild(newScript);
-        oldScript.remove();
-    });
-}
 
 function loadIAToolsScript() {
     if (!document.querySelector('script[src="/js/ia-tools.js"]')) {


### PR DESCRIPTION
## Summary
- remove the unused `insertHtmlWithScripts` helper function from `js/layout.js`

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854ac1d70a083299bc011809c0f499b