### PR TITLE
Add utility CSS classes and replace inline styles

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -2823,6 +2823,12 @@ button, input[type="submit"], input[type="button"], .cta-button, .submit-button,
     border-radius: var(--global-border-radius);
 }
 
+/* Highlighted tool error messages */
+.ia-tool-error {
+    color: var(--epic-error-red, #D9534F);
+    text-align: center;
+}
+
 .section-divider {
     margin-top: 30px;
     margin-bottom: 30px;
@@ -2851,6 +2857,20 @@ button, input[type="submit"], input[type="button"], .cta-button, .submit-button,
 .mt-20 {
     margin-top: 20px;
 }
+
+/* Additional spacing utilities */
+.mt-25 { margin-top: 2.5em; }
+.mb-25 { margin-bottom: 2.5em; }
+
+/* Center introductory text blocks */
+.intro-centered {
+    text-align: center;
+    margin: 0 auto 2em;
+    max-width: 80ch;
+}
+
+/* Inline form layout */
+.inline-form { display: inline; }
 
 .hero-atapuerca {
     background-image: linear-gradient(rgba(var(--epic-purple-emperor-rgb), 0.55), rgba(var(--epic-purple-emperor-rgb), 0.55)), url('/assets/img/placeholder.jpg');

--- a/contenido/lugares/cerezo_de_rio_tiron/visita.php
+++ b/contenido/lugares/cerezo_de_rio_tiron/visita.php
@@ -10,7 +10,7 @@
         <h3>Planifica Tu Visita a Cerezo</h3>
 <p>Cerezo de Río Tirón te espera con los brazos abiertos. Para organizar tu viaje y descubrir todos los secretos que esta tierra ancestral tiene para ofrecer, te invitamos a consultar nuestra sección de <a href="/visitas/visitas.html">Planifica Tu Visita</a>.</p>
 <p>Allí encontrarás información sobre cómo llegar, opciones de alojamiento, gastronomía local y rutas turísticas para no perderte nada. ¡Ven y vive la historia en primera persona!</p>
-<p class="text-center" style="margin-top: 2em;"><a href="/visitas/visitas.html" class="cta-button cta-button-small">Ir a Planifica Tu Visita</a></p>
+<p class="text-center mt-20"><a href="/visitas/visitas.html" class="cta-button cta-button-small">Ir a Planifica Tu Visita</a></p>
     </main>
 
     <?php require_once __DIR__ . '/../../../_footer.php'; ?>

--- a/cultura/cultura.php
+++ b/cultura/cultura.php
@@ -39,7 +39,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
     <main>
         <section class="section"> <div class="container page-content-block"> <?php editableText('cultura_intro_p1', $pdo, 'El Condado de Castilla no solo es un crisol de historia, sino también una fuente inagotable de cultura
                     y tradiciones que han perdurado a través de los siglos. Desde el nacimiento de un idioma universal
-                    hasta las costumbres que definen a sus gentes, te invitamos a explorar el alma de esta tierra.', 'p', 'intro-paragraph text-center', 'style="font-size: clamp(1.1em, 2.4vw, 1.3em); margin-bottom: 2.5em;"'); ?>
+                    hasta las costumbres que definen a sus gentes, te invitamos a explorar el alma de esta tierra.', 'p', 'intro-paragraph text-center mb-25'); ?>
 
                 <article class="culture-article-block">
                     <?php editableText('cultura_idioma_titulo_texto', $pdo, '<i class="fas fa-language"></i> El Origen del Idioma Castellano', 'h2'); ?>
@@ -121,7 +121,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
                         <img src="/assets/img/placeholder.jpg" alt="Fotografía de una excavación arqueológica en curso en el yacimiento de Auca Patricia">
                         <?php editableText('cultura_arqueologia_caption_texto', $pdo, '<i class="fas fa-search-location"></i> Arqueólogos desenterrando los secretos del pasado.', 'p', 'image-caption'); ?>
                     </div>
-                    <p class="text-center" style="margin-top: 2em;">
+                    <p class="text-center mt-20">
                         <?php editableText('cultura_link_explora_lugares_texto', $pdo, 'Explora los Lugares Emblemáticos', 'a', 'cta-button cta-button-small', 'href="/lugares/lugares.php"'); ?>
                     </p>
                 </article>

--- a/en_construccion.php
+++ b/en_construccion.php
@@ -1,7 +1,7 @@
 <?php require_once __DIR__ . '/includes/head_common.php'; ?>
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/_header.php'; ?>
-    <main class="container page-content-block" style="text-align: center; padding: 4em 1em;">
+    <main class="container page-content-block error-page">
         <h1>Esta sección estará disponible próximamente</h1>
         <p>Estamos trabajando para habilitar este enlace. Vuelve a visitarnos pronto.</p>
         <p><a href="/index.php" class="cta-button">Volver al inicio</a></p>

--- a/foro/index.php
+++ b/foro/index.php
@@ -68,7 +68,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo) {
 <?php endforeach; ?>
 </div>
 <main class="container page-content-block">
-    <h1 style="text-align:center;" class="gradient-text">Foro de Expertos</h1>
+    <h1 class="gradient-text text-center">Foro de Expertos</h1>
     <?php if (!empty($_SESSION['forum_error'])): ?>
         <p class="feedback error"><?php echo htmlspecialchars($_SESSION['forum_error']); unset($_SESSION['forum_error']); ?></p>
     <?php endif; ?>

--- a/foro/manage_comments.php
+++ b/foro/manage_comments.php
@@ -70,7 +70,7 @@ if ($pdo) {
                     <td><?php echo htmlspecialchars($c['comment']); ?></td>
                     <td><?php echo htmlspecialchars(date('d/m/Y H:i', strtotime($c['created_at']))); ?></td>
                     <td>
-                        <form method="post" style="display:inline;" onsubmit="return confirm('¿Eliminar este comentario?');">
+                        <form method="post" class="inline-form" onsubmit="return confirm('¿Eliminar este comentario?');">
                             <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(get_csrf_token()); ?>">
                             <input type="hidden" name="id" value="<?php echo $c['id']; ?>">
                             <button type="submit">Eliminar</button>

--- a/historia/subpaginas_indice.php
+++ b/historia/subpaginas_indice.php
@@ -47,8 +47,8 @@ load_page_css();
                         <p><?php echo htmlspecialchars($error_message); ?></p>
                     </div>
                 <?php else: ?>
-                    <p style="text-align: center; max-width: 80ch; margin-left: auto; margin-right: auto; margin-bottom: 2em;"><?php echo htmlspecialchars($descripcion_general); ?></p>
-                    <p style="text-align: center; margin-bottom: 2.5em;"><a href="/historia/nuestra_historia_nuevo4.html" class="read-more" style="background-color: var(--color-primario-purpura);">&laquo; Volver a la página principal de Nuestra Historia</a></p>
+                    <p class="intro-centered"><?php echo htmlspecialchars($descripcion_general); ?></p>
+                    <p class="text-center mb-25"><a href="/historia/nuestra_historia_nuevo4.html" class="read-more" style="background-color: var(--color-primario-purpura);">&laquo; Volver a la página principal de Nuestra Historia</a></p>
                     <?php if (!empty($temas_detallados)): ?>
                         <ul class="subpage-index-list">
                             <?php foreach ($temas_detallados as $tema): ?>

--- a/personajes/indice_personajes.html
+++ b/personajes/indice_personajes.html
@@ -34,7 +34,7 @@
                     Explora las biografías y el legado de las figuras más importantes que marcaron la historia de Cerezo de Río Tirón, el Alfoz de Cerasio y Lantarón, y el Condado de Castilla.
                 </p>
                 
-                <div id="error-message-container" style="color: red; text-align: center;"></div>
+                <div id="error-message-container" class="ia-tool-error"></div>
                 <ul class="indice-categorias">
                     <li>
                         <h3 class="gradient-text"><i class="fas fa-chess-king"></i> Condes de Castilla, Álava y Lantarón</h3>

--- a/secciones_index/historia_tiempo_resumen.html
+++ b/secciones_index/historia_tiempo_resumen.html
@@ -41,7 +41,7 @@
                         <p>Nacimiento y consolidación del Condado de Castilla, con Cerezo como enclave.</p>
                     </div>
                 </div>
-                <p class="text-center" style="margin-top: 2.5em;">
+                <p class="text-center mt-25">
                     <a href="/historia/historia.html" class="cta-button">Ver Línea de Tiempo Completa</a>
                 </p>
             </div>

--- a/secciones_index/memoria_hispanidad.html
+++ b/secciones_index/memoria_hispanidad.html
@@ -85,7 +85,7 @@
                     <img src="/assets/img/x.jpg" alt="Vista panorámica del yacimiento arqueológico de Auca Patricia, mostrando la extensión de la antigua ciudad romana">
                     <img src="/assets/img/Llana.jpg" alt="Exterior de la Iglesia de Santa María de la Llana en Cerezo, también conocida como Mezquita de Yanna">
                 </div>
-                <div style="margin-top: 2.5em;"> 
+                <div class="mt-25">
                     <h2>Castilla: Nacida en el Alfoz de Cerezo y Lantarón</h2>
                     <p>
                         Descubre con nosotros que <strong>Castilla nace</strong> en el <em>Alfoz de Cerezo y Lantarón</em>,  


### PR DESCRIPTION
## Summary
- define `.ia-tool-error` and spacing helpers in `epic_theme.css`
- create `.intro-centered` and `.inline-form` utilities
- clean up inline styles in PHP/HTML pages

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_app')*

------
https://chatgpt.com/codex/tasks/task_e_6854ac2251648329ab164ba73f6cc822