### PR TITLE
Fix duplicate header inclusion

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -1,6 +1,5 @@
 <?php
 require_once __DIR__ . '/includes/head_common.php';
-require_once __DIR__ . '/_header.php';
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';
 }


### PR DESCRIPTION
## Summary
- remove early header inclusion in `blog.php`

## Testing
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:8080/tests/manual/test_lang.html)*
- `node tests/moonToggleTest.js` *(fails: Activation failed)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ad0cbfe08329b1baabc640b43363