### PR TITLE
Fix blog header include

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -1,6 +1,5 @@
 <?php
 require_once __DIR__ . '/includes/head_common.php';
-require_once __DIR__ . '/_header.php';
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';
 }


### PR DESCRIPTION
## Summary
- remove duplicate header include in `blog.php`

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run test:puppeteer` *(fails: missing puppeteer)*
- `node tests/moonToggleTest.js` *(fails: missing jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_6854ad11fee4832985fea87e95211631