### PR TITLE
Use BASE_URL env var in sitemap generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ FORUM_COMMENT_COOLDOWN=60
 # Controla la visualización de errores y avisos en PHP. Usar 'true' para
 # entornos de desarrollo y 'false' en producción.
 APP_DEBUG=false
+# Base URL del sitio utilizada por scripts como `generate_sitemap.py`
+# Modifícala para pruebas locales o entornos de staging.
+BASE_URL="https://condadodecastilla.com"

--- a/README.md
+++ b/README.md
@@ -401,6 +401,18 @@ python tree_builder.py
 El script explora las distintas secciones y crea un fichero JSON con las URLs
 ordenadas jerárquicamente.
 
+## Generar `sitemap.xml`
+
+Para actualizar el mapa del sitio ejecuta:
+
+```bash
+python scripts/generate_sitemap.py
+```
+
+El script leerá la variable de entorno `BASE_URL` para construir cada entrada.
+Define esta variable en tu `.env` antes de ejecutar el comando si necesitas
+apuntar a un dominio distinto al predeterminado.
+
 ## CDN Checksums
 
 Los siguientes resúmenes se utilizan en los atributos `integrity` para los archivos cargados desde CDN. Se calcularon con `openssl dgst -sha384 -binary | openssl base64 -A`.

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -3,7 +3,9 @@ import xml.etree.ElementTree as ET
 from xml.dom import minidom
 from datetime import datetime
 
-BASE_URL = "https://condadodecastilla.com"
+# Base URL used in each entry of the sitemap. Can be overridden with an
+# environment variable for local testing or different deployments.
+BASE_URL = os.getenv('BASE_URL', 'https://condadodecastilla.com')
 
 EXCLUDE_DIRS = {
     'scripts', 'dashboard', '__pycache__', 'assets', 'uploads',


### PR DESCRIPTION
## Summary
- read BASE_URL from environment in `generate_sitemap.py`
- document BASE_URL in `.env.example`
- mention `BASE_URL` when regenerating `sitemap.xml`

## Testing
- `python -m unittest -q`
- `npm test --silent` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854ad219df08329a8c650db2deef524