### PR TITLE
Use env vars for DB config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
 # Archivo de configuración de entorno para Condado de Castilla
 
 # --- Configuración de la Base de Datos PostgreSQL ---
+# Dirección del servidor de PostgreSQL
 DB_HOST="localhost"
+# Puerto usado por el servicio
 DB_PORT="5432"
+# Nombre de la base de datos
 DB_NAME="condado_castilla_db"
+# Usuario con permisos de lectura/escritura
 DB_USER="condado_user"
 CONDADO_DB_PASSWORD="your_password"
 GEMINI_API_KEY=your_key

--- a/README.md
+++ b/README.md
@@ -77,23 +77,25 @@ sudo apt install php php-cli php-xml php-xmlwriter php-mbstring php-pgsql compos
 
 ## Configuración de la base de datos
 
-El archivo `includes/db_connect.php` define los parámetros para conectarse a la base de datos PostgreSQL. Se proporciona con valores de ejemplo y **debe** modificarse con las credenciales reales antes de usar el proyecto en producción.
+La conexion se configura mediante variables definidas en un archivo `.env`.
+Copia primero `.env.example` a `.env` y ajusta alli tus credenciales:
 
-Fragmento relevante de `includes/db_connect.php`:
-
-```php
-$db_host = "localhost";         // Host de la base de datos
-$db_name = "condado_castilla_db"; // Nombre de la base de datos
-$db_user = "condado_user";        // Usuario
-$db_pass = "tu_contraseña_muy_segura"; // CONTRASEÑA - reemplazar por la real
-$db_port = "5432";                // Puerto de PostgreSQL
+```bash
+cp .env.example .env
 ```
 
-Ajusta esos valores según tu entorno para que la aplicación pueda acceder a la base de datos.
+Las variables minimas son:
 
-El script obtiene la contraseña real desde la variable de entorno `CONDADO_DB_PASSWORD`.
-Si dicha variable no está definida, el sitio seguirá funcionando con los textos por defecto
-y se registrará un aviso en el log del servidor.
+```bash
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=condado_castilla_db
+DB_USER=condado_user
+CONDADO_DB_PASSWORD=tu_contrasena
+```
+
+`includes/db_connect.php` leera estos valores con `getenv()` y registrara un error si falta alguno.
+
 Para preparar la base de datos ejecuta en orden los scripts de `database_setup`: `01_create_tables.sql`, `02_create_museo_piezas_table.sql` y `03_create_tienda_productos.sql`.
 Si quieres cargar algunos ejemplos iniciales para el museo, puedes lanzar de forma opcional `04_insert_sample_museo_piezas.sql` tras crear la tabla correspondiente.
 

--- a/includes/db_connect.php
+++ b/includes/db_connect.php
@@ -30,18 +30,31 @@ if ($app_debug) {
 }
 // --- Fin de manejo de modo debug ---
 
-// Configuración de la base de datos PostgreSQL
-$db_host = "localhost";         // Host de la base de datos (PostgreSQL está en el mismo servidor)
-$db_name = "condado_castilla_db"; // Nombre de tu base de datos PostgreSQL
-$db_user = "condado_user";        // Usuario de tu base de datos PostgreSQL
-$db_pass = getenv('CONDADO_DB_PASSWORD'); // Definido vía variable de entorno
-if ($db_pass === false) {
-    // Si la variable no existe, deja $pdo como null y registra el problema
-    error_log('includes/db_connect.php - CONDADO_DB_PASSWORD not set');
+// Configuración de la base de datos PostgreSQL usando variables de entorno
+$db_host = getenv('DB_HOST');
+$db_port = getenv('DB_PORT');
+$db_name = getenv('DB_NAME');
+$db_user = getenv('DB_USER');
+$db_pass = getenv('CONDADO_DB_PASSWORD');
+
+// Validar que todas las variables requeridas estén definidas
+$missing = [];
+foreach ([
+    'DB_HOST' => $db_host,
+    'DB_PORT' => $db_port,
+    'DB_NAME' => $db_name,
+    'DB_USER' => $db_user,
+    'CONDADO_DB_PASSWORD' => $db_pass,
+] as $var => $value) {
+    if ($value === false || $value === '') {
+        $missing[] = $var;
+    }
+}
+if (!empty($missing)) {
+    error_log('includes/db_connect.php - missing env vars: ' . implode(', ', $missing));
     $pdo = null;
     return;
 }
-$db_port = "5432";                // Puerto estándar de PostgreSQL
 
 // Cadena de conexión (DSN) para PostgreSQL usando PDO
 $dsn = "pgsql:host=$db_host;port=$db_port;dbname=$db_name;user=$db_user;password=$db_pass";

--- a/scripts/check_db.sh
+++ b/scripts/check_db.sh
@@ -3,10 +3,21 @@ set -euo pipefail
 
 # Simple check for PostgreSQL connectivity and environment variable
 
-DB_HOST="localhost"
-DB_PORT="5432"
-DB_NAME="condado_castilla_db"
-DB_USER="condado_user"
+DB_HOST="${DB_HOST:-}"
+DB_PORT="${DB_PORT:-}"
+DB_NAME="${DB_NAME:-}"
+DB_USER="${DB_USER:-}"
+
+missing=""
+for var in DB_HOST DB_PORT DB_NAME DB_USER; do
+  if [ -z "${!var}" ]; then
+    missing="$missing $var"
+  fi
+done
+if [ -n "$missing" ]; then
+  echo "Missing required environment variables:$missing" >&2
+  exit 1
+fi
 
 if [ -z "$CONDADO_DB_PASSWORD" ]; then
   echo "CONDADO_DB_PASSWORD environment variable is not set" >&2


### PR DESCRIPTION
## Summary
- use environment variables in `includes/db_connect.php`
- read DB connection values from environment in `scripts/check_db.sh`
- document DB configuration variables in `.env.example`
- explain `.env` setup in README

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: could not find driver, php-cgi not found)*
- `pip install -r requirements.txt`
- `python3 -m unittest tests/test_flask_api.py`
- `npm install`
- `npm test` *(fails: TimeoutError in puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_6854ad2230188329a9dc6354e50cbc41