### PR TITLE
Add environment setup script and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,18 @@ jobs:
           tools: composer
           coverage: xdebug
 
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install project dependencies
+        run: ./scripts/setup_environment.sh
 
       - name: Verificar atributos alt
         run: ./scripts/check_alt_texts.sh
@@ -29,14 +39,6 @@ jobs:
 
       - name: Run PHPUnit
         run: vendor/bin/phpunit --coverage-clover build/coverage.xml
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-
-      - name: Install Node dependencies
-        run: npm ci
 
       - name: Run Puppeteer tests
         run: npm run test:puppeteer

--- a/README.md
+++ b/README.md
@@ -262,18 +262,15 @@ Si `GEMINI_API_KEY` no está definida, las funciones de `includes/ai_utils.php` 
 
 **Es obligatorio ejecutar los siguientes comandos antes de cualquier suite de pruebas:**
 Asegúrate de tener **Composer** y **PHPUnit** instalados en tu sistema antes de ejecutar las pruebas. `PHPUnit` puede instalarse de manera global o utilizar el binario que se genera en `vendor/bin/phpunit` tras ejecutar `composer install`.
-Instala **todas** las dependencias antes de lanzar las suites de pruebas. Las pruebas dependen de PHP, Composer y las extensiones indicadas, por lo que no se ejecutarán si alguno de estos componentes falta. En particular es imprescindible tener disponible la interfaz de línea de comandos de PHP (PHP CLI). Ejecuta primero:
+Instala **todas** las dependencias antes de lanzar las suites de pruebas. Las pruebas dependen de PHP, Composer y las extensiones indicadas, por lo que no se ejecutarán si alguno de estos componentes falta. En particular es imprescindible tener disponible la interfaz de línea de comandos de PHP (PHP CLI).
+
+Ejecuta el siguiente script para instalar de una sola vez las dependencias de PHP, Python y Node:
 
 ```bash
-composer install
-pip install -r requirements.txt
-npm install
+./scripts/setup_environment.sh
 ```
 
-`composer install` debe ejecutarse **antes** de usar `vendor/bin/phpunit` y
-`pip install -r requirements.txt` debe lanzarse **antes** de ejecutar las
-pruebas de Python. Comprueba que PHP CLI está disponible antes de ejecutar las
-pruebas de PHP:
+El script requiere contar con `composer`, `pip` y `npm` en el sistema. Tras la instalación comprueba que PHP CLI está disponible antes de ejecutar las pruebas de PHP:
 
 ```bash
 php -v

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+# Determine repository root and switch to it
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+# Install PHP dependencies
+if command -v composer >/dev/null 2>&1; then
+    composer install --no-interaction --no-progress --prefer-dist
+else
+    echo "Composer not found. Please install Composer to manage PHP dependencies." >&2
+    exit 1
+fi
+
+# Install Python dependencies
+if command -v pip >/dev/null 2>&1; then
+    pip install -r requirements.txt
+else
+    echo "pip not found. Please install pip to manage Python dependencies." >&2
+    exit 1
+fi
+
+# Install Node dependencies
+if command -v npm >/dev/null 2>&1; then
+    npm ci
+else
+    echo "npm not found. Please install Node.js and npm to manage Node dependencies." >&2
+    exit 1
+fi
+
+cat <<MSG
+Environment setup completed.
+MSG
+


### PR DESCRIPTION
## Summary
- add `scripts/setup_environment.sh` to install Composer, pip, and npm deps
- update README testing instructions to use the new script
- call the setup script from CI before running tests

## Testing
- `./scripts/setup_environment.sh` *(fails: Composer not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854b29c589c8329ad84ab7a7bc76dda