### PR TITLE
Fix blog header/footer includes

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -38,7 +38,7 @@ $post_slug = isset($_GET['post']) ? $_GET['post'] : null;
     <link rel="stylesheet" href="/assets/css/custom.css">
 </head>
 <body class="alabaster-bg">
-<?php include __DIR__.'/_header.php'; ?>
+<?php require_once __DIR__ . '/_header.php'; ?>
 <main class="container page-content-block">
 <?php if ($post_slug && isset($posts[$post_slug])): ?>
     <article class="blog-post">
@@ -55,7 +55,7 @@ $post_slug = isset($_GET['post']) ? $_GET['post'] : null;
     </ul>
 <?php endif; ?>
 </main>
-<?php include __DIR__.'/_footer.php'; ?>
+<?php require_once __DIR__ . '/_footer.php'; ?>
 <script src="/js/layout.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use `require_once` for blog header and footer includes

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_app')*

------
https://chatgpt.com/codex/tasks/task_e_6854b3a71b748329a9462034f31a7798