### PR TITLE
Update link checker for new fragments

### DIFF
--- a/check_links_extended.sh
+++ b/check_links_extended.sh
@@ -2,7 +2,13 @@
 # Subtask to check for broken internal links in key files AND HTML FRAGMENTS
 
 # Files to check initially
-files_to_check=("index.php" "_header.php" "_footer.php")
+files_to_check=(
+    "index.php"
+    "_header.php"
+    "_footer.php"
+    "fragments/header.php"
+    "fragments/footer.php"
+)
 
 # HTML Fragments to also check (header components)
 # Note: admin-menu.php is PHP; static analysis might be limited.


### PR DESCRIPTION
## Summary
- include `fragments/header.php` and `fragments/footer.php` in `check_links_extended.sh`
- keep other HTML fragment checks unchanged

## Testing
- `./scripts/setup_environment.sh` *(fails: Composer not found)*
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_6854b3a91d148329abe59fc01c8ba16c