### PR TITLE
Update docs for new fragment paths

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,16 +95,20 @@ La misión principal es *promocionar el turismo en Cerezo de Río Tirón y*
 Los encabezados y pies de página se extraen a ficheros reutilizables para
 simplificar el mantenimiento:
 
-- `_header.php` incluye los menús deslizantes y los fragmentos situados en
-  `fragments/header/` y `fragments/menus/`.
-- `_footer.php` carga los scripts comunes y el menú social.
+- `fragments/header.php` incluye los menús deslizantes y los fragmentos situados
+  en `fragments/header/` y `fragments/menus/`.
+- `fragments/footer.php` carga los scripts comunes y el menú social.
+
+**Nota:** el encabezado y el pie se encuentran ahora en `fragments/`. Modifica
+`fragments/header.php` o `fragments/footer.php` para aplicar cambios
+globales.
 
 Para insertar estas partes en una página basta con:
 
 ```php
-<?php require_once __DIR__ . '/_header.php'; ?>
+<?php require_once __DIR__ . '/fragments/header.php'; ?>
 <!-- contenido de la página -->
-<?php require_once __DIR__ . '/_footer.php'; ?>
+<?php require_once __DIR__ . '/fragments/footer.php'; ?>
 ```
 
 Los fragmentos del directorio `fragments/` pueden copiarse o modificarse para

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -18,8 +18,8 @@ Para usar anclas basta con añadir `id="..."` a cada elemento. Por ejemplo:
 <section id="video" class="video-section section spotlight-active">...
 ```
 
-## Cómo `_header.php` carga los menús
-El archivo `_header.php` genera el panel deslizante derecho e inserta las diferentes secciones de menú leyendo los archivos de `fragments/menus/`:
+## Cómo `fragments/header.php` carga los menús
+El archivo `fragments/header.php` genera el panel deslizante derecho e inserta las diferentes secciones de menú leyendo los archivos de `fragments/menus/`:
 ```php
 <?php
 if (file_exists(__DIR__ . '/fragments/menus/main-menu.php')) {


### PR DESCRIPTION
## Summary
- update docs to reference `fragments/header.php` and `fragments/footer.php`
- note where to edit header and footer

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854b3aa01308329b8c72a0c95004ee1