### PR TITLE
Fix manual test script paths

### DIFF
--- a/tests/manual/test_lang.html
+++ b/tests/manual/test_lang.html
@@ -9,7 +9,7 @@
 <div id="google_translate_element"></div>
 <button id="flag-toggle">Traducir</button>
 <p id="text">Hola Mundo</p>
-<script src="/js/lang-bar.js"></script>
+<script src="/assets/js/lang-bar.js"></script>
 </body>
 </html>
 

--- a/tests/manual/test_language_panel.html
+++ b/tests/manual/test_language_panel.html
@@ -16,6 +16,6 @@
         <img src="/assets/flags/gb.svg" alt="EN" data-lang="en">
     </div>
 </div>
-<script src="/js/lang-bar.js"></script>
+<script src="/assets/js/lang-bar.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update manual Puppeteer tests to reference scripts from `/assets/js`

## Testing
- `./scripts/setup_environment.sh` *(fails: Composer not found)*
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854b9afc6f883298d81d264b4dd581d