### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Thumbs.db
 vendor/
 !assets/vendor/
 .phpunit.result.cache
+.php-cs-fixer.cache
 
 # Uploaded files
 uploads/**


### PR DESCRIPTION
## Summary
- keep `php-cs-fixer` cache out of version control

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED at localhost)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b9b5a6f88329bc025955b97acdc1