### PR TITLE
Update blog header/footer includes

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -38,7 +38,7 @@ $post_slug = isset($_GET['post']) ? $_GET['post'] : null;
     <link rel="stylesheet" href="/assets/css/custom.css">
 </head>
 <body class="alabaster-bg">
-<?php include __DIR__.'/fragments/header.php'; ?>
+<?php require_once __DIR__.'/fragments/header.php'; ?>
 <main class="container page-content-block">
 <?php if ($post_slug && isset($posts[$post_slug])): ?>
     <article class="blog-post">
@@ -55,7 +55,7 @@ $post_slug = isset($_GET['post']) ? $_GET['post'] : null;
     </ul>
 <?php endif; ?>
 </main>
-<?php include __DIR__.'/fragments/footer.php'; ?>
+<?php require_once __DIR__.'/fragments/footer.php'; ?>
 <script src="/js/layout.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use `require_once` instead of `include` for blog header and footer fragments

## Testing
- `php -l blog.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bbefa4508329a3ca5328e310c7f5