### PR TITLE
Fix audio controller path in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Este repositorio puede mostrar textos generados automáticamente. Estos contenid
 - Textos con degradados de alto contraste.
 - Paleta que cambia automáticamente según la hora del visitante (amanecer, mediodía, atardecer o noche) con opción manual.
 - Foro con cinco agentes expertos para dinamizar la comunidad.
- - El script `js/audio-controller.js` atenúa el volumen de los elementos `<audio>` y `<video>` cuando cualquier menú deslizante está activo. Escucha el evento `menu-toggled` que dispara `assets/js/main.js` al abrir o cerrar un menú.
+ - El script `/js/audio-controller.js` atenúa el volumen de los elementos `<audio>` y `<video>` cuando cualquier menú deslizante está activo. Escucha el evento `menu-toggled` que dispara `assets/js/main.js` al abrir o cerrar un menú.
 
 ### Modo luna
 

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -7,7 +7,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `assets/js/main.js` | Handles sliding menu interactions, closing behavior, and the light/dark theme toggle used across all pages. |
 | `assets/js/homonexus-toggle.js` | Toggles Homonexus mode, storing the preference in a cookie. |
 | `assets/js/foro.js` | Simple toggling for the forum agents menu. |
-| `js/audio-controller.js` | Lowers audio/video volume when sliding menus open and exposes `handleMenuToggle` for other scripts. |
+| `/js/audio-controller.js` | Lowers audio/video volume when sliding menus open and exposes `handleMenuToggle` for other scripts. |
 | `js/config.js` | Defines `API_BASE_URL` and `DEBUG_MODE` globals for other scripts. |
 | `js/layout.js` | Loads external CSS/JS libraries on demand, initializes the flashlight effect and other page-level utilities. |
 | `js/load_menu_parts.js` | Dynamically loads menu fragments into the header when needed. |


### PR DESCRIPTION
## Summary
- update references to `/js/audio-controller.js` in README and docs

## Testing
- `./scripts/setup_environment.sh` *(fails: Composer not found)*
- `pytest -q` *(fails: ModuleNotFoundError for flask_app and graph_db_interface)*
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854bbf1832c832992e9303421a40b31