### PR TITLE
Improve dynamic fragment search in link checker

### DIFF
--- a/check_links_extended.sh
+++ b/check_links_extended.sh
@@ -4,15 +4,17 @@
 # Files to check initially
 files_to_check=("index.php" "fragments/header.php" "fragments/footer.php")
 
-# HTML Fragments to also check (header components)
-# Note: admin-menu.php is PHP; static analysis might be limited.
-html_fragments=(
-    "fragments/header/language-bar.html"
-    "fragments/header/navigation.html"
-    "fragments/menus/main-menu.php"
-    "fragments/menus/admin-menu.php"
-    "fragments/menus/social-menu.html"
-)
+# HTML fragments to also check (header/menus). Gather dynamically
+fragment_dirs=("fragments/header" "fragments/menus")
+html_fragments=()
+
+for dir in "${fragment_dirs[@]}"; do
+    if [ -d "$dir" ]; then
+        while IFS= read -r -d '' file; do
+            html_fragments+=("$file")
+        done < <(find "$dir" -type f \( -name '*.php' -o -name '*.html' \) -print0)
+    fi
+done
 
 # Combine the arrays
 all_files_to_check=("${files_to_check[@]}" "${html_fragments[@]}")


### PR DESCRIPTION
## Summary
- make `check_links_extended.sh` gather all `.php` and `.html` files under `fragments/header` and `fragments/menus`
- combine these dynamically collected files with the main list before checking

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: missing Flask)*
- `npm run test:puppeteer` *(fails: missing Puppeteer module)*
- `node tests/moonToggleTest.js` *(fails: missing jsdom module)*
- `./check_links_extended.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854bbf9c598832994385c115bad26e8