### PR TITLE
Add audio controller toggle and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Este repositorio puede mostrar textos generados automáticamente. Estos contenid
 - Textos con degradados de alto contraste.
 - Paleta que cambia automáticamente según la hora del visitante (amanecer, mediodía, atardecer o noche) con opción manual.
 - Foro con cinco agentes expertos para dinamizar la comunidad.
- - El script `js/audio-controller.js` atenúa el volumen de los elementos `<audio>` y `<video>` cuando cualquier menú deslizante está activo. Escucha el evento `menu-toggled` que dispara `assets/js/main.js` al abrir o cerrar un menú.
+ - El script `js/audio-controller.js` atenúa el volumen de los elementos `<audio>` y `<video>` cuando cualquier menú deslizante está activo. `assets/js/main.js` llama a `window.audioController.handleMenuToggle()` directamente al abrir o cerrar un menú.
 
 ### Modo luna
 

--- a/assets/js/audio-controller.js
+++ b/assets/js/audio-controller.js
@@ -1,4 +1,22 @@
 (function(){
+    const api = {};
+
+    api.handleMenuToggle = function(open) {
+        document.querySelectorAll('audio, video').forEach(el => {
+            if (open) {
+                if (!el.hasAttribute('data-prev-volume')) {
+                    el.dataset.prevVolume = el.volume;
+                    el.volume = Math.max(0, Math.min(1, el.volume * 0.2));
+                }
+            } else {
+                if (el.hasAttribute('data-prev-volume')) {
+                    el.volume = parseFloat(el.dataset.prevVolume);
+                    el.removeAttribute('data-prev-volume');
+                }
+            }
+        });
+    };
+
     document.addEventListener('DOMContentLoaded', function(){
         const btn = document.getElementById('mute-toggle');
         if(!btn) return;
@@ -18,4 +36,6 @@
             updateState();
         });
     });
+
+    window.audioController = api;
 })();

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -7,7 +7,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `assets/js/main.js` | Handles sliding menu interactions, closing behavior, and the light/dark theme toggle used across all pages. |
 | `assets/js/homonexus-toggle.js` | Toggles Homonexus mode, storing the preference in a cookie. |
 | `assets/js/foro.js` | Simple toggling for the forum agents menu. |
-| `js/audio-controller.js` | Lowers audio/video volume when sliding menus open and exposes `handleMenuToggle` for other scripts. |
+| `assets/js/audio-controller.js` | Lowers audio/video volume when sliding menus open and exposes `handleMenuToggle`. Other scripts, como `assets/js/main.js`, invocan esta función al gestionar los menús. |
 | `js/config.js` | Defines `API_BASE_URL` and `DEBUG_MODE` globals for other scripts. |
 | `js/layout.js` | Loads external CSS/JS libraries on demand, initializes the flashlight effect and other page-level utilities. |
 | `js/load_menu_parts.js` | Dynamically loads menu fragments into the header when needed. |

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
   "scripts": {
     "pretest:puppeteer": "php -S localhost:8080 >/dev/null 2>&1 &",
-    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js",
+    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/menuVolumeTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js",
     "test": "npm run test:puppeteer"
   }
 }

--- a/tests/manual/test_audio_volume.html
+++ b/tests/manual/test_audio_volume.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <title>Test Audio Volume</title>
+    <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+    <link rel="stylesheet" href="/assets/css/menus/consolidated-menu.css">
+</head>
+<body>
+<div id="fixed-header-elements">
+    <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items">Menú</button>
+</div>
+<div id="consolidated-menu-items" class="menu-panel left-panel">
+    <p>Menu content</p>
+</div>
+<audio id="test-audio" src="https://samplelib.com/lib/preview/mp3/sample-3s.mp3" controls></audio>
+<script src="/assets/js/audio-controller.js"></script>
+<script src="/assets/js/main.js"></script>
+</body>
+</html>
+

--- a/tests/menuVolumeTest.js
+++ b/tests/menuVolumeTest.js
@@ -1,0 +1,31 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/tests/manual/test_audio_volume.html');
+  await page.waitForSelector('#consolidated-menu-button');
+  await page.evaluate(() => {
+    const a = document.getElementById('test-audio');
+    a.volume = 1;
+    a.muted = false;
+  });
+  await page.click('#consolidated-menu-button');
+  await page.waitForTimeout(500);
+  const volAfterOpen = await page.$eval('#test-audio', el => el.volume);
+  if (volAfterOpen >= 1) {
+    console.error('Volume not reduced on menu open');
+    await browser.close();
+    process.exit(1);
+  }
+  await page.click('#consolidated-menu-button');
+  await page.waitForTimeout(500);
+  const volAfterClose = await page.$eval('#test-audio', el => el.volume);
+  if (Math.abs(volAfterClose - 1) > 0.01) {
+    console.error('Volume not restored on menu close');
+    await browser.close();
+    process.exit(1);
+  }
+  console.log('Audio volume lowered and restored correctly');
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- expose `window.audioController` and implement `handleMenuToggle`
- document direct call to `handleMenuToggle` in README
- note new function in JS modules overview
- run volume test via puppeteer and register in npm scripts

## Testing
- `composer install` *(fails: command not found)*
- `npm install`
- `npm test` *(fails: TimeoutError waiting for selector)*

------
https://chatgpt.com/codex/tasks/task_e_6854bc0d4578832989db9b7be580bd94