### PR TITLE
Remove old header/footer stubs

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -1,1 +1,0 @@
-<?php require_once __DIR__ . '/fragments/footer.php'; ?>

--- a/_header.php
+++ b/_header.php
@@ -1,1 +1,0 @@
-<?php require_once __DIR__ . '/fragments/header.php'; ?>

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,7 @@ La misión principal es *promocionar el turismo en Cerezo de Río Tirón y*
 
 Los encabezados y pies de página se extraen a ficheros reutilizables para
 simplificar el mantenimiento:
+Los archivos de entrada son `fragments/header.php` y `fragments/footer.php`, que deben incluirse directamente.
 
 - `fragments/header.php` incluye los menús deslizantes y los fragmentos situados en
   `fragments/header/` y `fragments/menus/`.


### PR DESCRIPTION
## Summary
- delete `_header.php` and `_footer.php`
- clarify the template section of the docs to reference `fragments/header.php` and `fragments/footer.php`

## Testing
- `./scripts/setup_environment.sh` *(fails: Composer not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6854bd0bc89083299a588a0d1420e4d9