### PR TITLE
Update responsible AI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ pip install -r requirements.txt
 ```
 
 3. Copia `.env.example` a `.env` y define al menos `GEMINI_API_KEY` y `CONDADO_DB_PASSWORD`.
+Para la API de Flask es imprescindible definir `GEMINI_API_KEY`, variable que se emplea únicamente en el servidor para contactar con el proveedor de IA. Consulta la [política de uso responsable](docs/responsible-ai.md) para saber cómo protegemos la privacidad y moderamos el contenido.
 4. Carga dichas variables en tu terminal:
    ```bash
    set -a

--- a/docs/responsible-ai.md
+++ b/docs/responsible-ai.md
@@ -9,3 +9,14 @@ Principios:
 - Corrección rápida de fallos o información inapropiada.
 
 Si detectas problemas, por favor avisa al equipo de administración.
+## Protección de datos y privacidad
+La plataforma registra únicamente la información necesaria para prestar el servicio y nunca comparte datos personales con terceros. Los mensajes enviados a los modelos de IA se utilizan de forma transitoria y no se almacenan para entrenar sistemas externos. Cumplimos con la legislación española y el Reglamento General de Protección de Datos (RGPD).
+
+## Transparencia hacia los usuarios
+Cada vez que se muestra un texto generado automáticamente se indica de forma explícita. El visitante puede identificar qué respuestas proceden de un modelo de IA y cuáles han sido escritas por el equipo editorial.
+
+## Moderación del contenido generado
+Todo el material producido por IA pasa por un proceso de revisión. Los administradores pueden editar o retirar cualquier fragmento que infrinja nuestras normas de convivencia o contenga información inexacta.
+
+## Cómo informar de contenido problemático
+Si detectas un resultado inadecuado o que crees que incumple esta política, envía un correo a [info@condadodecastilla.com](mailto:info@condadodecastilla.com) o utiliza el formulario de [contacto](../contacto/contacto.php). Incluye la URL y una breve descripción del problema para que podamos resolverlo con rapidez.


### PR DESCRIPTION
## Summary
- expand the policy with privacy, transparency, and moderation
- explain how to report problematic content
- highlight GEMINI_API_KEY usage in the Flask API and link to the policy

## Testing
- `PYTHONPATH=. python tests/test_flask_api.py -v`
- `npm test` *(fails: cannot connect to PHP server)*
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bd0a734c8329a0e42b6c0fd0371b