### PR TITLE
Update audio controller with menu handling

### DIFF
--- a/assets/js/audio-controller.js
+++ b/assets/js/audio-controller.js
@@ -1,4 +1,17 @@
 (function(){
+    function handleMenuToggle(open){
+        document.querySelectorAll('audio, video').forEach(el => {
+            if(!el.dataset.prevVolume){
+                el.dataset.prevVolume = el.volume;
+            }
+            if(open){
+                el.volume = el.dataset.prevVolume * 0.3;
+            } else if(el.dataset.prevVolume !== undefined){
+                el.volume = parseFloat(el.dataset.prevVolume);
+            }
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', function(){
         const btn = document.getElementById('mute-toggle');
         if(!btn) return;
@@ -18,4 +31,6 @@
             updateState();
         });
     });
+
+    window.audioController = { handleMenuToggle };
 })();


### PR DESCRIPTION
## Summary
- modify audio-controller to expose `window.audioController`
- add `handleMenuToggle` that temporarily lowers volume while menu is open

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6854bf0444b083299a5e52301747f38c