### PR TITLE
Add automated test run summary

### DIFF
--- a/docs/test-results.md
+++ b/docs/test-results.md
@@ -1,0 +1,26 @@
+# Test Results - Automated Run
+
+This document summarizes the outcome of the automated test commands executed in the Codex environment.
+
+## `npm test`
+- **Status:** Failed
+- **Reason:** Puppeteer attempted to navigate to `http://localhost:8080/tests/manual/test_lang.html` but the connection was refused. The local PHP server required for the tests was not running.
+
+## `vendor/bin/phpunit`
+- **Status:** Not executed
+- **Reason:** `composer` is not installed in the environment, so `vendor/bin/phpunit` is missing. Installing dependencies via `composer install` is required before running PHPUnit.
+
+## `python -m unittest tests/test_flask_api.py`
+- **Status:** Failed
+- **Reason:** The `flask` module was not found. Install dependencies from `requirements.txt` before running the Python tests.
+
+## Suggested Adjustments
+1. Install project dependencies:
+   - Run `npm install` to fetch Node packages (already done in this run).
+   - Ensure `composer` is installed, then run `composer install` for PHP dependencies.
+   - Install Python packages with `pip install -r requirements.txt`.
+2. Start a local PHP server on port 8080 before executing Puppeteer tests:
+   ```bash
+   php -S localhost:8080
+   ```
+3. Run the test suites in the order described in `docs/testing.md`.


### PR DESCRIPTION
## Summary
- document results of running `npm test`, `vendor/bin/phpunit`, and Python unittests

## Testing
- `npm test` *(fails: connection refused)*
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: missing flask module)*

------
https://chatgpt.com/codex/tasks/task_e_6854bf001e8483298a8751245cf13069