### PR TITLE
Update setup script and docs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,7 +4,9 @@ Esta guía explica cómo preparar el entorno y ejecutar las pruebas automatizada
 
 ## Configurar el entorno
 
-Ejecuta el script `setup_environment.sh` para instalar de una sola vez las dependencias de PHP, Python y Node. Es necesario contar con `composer`, `pip` y `npm` en el sistema.
+Ejecuta el script `setup_environment.sh` para instalar de una sola vez las dependencias de PHP, Python y Node.
+Si alguno de estos gestores no está disponible, el script mostrará una advertencia y continuará con el resto, de modo que la configuración puede completarse de forma parcial.
+Más adelante podrás instalar la herramienta faltante y ejecutar manualmente el paso correspondiente.
 
 ```bash
 ./scripts/setup_environment.sh

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 # Determine repository root and switch to it
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -8,26 +8,29 @@ cd "$PROJECT_ROOT"
 
 # Install PHP dependencies
 if command -v composer >/dev/null 2>&1; then
-    composer install --no-interaction --no-progress --prefer-dist
+    if ! composer install --no-interaction --no-progress --prefer-dist; then
+        echo "Warning: composer install failed." >&2
+    fi
 else
-    echo "Composer not found. Please install Composer to manage PHP dependencies." >&2
-    exit 1
+    echo "Warning: Composer not found; skipping PHP dependencies." >&2
 fi
 
 # Install Python dependencies
 if command -v pip >/dev/null 2>&1; then
-    pip install -r requirements.txt
+    if ! pip install -r requirements.txt; then
+        echo "Warning: pip install failed." >&2
+    fi
 else
-    echo "pip not found. Please install pip to manage Python dependencies." >&2
-    exit 1
+    echo "Warning: pip not found; skipping Python dependencies." >&2
 fi
 
 # Install Node dependencies
 if command -v npm >/dev/null 2>&1; then
-    npm ci
+    if ! npm ci; then
+        echo "Warning: npm install failed." >&2
+    fi
 else
-    echo "npm not found. Please install Node.js and npm to manage Node dependencies." >&2
-    exit 1
+    echo "Warning: npm not found; skipping Node dependencies." >&2
 fi
 
 cat <<MSG


### PR DESCRIPTION
## Summary
- make environment setup script continue when tools are missing
- clarify optional setup steps in testing guide

## Testing
- `./scripts/setup_environment.sh > /tmp/setup_output.log 2>&1`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py`
- `npm run test:puppeteer` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6854bf8d78c08329a419366249360f78