### PR TITLE
Add menu volume logic

### DIFF
--- a/assets/js/audio-controller.js
+++ b/assets/js/audio-controller.js
@@ -1,13 +1,14 @@
 (function(){
     function handleMenuToggle(open){
         document.querySelectorAll('audio, video').forEach(el => {
-            if(!el.dataset.prevVolume){
-                el.dataset.prevVolume = el.volume;
+            if(el.dataset.originalVolume === undefined){
+                el.dataset.originalVolume = el.volume;
             }
+            const original = parseFloat(el.dataset.originalVolume);
             if(open){
-                el.volume = el.dataset.prevVolume * 0.3;
-            } else if(el.dataset.prevVolume !== undefined){
-                el.volume = parseFloat(el.dataset.prevVolume);
+                el.volume = original * 0.3;
+            } else {
+                el.volume = original;
             }
         });
     }


### PR DESCRIPTION
## Summary
- adjust audio-controller volume logic using an `originalVolume` dataset attribute
- keep mute logic intact and expose the new function via `window.audioController`

## Testing
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bf8e81d483298fbd07c0efab5b90