### PR TITLE
Add menu volume puppeteer test

### DIFF
--- a/assets/js/audio-controller.js
+++ b/assets/js/audio-controller.js
@@ -1,21 +1,62 @@
 (function(){
-    document.addEventListener('DOMContentLoaded', function(){
-        const btn = document.getElementById('mute-toggle');
-        if(!btn) return;
+    const previousVolumes = new Map();
+
+    const setMutedState = (state) => {
+        document.querySelectorAll('audio, video').forEach(el => {
+            el.muted = state;
+        });
+    };
+
+    const exposeController = (btn) => {
+        window.audioController = {
+            handleMenuToggle(open) {
+                document.querySelectorAll('audio, video').forEach(el => {
+                    if (open) {
+                        previousVolumes.set(el, el.volume);
+                        el.volume = Math.max(0, el.volume * 0.2);
+                    } else if (previousVolumes.has(el)) {
+                        el.volume = previousVolumes.get(el);
+                    }
+                });
+                if (!open) previousVolumes.clear();
+            }
+        };
 
         let muted = false;
+
         const updateState = () => {
             btn.setAttribute('aria-pressed', muted ? 'true' : 'false');
             btn.textContent = muted ? '🔇' : '🔊';
         };
+
         updateState();
 
         btn.addEventListener('click', () => {
             muted = !muted;
-            document.querySelectorAll('audio, video').forEach(el => {
-                el.muted = muted;
-            });
+            setMutedState(muted);
             updateState();
         });
+    };
+
+    document.addEventListener('DOMContentLoaded', function(){
+        const btn = document.getElementById('mute-toggle');
+        if(btn) {
+            exposeController(btn);
+        } else {
+            // Even if the button is missing, expose the controller for menu events
+            window.audioController = {
+                handleMenuToggle(open) {
+                    document.querySelectorAll('audio, video').forEach(el => {
+                        if (open) {
+                            previousVolumes.set(el, el.volume);
+                            el.volume = Math.max(0, el.volume * 0.2);
+                        } else if (previousVolumes.has(el)) {
+                            el.volume = previousVolumes.get(el);
+                        }
+                    });
+                    if (!open) previousVolumes.clear();
+                }
+            };
+        }
     });
 })();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
   "scripts": {
     "pretest:puppeteer": "php -S localhost:8080 >/dev/null 2>&1 &",
-    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js",
+    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuVolumeTest.js",
     "test": "npm run test:puppeteer"
   }
 }

--- a/tests/menuVolumeTest.js
+++ b/tests/menuVolumeTest.js
@@ -1,0 +1,32 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/index.php');
+  await page.waitForSelector('audio, video');
+  const initialVolume = await page.$eval('audio, video', el => el.volume);
+  if (initialVolume <= 0) {
+    console.error('Initial volume not greater than 0');
+    await browser.close();
+    process.exit(1);
+  }
+  await page.click('#consolidated-menu-button');
+  await page.waitForTimeout(500);
+  const loweredVolume = await page.$eval('audio, video', el => el.volume);
+  if (loweredVolume >= initialVolume) {
+    console.error('Volume did not decrease when menu opened');
+    await browser.close();
+    process.exit(1);
+  }
+  await page.click('#consolidated-menu-button');
+  await page.waitForTimeout(500);
+  const restoredVolume = await page.$eval('audio, video', el => el.volume);
+  if (Math.abs(restoredVolume - initialVolume) > 0.01) {
+    console.error('Volume did not restore after closing menu');
+    await browser.close();
+    process.exit(1);
+  }
+  console.log('Menu volume attenuation works');
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- test menu volume reduction when a sliding menu opens
- expose `handleMenuToggle` in `audio-controller.js`
- run the new test as part of the puppeteer test suite

## Testing
- `npm run test:puppeteer` *(fails: TimeoutError: Waiting for selector `#google_translate_element` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6854bf0198c08329ad65202acc4e3135