### PR TITLE
Add PHP server start/stop scripts for test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,7 @@ Con las dependencias ya instaladas, ejecuta cada conjunto de tests de forma expl
 ```bash
 vendor/bin/phpunit
 python -m unittest tests/test_flask_api.py
-# Asegúrate de tener un servidor local en marcha (por ejemplo `php -S localhost:8080`)
-npm run test:puppeteer
+npm test
 node tests/moonToggleTest.js
 ```
 
@@ -292,7 +291,9 @@ node tests/moonToggleTest.js
 
 `vendor/bin/phpunit` lanza la suite de PHP definida en `phpunit.xml`.
 `python -m unittest tests/test_flask_api.py` ejecuta el conjunto de pruebas de Python sobre la API Flask.
-`npm run test:puppeteer` ejecuta las pruebas de interfaz con Puppeteer.
+`npm test` ejecuta las pruebas de interfaz con Puppeteer. El script inicia un
+servidor PHP con `php -S` antes de la prueba y lo detiene automáticamente al
+finalizar.
 
 Si cualquiera de estos comandos devuelve un error de "command not found" lo más probable es que **PHP**, **Composer** o **PHPUnit** no estén instalados correctamente.
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
       "tailwindcss": "^4.1.10"
     },
   "scripts": {
-    "pretest:puppeteer": "php -S localhost:8080 >/dev/null 2>&1 &",
+    "start:php": "sh -c 'php -S localhost:8080 >/dev/null 2>&1 & echo $! > .php_server.pid'",
+    "stop:php": "sh -c 'if [ -f .php_server.pid ]; then kill $(cat .php_server.pid); rm .php_server.pid; fi'",
     "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js",
-    "test": "npm run test:puppeteer"
+    "test": "npm run start:php && npm run test:puppeteer; npm run stop:php"
   }
 }


### PR DESCRIPTION
## Summary
- run a PHP dev server for tests and stop it automatically
- document the new test workflow

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854c18111088329b04c69e5f84dd628