### PR TITLE
Clean duplicate back-link rule

### DIFF
--- a/assets/css/pages/historia_subpaginas_auca_patricia_ubicacion.css
+++ b/assets/css/pages/historia_subpaginas_auca_patricia_ubicacion.css
@@ -1,10 +1,4 @@
 @import "../components.css";
-.back-link {
-    margin-top: 1em;
-    margin-bottom: 1em;
-}
-
-
 
         /* Breadcrumb Styles */
         .breadcrumb-container {


### PR DESCRIPTION
## Summary
- tidy `historia_subpaginas_auca_patricia_ubicacion.css` by removing its redundant `.back-link` rule so it relies on the shared definition

## Testing
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*
- `node tests/moonToggleTest.js` *(fails: cannot find module 'jsdom')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c246e8688329ac648584776bd294