### PR TITLE
Remove body and hero rules

### DIFF
--- a/assets/css/pages/foro.css
+++ b/assets/css/pages/foro.css
@@ -1,5 +1,4 @@
 /* Page-specific styles for foro/index.php */
-body { background-color: rgba(var(--epic-alabaster-bg-rgb), 0.95); }
 .agent-profile {
     background-color: rgba(var(--epic-alabaster-bg-rgb), 0.95);
     padding: 1em;

--- a/assets/css/pages/historia_cerezo_index.css
+++ b/assets/css/pages/historia_cerezo_index.css
@@ -1,4 +1,3 @@
-        body { font-family: sans-serif; margin: 20px; }
         nav ul { list-style-type: none; padding: 0; }
         nav ul li { margin-bottom: 10px; }
         nav h2 { margin-top: 30px; }

--- a/assets/css/pages/historia_subpaginas_indice.css
+++ b/assets/css/pages/historia_subpaginas_indice.css
@@ -36,9 +36,6 @@
             background-color: var(--color-secundario-dorado);
             color: var(--color-negro-contraste);
         }
-        .page-header.hero {
-            min-height: 30vh; /* Reduced height for index page */
-        }
         .error-message {
             background-color: var(--alert-bg);
             border: 1px solid var(--alert-border);

--- a/assets/css/pages/index.css
+++ b/assets/css/pages/index.css
@@ -1,16 +1,4 @@
 /* Page-specific styles for index.php */
-body {
-    /* Use alabaster background, rely on global CSS variables if defined */
-}
-
-.hero {
-    animation: hero-fade 20s infinite alternate;
-}
-
-@keyframes hero-fade {
-    from { filter: brightness(1); }
-    to { filter: brightness(1.1) saturate(1.2); }
-}
 
 .cta-group {
   margin-top: 2.5em;

--- a/assets/css/pages/manage_comments.css
+++ b/assets/css/pages/manage_comments.css
@@ -1,4 +1,3 @@
-body { background-color: var(--epic-alabaster-bg); padding: 20px; }
 table { width: 100%; border-collapse: collapse; }
 th, td { padding: 8px; border: 1px solid var(--epic-neutral-border); }
 .feedback { padding: 10px; margin: 10px 0; border-radius: 4px; }

--- a/foro/manage_comments.php
+++ b/foro/manage_comments.php
@@ -49,7 +49,7 @@ if ($pdo) {
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
     <link rel="stylesheet" href="/assets/css/pages/manage_comments.css">
 </head>
-<body class="alabaster-bg">
+<body class="alabaster-bg p-5">
     <h1>Administrar Comentarios del Foro</h1>
     <nav>
         <a href="../index.php">Inicio</a>

--- a/historia/subpaginas_indice.php
+++ b/historia/subpaginas_indice.php
@@ -33,7 +33,7 @@ load_page_css();
 </head>
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/imagenes/mapa_antiguo_detalle.jpg');">
+    <header class="page-header hero min-h-[30vh]" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/imagenes/mapa_antiguo_detalle.jpg');">
         <div class="hero-content">
             <h1><?php echo htmlspecialchars($titulo_pagina); ?></h1>
         </div>

--- a/historia_cerezo/index.php
+++ b/historia_cerezo/index.php
@@ -8,7 +8,7 @@
     ?>
     <title>Historia de Cerezo: Cuna y Origen de Castilla</title>
 </head>
-<body class="alabaster-bg">
+<body class="alabaster-bg font-sans m-5">
     <?php require_once __DIR__ . "/../fragments/header.php"; ?>
 
 <h1>Historia de Cerezo: Cuna y Origen de Castilla</h1>


### PR DESCRIPTION
## Summary
- clean up page CSS to remove `body` and `.hero` declarations
- replace removed styles in templates with Tailwind classes

## Testing
- `./scripts/setup_environment.sh`
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py`
- `npm run test:puppeteer` *(fails: connection refused)*
- `node tests/moonToggleTest.js` *(fails: cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6854c245cdc083299eb5e819c9ba124a