### PR TITLE
Sync Tailwind version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwrit
 
 Este proyecto utiliza la librería **league/commonmark** para transformar a HTML los archivos Markdown del blog. La dependencia se instala automáticamente con el comando anterior.
 
-El script descarga las bibliotecas **jQuery**, **Bootstrap** y **Tailwind CSS**
+El script descarga las bibliotecas **jQuery**, **Bootstrap** y **Tailwind CSS 4.1.10**
 en `assets/vendor`. Tras ello genera la hoja `assets/vendor/css/tailwind.min.css`
 si ejecutas:
 
@@ -191,7 +191,7 @@ Debes lanzar este comando al instalar el proyecto y cada vez que modifiques
 diseño se reflejen en la hoja final:
 
 ```bash
-npx tailwindcss@3.4.4 -i assets/css/tailwind_base.css -o assets/vendor/css/tailwind.min.css --minify
+npx tailwindcss@4.1.10 -i assets/css/tailwind_base.css -o assets/vendor/css/tailwind.min.css --minify
 ```
 
 ### Dependencias de npm

--- a/scripts/setup_frontend_libs.sh
+++ b/scripts/setup_frontend_libs.sh
@@ -20,7 +20,7 @@ curl -L "$BOOTSTRAP_BASE/js/bootstrap.bundle.min.js" -o "$JS_DIR/bootstrap.bundl
 curl -L "$BOOTSTRAP_BASE/css/bootstrap.min.css" -o "$CSS_DIR/bootstrap.min.css"
 
 # Tailwind CSS
-TAILWIND_VERSION="3.4.4"
+TAILWIND_VERSION="4.1.10"
 TAILWIND_URL="https://cdn.jsdelivr.net/npm/tailwindcss@${TAILWIND_VERSION}/tailwind.min.css"
 curl -L "$TAILWIND_URL" -o "$CSS_DIR/tailwind.min.css"
 


### PR DESCRIPTION
## Summary
- align README with Tailwind 4.1.10 used in package.json
- update setup script to download Tailwind 4.1.10

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854c84c2fe88329ae6921bdeed1f28a