### PR TITLE
Update Composer dependency note

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Ejecuta el siguiente script para instalar de una sola vez las dependencias de PH
 ./scripts/setup_environment.sh
 ```
 
-El script requiere contar con `composer`, `pip` y `npm` en el sistema. Tras la instalación comprueba que PHP CLI está disponible antes de ejecutar las pruebas de PHP:
+Es imprescindible instalar **Composer** antes de ejecutar `scripts/setup_environment.sh`; el script se detendrá con un mensaje de error si no lo encuentra. También requiere contar con `pip` y `npm` en el sistema. Tras la instalación comprueba que PHP CLI está disponible antes de ejecutar las pruebas de PHP:
 
 ```bash
 php -v

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -6,13 +6,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
+# Verify Composer is available before proceeding
+if ! command -v composer >/dev/null 2>&1; then
+    echo "Error: Composer is required to run this script. Please install it first." >&2
+    exit 1
+fi
+
 # Install PHP dependencies
-if command -v composer >/dev/null 2>&1; then
-    if ! composer install --no-interaction --no-progress --prefer-dist; then
-        echo "Warning: composer install failed." >&2
-    fi
-else
-    echo "Warning: Composer not found; skipping PHP dependencies." >&2
+if ! composer install --no-interaction --no-progress --prefer-dist; then
+    echo "Warning: composer install failed." >&2
 fi
 
 # Install Python dependencies


### PR DESCRIPTION
## Summary
- mention Composer must be installed before running `scripts/setup_environment.sh`
- exit early in setup script when Composer is missing

## Testing
- `./scripts/setup_environment.sh` *(fails: composer install issues)*
- `vendor/bin/phpunit` *(fails: missing dom/xml extensions)*
- `python -m unittest tests/test_flask_api.py`
- `npm test` *(fails: WaitTask timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6854c8528758832995bb6d4283f41643