### PR TITLE
Add shared height variable for header and footer

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -50,6 +50,7 @@
     --global-box-shadow-dark: 0 8px 25px rgba(var(--epic-text-color-rgb), 0.2);
     --alabaster-background-image: url('/assets/img/alabastro.jpg');
     --menu-extra-offset: 60px;
+    --header-footer-height: 60px;
     /* Altura reservada para la barra de idiomas superior (no usada en el panel lateral) */
     --language-bar-height: 40px;
     /* Espacio superior aplicado al menú, ajustado dinámicamente */
@@ -444,6 +445,7 @@ th {
 .footer {
     background: linear-gradient(to bottom, rgba(var(--epic-purple-emperor-rgb), 0.9), rgba(var(--epic-purple-emperor-rgb), 0.75));
     color: var(--epic-text-light);
+    height: var(--header-footer-height);
     padding: 3em 1em 2em 1em; /* More padding */
     text-align: center; /* Footer content should generally be centered */
     border-top: 8px solid var(--epic-gold-main);

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -7,6 +7,7 @@
     right: 0;
     z-index: 4000;
     /* Use a semi-transparent purple tone for the fixed button bar */
+    height: var(--header-footer-height);
     background-color: rgba(var(--epic-purple-emperor-rgb), 0.85);
     padding: 5px 10px;
     display: flex;

--- a/fragments/footer.php
+++ b/fragments/footer.php
@@ -1,4 +1,4 @@
-<footer class="footer">
+<footer class="footer" style="height: var(--header-footer-height);">
     <div class="container-epic">
         <p>© <script>document.write(new Date().getFullYear());</script> CondadoDeCastilla.com - Todos los derechos reservados.</p>
         <p>Un proyecto para la difusión del patrimonio histórico de Cerezo de Río Tirón y el Alfoz de Cerasio y Lantarón.</p>

--- a/fragments/header.php
+++ b/fragments/header.php
@@ -1,5 +1,5 @@
 <div id="cave-mask"></div>
-<div id="fixed-header-elements">
+<div id="fixed-header-elements" style="height: var(--header-footer-height);">
     <div class="header-action-buttons">
         <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
         <button id="flag-toggle" data-menu-target="language-panel" aria-label="Seleccionar idioma" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>


### PR DESCRIPTION
## Summary
- define `--header-footer-height` in `epic_theme.css`
- use this variable for the fixed header bar
- apply the same height to `.footer`
- inline height usage in `header.php` and `footer.php`

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6854c8551f788329a31e7bb8ea682e29