### PR TITLE
Enhance header visuals with cultural icons

### DIFF
--- a/assets/css/header/layout.css
+++ b/assets/css/header/layout.css
@@ -1,2 +1,21 @@
 /* Layout styles for header container */
 
+/* Decorative icons inside the fixed header */
+.header-icon {
+    width: 32px;
+    height: auto;
+    border: 2px solid var(--epic-gold-main);
+    border-radius: 50%;
+    padding: 2px;
+    background-color: rgba(var(--epic-alabaster-bg-rgb), 0.9);
+    box-shadow: 0 0 4px rgba(var(--epic-gold-main-rgb), 0.5);
+}
+
+.header-icon.star-of-venus {
+    margin-right: 10px;
+}
+
+.header-icon.roman-column {
+    margin-left: 10px;
+}
+

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -6,8 +6,10 @@
     left: 0;
     right: 0;
     z-index: 4000;
-    /* Use a semi-transparent purple tone for the fixed button bar */
     background-color: rgba(var(--epic-purple-emperor-rgb), 0.85);
+    background-image: var(--alabaster-background-image);
+    background-size: cover;
+    background-blend-mode: multiply;
     padding: 5px 10px;
     display: flex;
     justify-content: space-between;

--- a/fragments/header.php
+++ b/fragments/header.php
@@ -1,10 +1,12 @@
 <div id="cave-mask"></div>
 <div id="fixed-header-elements">
+    <img class="header-icon star-of-venus" src="/assets/img/estrella.png" alt="Estrella de Venus decorativa">
     <div class="header-action-buttons">
         <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
         <button id="flag-toggle" data-menu-target="language-panel" aria-label="Seleccionar idioma" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>
         <button id="mute-toggle" aria-pressed="false" aria-label="Silenciar">🔊</button>
     </div>
+    <img class="header-icon roman-column" src="/assets/icons/columna.svg" alt="Columna romana decorativa">
 </div>
 
 <!-- Left Sliding Panel for Main Menu -->


### PR DESCRIPTION
## Summary
- add star of Venus and Roman column icons to the fixed header
- apply alabaster background texture in the header bar
- style header icons and borders with old gold tones

## Testing
- `vendor/bin/phpunit` *(fails: php-cgi not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Waiting for selector `#google_translate_element` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6854c85518808329b6536983da5d806f