### PR TITLE
Refactor header background styles to use Tailwind utilities

### DIFF
--- a/alfoz/alfoz.php
+++ b/alfoz/alfoz.php
@@ -28,7 +28,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
     require_once __DIR__ . '/../fragments/header.php';
     ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_mis_tierras.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_mis_tierras.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <?php editableText('alfoz_hero_titulo', $pdo, 'El Alfoz de Cerasio y Lantarón', 'h1'); ?>

--- a/camino_santiago/camino_santiago.php
+++ b/camino_santiago/camino_santiago.php
@@ -11,7 +11,7 @@ load_page_css();
 
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.75), rgba(var(--color-negro-contraste-rgb), 0.88)), url('/assets/img/hero_camino_santiago.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_camino_santiago.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus" class="decorative-star-header">
             <h1>Cerezo de Río Tirón: Hito Histórico del Camino de Santiago</h1>

--- a/contacto/contacto.php
+++ b/contacto/contacto.php
@@ -28,7 +28,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
     require_once __DIR__ . '/../fragments/header.php';
     ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.75), rgba(var(--color-negro-contraste-rgb), 0.88)), url('/assets/img/hero_contacto_background.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_contacto_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <?php editableText('contacto_hero_titulo', $pdo, 'Ponte en Contacto', 'h1'); ?>

--- a/cultura/cultura.php
+++ b/cultura/cultura.php
@@ -28,7 +28,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
     require_once __DIR__ . '/../fragments/header.php';
     ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.75), rgba(var(--color-negro-contraste-rgb), 0.88)), url('/assets/img/hero_cultura_background.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_cultura_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <?php editableText('cultura_hero_titulo', $pdo, 'Cultura Viva y Legado Perenne', 'h1'); ?>

--- a/empresa/index.php
+++ b/empresa/index.php
@@ -14,7 +14,7 @@ require_admin_login();
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.75), rgba(var(--color-negro-contraste-rgb), 0.88)), url('/assets/img/hero_contacto_background.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_contacto_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <h1>Empresa de Gestión de Yacimientos</h1>

--- a/historia/atapuerca_static_converted.php
+++ b/historia/atapuerca_static_converted.php
@@ -5,7 +5,7 @@
 </head>
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(0,0,0, 0.5), rgba(0,0,0, 0.5)), url('../assets/img/placeholder.jpg');"> <!-- Basic hero style -->
+    <header class="page-header hero bg-[url('../assets/img/placeholder.jpg')] bg-cover bg-center md:bg-center"> <!-- Basic hero style -->
         <div class="hero-content">
             <h1>Los Yacimientos de la Sierra de Atapuerca</h1>
         </div>

--- a/historia/documentos/index.php
+++ b/historia/documentos/index.php
@@ -7,7 +7,7 @@
 
     <?php require_once __DIR__ . '/../../fragments/header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_historia_background.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_historia_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <h1>Documentos Históricos</h1>
             <p>Una colección de documentos, manuscritos y archivos relacionados con la historia del Condado de Castilla y Cerezo de Río Tirón.</p>

--- a/historia/galeria_historica/index.php
+++ b/historia/galeria_historica/index.php
@@ -10,7 +10,7 @@ load_page_css();
 <body class="alabaster-bg">
 
     <?php require_once __DIR__ . '/../../fragments/header.php'; ?>
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_historia_background.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_historia_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <h1>Galería Histórica</h1>
             <p>Imágenes, documentos y artefactos visuales que narran la rica historia del Condado de Castilla y sus gentes.</p>

--- a/historia/historia.php
+++ b/historia/historia.php
@@ -7,7 +7,7 @@
 
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_historia_background.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_historia_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <h1 class="gradient-text">Línea de Tiempo de Nuestra Historia</h1>
             <p>Un recorrido cronológico por los eventos y eras que forjaron el Condado de Castilla y la identidad de Cerezo de Río Tirón.</p>

--- a/historia/influencia_romana.php
+++ b/historia/influencia_romana.php
@@ -16,7 +16,7 @@
 </head>
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb),0.7), rgba(var(--color-negro-contraste-rgb),0.85)), url('/assets/img/hero_historia_background.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_historia_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <h1 class="gradient-text">Influencia Romana en la Región</h1>
             <p>Una mirada a la huella romana desde la Antigüedad hasta hoy.</p>

--- a/historia/subpaginas_indice.php
+++ b/historia/subpaginas_indice.php
@@ -33,7 +33,7 @@ load_page_css();
 </head>
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
-    <header class="page-header hero min-h-[30vh]" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/imagenes/mapa_antiguo_detalle.jpg');">
+    <header class="page-header hero min-h-[30vh] bg-[url('/imagenes/mapa_antiguo_detalle.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <h1><?php echo htmlspecialchars($titulo_pagina); ?></h1>
         </div>

--- a/lugares/alfozcerezolantaron/Cerezo_de_Rio_Tiron/index.php
+++ b/lugares/alfozcerezolantaron/Cerezo_de_Rio_Tiron/index.php
@@ -11,7 +11,7 @@
 <body class="alabaster-bg">
   <?php require_once __DIR__ . '/../../fragments/header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/Muralla.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/Muralla.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <img src="/assets/img/estrellaGordita.png" alt="Estrella Decorativa de Cerezo" class="decorative-star-header decorative-star-header-highlighted">
             <h1>Cerezo de Río Tirón</h1>

--- a/lugares/alfozcerezolantaron/alfoz.php
+++ b/lugares/alfozcerezolantaron/alfoz.php
@@ -11,7 +11,7 @@
     <?php require_once __DIR__ . '/../../fragments/header.php'; ?>
 
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_alfoz_background.jpg'); min-height: 50vh;">
+    <header class="page-header hero bg-[url('/assets/img/hero_alfoz_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content" style="background-color: rgba(var(--color-negro-contraste-rgb), 0.5); padding: clamp(30px, 5vw, 50px);">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header" style="width: clamp(50px, 8vw, 70px); margin-bottom:15px;">
             <h1 style="font-size: clamp(2.6em, 6.5vw, 4.2em);">El Alfoz de Cerasio y Lantarón</h1>

--- a/lugares/cerasio.php
+++ b/lugares/cerasio.php
@@ -10,7 +10,7 @@
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.7), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_mis_tierras.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_mis_tierras.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content" style="background-color: rgba(var(--color-negro-contraste-rgb), 0.5); padding: clamp(30px, 5vw, 50px);">
             <h1 style="font-size: clamp(2.6em, 6.5vw, 4.2em);">Cerasio</h1>
             <p style="font-size: clamp(1.05em, 2.3vw, 1.45em); max-width: 70ch;">Reflexiones y fragmentos tomados de <code>nuevo4.md</code> sobre el origen de Castilla.</p>

--- a/lugares/el_culebron.php
+++ b/lugares/el_culebron.php
@@ -7,7 +7,7 @@
 </head>
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.6), rgba(var(--color-negro-contraste-rgb), 0.7)), url('/assets/img/hero_mis_tierras.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_mis_tierras.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content" style="padding: clamp(20px, 4vw, 40px);">
             <h1>El Culebrón</h1>
         </div>

--- a/lugares/lugares.php
+++ b/lugares/lugares.php
@@ -12,7 +12,7 @@
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.75), rgba(var(--color-negro-contraste-rgb), 0.88)), url('/assets/img/hero_lugares_background.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_lugares_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <h1>Lugares Emblemáticos: Huellas de la Historia</h1>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html
@@ -14,7 +14,7 @@
 <body class="alabaster-bg">
     <?php require_once __DIR__.'/../../fragments/header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.75), rgba(var(--color-negro-contraste-rgb), 0.85)), url('/assets/img/hero_personajes_background.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_personajes_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <h1>Gonzalo Téllez</h1>
             <p>Conde de Lantarón y Cerezo, figura clave en la primitiva Castilla.</p>

--- a/personajes/indice_personajes.html
+++ b/personajes/indice_personajes.html
@@ -21,7 +21,7 @@
 
     <?php require_once __DIR__.'/../fragments/header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.75), rgba(var(--color-negro-contraste-rgb), 0.88)), url('/assets/img/hero_personajes_background.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_personajes_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <h1 class="gradient-text">Índice de Personajes Históricos y Legendarios</h1>

--- a/visitas/visitas.php
+++ b/visitas/visitas.php
@@ -11,7 +11,7 @@ load_page_css();
 
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
 
-    <header class="page-header hero" style="background-image: linear-gradient(rgba(var(--color-primario-purpura-rgb), 0.75), rgba(var(--color-negro-contraste-rgb), 0.88)), url('/assets/img/hero_visitas_background.jpg');">
+    <header class="page-header hero bg-[url('/assets/img/hero_visitas_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <h1>Planifica Tu Viaje al Corazón de Castilla</h1>


### PR DESCRIPTION
## Summary
- use Tailwind `bg-[url(...)]` utility classes instead of inline `background-image` styles on page headers

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854c85e712083298dba4e85383b7bca