### PR TITLE
Update admin fonts to use CSS variables

### DIFF
--- a/assets/css/admin_theme.css
+++ b/assets/css/admin_theme.css
@@ -2,11 +2,15 @@
 
 /* Admin dashboard common styles */
 body.admin-page {
-    font-family: Arial, sans-serif;
+    font-family: var(--font-primary);
     margin: 0;
     padding: 0;
     background-color: var(--epic-alabaster-bg);
     color: var(--epic-text-color);
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-headings);
 }
 
 body.admin-page.centered {


### PR DESCRIPTION
## Summary
- use `var(--font-primary)` for main admin font
- add heading font rule in `admin_theme.css`

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm test` *(fails: cannot find module 'puppeteer')*
- `python -m unittest tests/test_flask_api.py`
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6854c870d83c83298e591e7983d23c87