### PR TITLE
Extract admin edit styles to CSS file

### DIFF
--- a/assets/css/admin_theme.css
+++ b/assets/css/admin_theme.css
@@ -2,7 +2,7 @@
 
 /* Admin dashboard common styles */
 body.admin-page {
-    font-family: Arial, sans-serif;
+    font-family: var(--font-primary);
     margin: 0;
     padding: 0;
     background-color: var(--epic-alabaster-bg);
@@ -140,3 +140,25 @@ canvas { max-width: 100%; height: auto !important; }
     display: none;
 }
 .ml-10 { margin-left: 10px; }
+
+/* Styles for museo/editar_pieza.php */
+body.edit-pieza-page {
+    margin: 20px;
+}
+
+body.edit-pieza-page table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 20px;
+}
+
+body.edit-pieza-page th,
+body.edit-pieza-page td {
+    border: 1px solid var(--epic-neutral-border);
+    padding: 8px;
+    text-align: left;
+}
+
+body.edit-pieza-page th {
+    background-color: var(--epic-neutral-bg);
+}

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/env_loader.php';
 <link rel="stylesheet" href="/assets/css/time_palettes.css">
 <link rel="stylesheet" href="/assets/css/lighting.css">
 <link rel="stylesheet" href="/assets/css/cave_mask.css">
+<link rel="stylesheet" href="/assets/css/admin_theme.css">
 <link rel="stylesheet" href="/assets/vendor/css/tailwind.min.css">
 <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-SN33kWx+ihQ/HVbUaz2QmiFjCwXTlzAIXazhbugzuDUFc1l1b/HFB70dNFuPu6j6" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" integrity="sha384-/rJKQnzOkEo+daG0jMjU1IwwY9unxt1NBw3Ef2fmOJ3PW/TfAg2KXVoWwMZQZtw9" crossorigin="anonymous" />

--- a/museo/editar_pieza.php
+++ b/museo/editar_pieza.php
@@ -58,16 +58,8 @@ try {
 <head>
     <title>Editar Piezas del Museo</title>
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
-    <style>
-        body { font-family: Arial, sans-serif; margin:20px; }
-        table { width:100%; border-collapse: collapse; margin-bottom:20px; }
-        th, td { border:1px solid #ccc; padding:8px; text-align:left; }
-        th { background-color:#f2f2f2; }
-        .feedback.success { background:#d4edda; padding:10px; margin-bottom:10px; }
-        .feedback.error { background:#f8d7da; padding:10px; margin-bottom:10px; }
-    </style>
 </head>
-<body class="alabaster-bg">
+<body class="alabaster-bg admin-page edit-pieza-page">
 <nav>
     <a href="../index.php">Inicio</a>
     <a href="../dashboard/index.php">Dashboard</a>


### PR DESCRIPTION
## Summary
- extend admin theme stylesheet to cover museum editing page
- load admin stylesheet from common head template
- use admin-page classes in `museo/editar_pieza.php`

## Testing
- `npm install`
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c87222b4832983bfbb1b668d03ee