### PR TITLE
Fix white hero text color variable

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -1617,7 +1617,7 @@ body.dark-mode .footer .social-links a:focus-visible {
 }
 
 .page-header.hero[style*="hero_personajes_background.jpg"] .hero-content h1 {
-    color: #fff;
+    color: var(--epic-text-light);
     text-shadow: 2px 2px 8px rgba(var(--color-negro-contraste-rgb, 10, 10, 10), 0.75);
     font-size: clamp(2.8em, 6.5vw, 4.2em);
 }
@@ -1627,7 +1627,7 @@ body.dark-mode .footer .social-links a:focus-visible {
 }
 
 .page-header-indice .hero-content h1 {
-     color: #fff;
+     color: var(--epic-text-light);
      text-shadow: 2px 2px 6px var(--color-negro-contraste, #1A1A1A); 
 }
 


### PR DESCRIPTION
## Summary
- use `var(--epic-text-light)` variable for white hero headers

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: flask)*
- `npm test` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854c873c888832996863480cf4fbb7e