### PR TITLE
Fix hero text & overlay styling

### DIFF
--- a/index.php
+++ b/index.php
@@ -35,10 +35,10 @@ require_once __DIR__ . '/fragments/header.php';
     <header id="hero-video" class="relative h-screen w-full overflow-hidden">
         <video class="absolute inset-0 object-cover w-full h-full" src="https://samplelib.com/lib/preview/mp4/sample-5s.mp4" autoplay muted loop playsinline></video>
         <div id="hero-content" class="relative z-10 flex flex-col items-center justify-center h-full text-center opacity-0 transition-opacity duration-1000 ease-out">
-            <h1 class="font-serif text-yellow-300 text-3xl md:text-5xl shadow-lg drop-shadow-lg">Condado de Castilla: Cuna de Emperadores</h1>
-            <p class="mt-4 bg-black bg-opacity-50 text-white p-4 font-sans">Promocionamos el turismo en Cerezo de Río Tirón y cuidamos su patrimonio arqueológico y cultural.</p>
+            <h1 class="font-serif text-3xl md:text-5xl shadow-lg drop-shadow-lg gradient-text">Condado de Castilla: Cuna de Emperadores</h1>
+            <p class="mt-4 text-white p-4 font-sans" style="background-color: var(--epic-transparent-black-overlay);">Promocionamos el turismo en Cerezo de Río Tirón y cuidamos su patrimonio arqueológico y cultural.</p>
         </div>
-        <div class="absolute bottom-8 left-1/2 transform -translate-x-1/2 text-yellow-300">
+        <div class="absolute bottom-8 left-1/2 transform -translate-x-1/2" style="color: var(--epic-gold-main);">
             <svg class="w-8 h-8 animate-bounce" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
             </svg>


### PR DESCRIPTION
## Summary
- style hero text with `gradient-text`
- use CSS variable for header overlay background
- color the down arrow with `--epic-gold-main`

## Testing
- `composer install` *(fails: command not found)*
- `npm install`
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*
- `./check_links.sh`
- `./check_links_extended.sh`
- `./scripts/check_alt_texts.sh`


------
https://chatgpt.com/codex/tasks/task_e_6854c8767c6c8329a038d2516d5dc599