### PR TITLE
Remove Google fonts

### DIFF
--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -6,9 +6,6 @@ require_once __DIR__ . '/env_loader.php';
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
 <link rel="stylesheet" href="/assets/css/epic_theme.css">
 <link rel="stylesheet" href="/assets/css/header.css">

--- a/museo/subir_pieza.php
+++ b/museo/subir_pieza.php
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Subir Pieza al Museo - Condado de Castilla</title>
     <link rel="icon" href="/imagenes/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/alvaro_herramelliz.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Álvaro Herramelliz - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Diego Rodríguez Porcelos - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/dona_sancha.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/dona_sancha.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Doña Sancha - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernan_gonzalez.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernan_gonzalez.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fernán González - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gonzalo Téllez - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
+++ b/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Rodrigo, Primer Conde de Castilla - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/aureliano.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/aureliano.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Aureliano - Emperadores Romanos</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_teodosio_i_el_grande.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_teodosio_i_el_grande.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Flavio Teodosio I El Grande - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="../../assets/css/epic_theme.css"> <!-- Referencia al CSS común de personajes -->
 </head>

--- a/personajes/Emperadores_Romanos_Hispanos_Auca/magno_clemente_maximo.html
+++ b/personajes/Emperadores_Romanos_Hispanos_Auca/magno_clemente_maximo.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Magno Clemente Máximo - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="../../assets/css/epic_theme.css"> <!-- Referencia al CSS común de personajes -->
 </head>

--- a/personajes/Militares_y_Gobernantes/agripa.html
+++ b/personajes/Militares_y_Gobernantes/agripa.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Agripa - General Romano</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/alfonso_ii_el_casto.html
+++ b/personajes/Militares_y_Gobernantes/alfonso_ii_el_casto.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Alfonso II el Casto - Rey de Asturias</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/cesar_augusto.html
+++ b/personajes/Militares_y_Gobernantes/cesar_augusto.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cesar Augusto - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html
+++ b/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Conde Casio - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/corocotta.html
+++ b/personajes/Militares_y_Gobernantes/corocotta.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Corocotta - Caudillo Cántabro</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/leovigildo.html
+++ b/personajes/Militares_y_Gobernantes/leovigildo.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Leovigildo - Rey Visigodo</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Militares_y_Gobernantes/ramiro_i_de_asturias.html
+++ b/personajes/Militares_y_Gobernantes/ramiro_i_de_asturias.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ramiro I De Asturias - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
+++ b/personajes/Ordenes_y_Legados/fray_prudencio_de_sandoval.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fray Prudencio de Sandoval - Cronistas e Historiadores</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Ordenes_y_Legados/paterna_banucasi.html
+++ b/personajes/Ordenes_y_Legados/paterna_banucasi.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paterna Banucasi - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Santos_y_Martires/san_braulio.html
+++ b/personajes/Santos_y_Martires/san_braulio.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>San Braulio de Zaragoza - Obispos y Escritores</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Santos_y_Martires/san_formerio.html
+++ b/personajes/Santos_y_Martires/san_formerio.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>San Formerio - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/Santos_y_Martires/san_vitores.html
+++ b/personajes/Santos_y_Martires/san_vitores.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>San Vitores - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>

--- a/personajes/indice_personajes.html
+++ b/personajes/indice_personajes.html
@@ -6,9 +6,6 @@
     <title>Índice de Personajes Históricos - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/secciones_index/historia_tiempo_resumen.html
+++ b/secciones_index/historia_tiempo_resumen.html
@@ -6,9 +6,6 @@
     <title>Resumen de Nuestra Historia en el Tiempo - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/secciones_index/memoria_hispanidad.html
+++ b/secciones_index/memoria_hispanidad.html
@@ -6,9 +6,6 @@
     <title>Memoria de la Hispanidad Castellana - Condado de Castilla</title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
 
     <link rel="stylesheet" href="/assets/css/epic_theme.css">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,10 @@ module.exports = {
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
       },
+      fontFamily: {
+        headings: "var(--font-headings)",
+        body: "var(--font-primary)",
+      },
     },
   },
   plugins: [],

--- a/tailwind_index.html
+++ b/tailwind_index.html
@@ -5,22 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Condado de Castilla - Página Principal</title>
     <link rel="stylesheet" href="/assets/vendor/css/tailwind.min.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Lora:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <style>
-        .font-epic-title { font-family: 'Cinzel', serif; }
-        .font-epic-body { font-family: 'Lora', serif; }
         .bg-imperial-purple { --tw-bg-opacity: 1; background-color: rgb(74 13 103 / var(--tw-bg-opacity)); }
         .text-old-gold { --tw-text-opacity: 1; color: rgb(184 134 11 / var(--tw-text-opacity)); }
         .bg-old-gold { --tw-bg-opacity: 1; background-color: rgb(207 181 59 / var(--tw-bg-opacity)); }
         .texture-alabaster { background-image: url('/assets/img/alabastro.jpg'); background-size: cover; background-blend-mode: multiply; }
     </style>
 </head>
-<body class="font-epic-body bg-[color:var(--epic-alabaster-bg)] text-gray-900">
+<body class="font-body bg-[color:var(--epic-alabaster-bg)] text-gray-900">
     <header class="fixed w-full bg-imperial-purple bg-opacity-90 text-old-gold shadow z-20">
         <div class="max-w-7xl mx-auto flex items-center justify-between p-4">
-            <h1 class="font-epic-title text-xl md:text-2xl gradient-text">Condado de Castilla</h1>
+            <h1 class="font-headings text-xl md:text-2xl gradient-text">Condado de Castilla</h1>
             <button id="menu-toggle" aria-label="Abrir menú" class="text-old-gold md:hidden focus:outline-none">☰</button>
             <nav class="hidden md:flex space-x-4" aria-label="Navegación principal">
                 <a href="#hero" class="hover:underline">Inicio</a>
@@ -41,19 +36,19 @@
 
     <main class="pt-20 space-y-20">
         <section id="hero" class="relative text-center text-old-gold texture-alabaster bg-imperial-purple bg-opacity-75 py-20">
-            <h2 class="font-epic-title text-4xl sm:text-5xl lg:text-6xl mb-4 gradient-text">Cuna de la Cultura Hispana</h2>
+            <h2 class="font-headings text-4xl sm:text-5xl lg:text-6xl mb-4 gradient-text">Cuna de la Cultura Hispana</h2>
             <p class="text-lg sm:text-xl max-w-prose mx-auto">Promocionamos el turismo en Cerezo de Río Tirón y gestionamos su patrimonio arqueológico y cultural.</p>
         </section>
 
         <section id="timeline" class="max-w-5xl mx-auto px-4">
-            <h2 class="font-epic-title text-3xl text-imperial-purple mb-6">Línea de Tiempo Histórica</h2>
+            <h2 class="font-headings text-3xl text-imperial-purple mb-6">Línea de Tiempo Histórica</h2>
             <div class="grid sm:grid-cols-2 gap-6">
                 <article class="p-4 bg-white/70 border-l-4 border-old-gold">
-                    <h3 class="font-epic-title text-2xl">Antigüedad</h3>
+                    <h3 class="font-headings text-2xl">Antigüedad</h3>
                     <p>Espacio para describir los orígenes y primeros asentamientos.</p>
                 </article>
                 <article class="p-4 bg-white/70 border-l-4 border-old-gold">
-                    <h3 class="font-epic-title text-2xl">Edad Media</h3>
+                    <h3 class="font-headings text-2xl">Edad Media</h3>
                     <p>Breve introducción a la formación del Condado de Castilla.</p>
                 </article>
             </div>
@@ -61,14 +56,14 @@
 
         <section id="arqueologia" class="texture-alabaster bg-old-gold bg-opacity-80 py-16">
             <div class="max-w-4xl mx-auto px-4 text-imperial-purple">
-                <h2 class="font-epic-title text-3xl mb-4">Exploración Arqueológica</h2>
+                <h2 class="font-headings text-3xl mb-4">Exploración Arqueológica</h2>
                 <p class="mb-6">Zona preparada para mostrar hallazgos y excavaciones de Cerezo de Río Tirón.</p>
                 <img src="/assets/img/Muralla.jpg" alt="Muralla histórica de Cerezo de Río Tirón" class="w-full h-auto rounded shadow-md" />
             </div>
         </section>
 
         <section id="foro" class="max-w-4xl mx-auto px-4">
-            <h2 class="font-epic-title text-3xl text-imperial-purple mb-4">Foro de Expertos</h2>
+            <h2 class="font-headings text-3xl text-imperial-purple mb-4">Foro de Expertos</h2>
             <p class="mb-8">Cinco especialistas comparten su conocimiento para impulsar la comunidad.</p>
             <ul class="grid md:grid-cols-5 gap-4 text-center">
                 <li>Alicia la Historiadora</li>
@@ -81,7 +76,7 @@
     </main>
 
     <footer class="bg-imperial-purple text-old-gold text-center py-4 texture-alabaster">
-        <p class="font-epic-title">© 2024 Condado de Castilla</p>
+        <p class="font-headings">© 2024 Condado de Castilla</p>
         <p>Difundiendo el legado de Castilla y Cerezo de Río Tirón.</p>
     </footer>
 


### PR DESCRIPTION
## Summary
- drop Google fonts link tags
- remove old `.font-epic-*` styles and switch to `font-headings`/`font-body`
- define `fontFamily` utilities in Tailwind config

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6854c8d131e4832991f4bf3b650115e3