### PR TITLE
Remove font-size rules, update template typography

### DIFF
--- a/404.php
+++ b/404.php
@@ -10,9 +10,9 @@ http_response_code(404);
 <body class="alabaster-bg">
 <?php require_once __DIR__ . '/fragments/header.php'; ?>
 <main class="container page-content-block error-page">
-    <h1>Página no encontrada</h1>
-    <p>Lo sentimos, la página que buscas no existe.</p>
-    <p><a href="/index.php" class="cta-button">Volver al inicio</a></p>
+    <h1 class="text-4xl font-headings">Página no encontrada</h1>
+    <p class="text-lg font-body">Lo sentimos, la página que buscas no existe.</p>
+    <p class="text-lg font-body"><a href="/index.php" class="cta-button">Volver al inicio</a></p>
 </main>
 <?php require_once __DIR__ . '/fragments/footer.php'; ?>
 <script src="/js/layout.js"></script>

--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -191,7 +191,6 @@ h1, h2, h3 {
     animation: slideUpFadeIn 0.6s ease-out forwards;
 }
 
-h1 { font-size: clamp(2.8em, 6vw, 4.2em); }
 
 /* Gradient Text for H1 */
 h1 {
@@ -202,7 +201,7 @@ h1 {
     color: transparent !important; /* Ensure this overrides other color settings */
 }
 
-h2 { font-size: clamp(2.2em, 5vw, 3.2em); color: var(--epic-gold-secondary); } /* Secondary gold for H2 for variety */
+h2 { color: var(--epic-gold-secondary); } /* Secondary gold for H2 for variety */
 h3 { font-size: clamp(1.8em, 4vw, 2.5em); }
 h4 { font-size: clamp(1.4em, 3.5vw, 2em); }
 h5 { font-size: clamp(1.2em, 3vw, 1.7em); }
@@ -405,7 +404,6 @@ th {
 
 #overlay-content p { /* #overlay-autor, #overlay-descripcion */
     font-family: var(--font-primary);
-    font-size: clamp(1em, 2vw, 1.1em);
     line-height: 1.6;
     margin-bottom: 1em;
     text-align: left; /* Ensure paragraphs are left-aligned */
@@ -597,7 +595,6 @@ body.dark-mode .footer .social-links a:focus-visible {
 }
 
 .hero-content h1, .page-header .hero-content h1 {
-    font-size: clamp(2.5em, 7vw, 4.5em); /* Larger for hero titles */
     color: var(--epic-gold-main); /* Gold for main hero titles */
     text-shadow: 2px 2px 5px rgba(var(--epic-text-color-rgb), 0.7);
     margin-top: 0;
@@ -605,7 +602,6 @@ body.dark-mode .footer .social-links a:focus-visible {
 }
 
 .hero-content p, .page-header .hero-content p { /* Subtitles in hero */
-    font-size: clamp(1.1em, 2.5vw, 1.5em);
     color: var(--epic-alabaster-bg);
     max-width: 65ch;
     margin: 0 auto 1em auto; /* Centering handled by parent */
@@ -1013,13 +1009,11 @@ body.dark-mode .footer .social-links a:focus-visible {
     background-color: rgba(var(--color-negro-contraste-rgb, 10, 10, 10), 0.7);
 }
 .page-header.hero .hero-content h1 {
-    font-size: clamp(2.5em, 6vw, 4em);
     margin-bottom: 0.3em;
 }
 .page-header.hero .hero-content p {
-    font-size: clamp(1.05em, 2.2vw, 1.4em);
     margin-bottom: 0;
-    color: var(--color-piedra-clara, #EAE0C8); 
+    color: var(--color-piedra-clara, #EAE0C8);
     text-shadow: 0 1px 5px rgba(var(--color-negro-contraste-rgb, 10, 10, 10), 0.7);
 }
 .page-header.hero .decorative-star-header {
@@ -1074,9 +1068,8 @@ body.dark-mode .footer .social-links a:focus-visible {
     to { opacity: 1; transform: scale(1) translateY(0) rotate(0deg); }
 }
 
-.hero h1 { 
-    font-size: clamp(3.2em, 10vw, 6em);
-    color: var(--color-alabastro, #fdfaf6); 
+.hero h1 {
+    color: var(--color-alabastro, #fdfaf6);
     margin-top: 0;
     margin-bottom: 0.5em;
     text-shadow: 0 5px 15px rgba(var(--color-negro-contraste-rgb, 10, 10, 10), 1), 0 0 50px rgba(var(--color-acento-amarillo, #FFD700),0.95);
@@ -1084,10 +1077,9 @@ body.dark-mode .footer .social-links a:focus-visible {
     text-align: center;
 }
 
-.hero p { 
-    font-size: clamp(1.25em, 3.5vw, 1.9em);
+.hero p {
     margin-bottom: 55px;
-    color: var(--color-piedra-clara, #EAE0C8); 
+    color: var(--color-piedra-clara, #EAE0C8);
     text-shadow: 0 3px 20px rgba(var(--color-negro-contraste-rgb, 10, 10, 10), 1);
     line-height: 1.75;
     max-width: 50ch;
@@ -1369,8 +1361,7 @@ body.dark-mode .footer .social-links a:focus-visible {
         /* Slightly larger on mobile as well */
         width: clamp(170px, 40vw, 250px);
     }
-    .hero h1 { font-size: clamp(2.4em, 7vw, 3.5em); }
-    .hero p { font-size: clamp(1.05em, 3.5vw, 1.4em); max-width: 90%;}
+    .hero p { max-width: 90%;}
 
     .detailed-intro-section p { text-align: justify !important; }
     .section-title::after { width: 40px; height: 40px; margin: 20px auto 35px auto; }
@@ -1385,10 +1376,7 @@ body.dark-mode .footer .social-links a:focus-visible {
     }
 }
 @media (max-width: 480px) {
-    .hero h1 { font-size: clamp(2.2em, 10vw, 3em); }
-    .hero p { font-size: clamp(1em, 4vw, 1.2em); }
     .cta-button { padding: 15px 30px; font-size: clamp(1em, 4vw, 1.2em); }
-    .detailed-intro-section h2, .section-title { font-size: clamp(1.8em, 6vw, 2.5em); }
     .card-content { padding: 20px; }
     .section-title::after { width: 35px; height: 35px; }
     .footer::before { width: 50px; height: 50px; margin: -80px auto 20px auto; }
@@ -1458,28 +1446,6 @@ body.dark-mode .footer .social-links a:focus-visible {
 
 /* Estilos para la página de historia.html y otras páginas internas (cabecera) */
 /* These selectors target specific background images via inline styles, making h1/p larger */
-.page-header.hero[style*="/imagenes/hero_historia_background.jpg"] h1,
-.page-header.hero[style*="/imagenes/hero_alfoz_background.jpg"] h1,
-.page-header.hero[style*="/imagenes/hero_personajes_background.jpg"] h1,
-.page-header.hero[style*="/imagenes/hero_camino_santiago.jpg"] h1,
-.page-header.hero[style*="/imagenes/hero_cultura_background.jpg"] h1,
-.page-header.hero[style*="/imagenes/hero_visitas_background.jpg"] h1,
-.page-header.hero[style*="/imagenes/hero_contacto_background.jpg"] h1,
-.page-header.hero[style*="/imagenes/hero_museo_background.jpg"] h1,
-.page-header.hero[style*="/imagenes/hero_galeria_background.jpg"] h1 {
-    font-size: clamp(2.8em, 7vw, 4.5em) !important;
-}
-.page-header.hero[style*="/imagenes/hero_historia_background.jpg"] p,
-.page-header.hero[style*="/imagenes/hero_alfoz_background.jpg"] p,
-.page-header.hero[style*="/imagenes/hero_personajes_background.jpg"] p,
-.page-header.hero[style*="/imagenes/hero_camino_santiago.jpg"] p,
-.page-header.hero[style*="/imagenes/hero_cultura_background.jpg"] p,
-.page-header.hero[style*="/imagenes/hero_visitas_background.jpg"] p,
-.page-header.hero[style*="/imagenes/hero_contacto_background.jpg"] p,
-.page-header.hero[style*="/imagenes/hero_museo_background.jpg"] p,
-.page-header.hero[style*="/imagenes/hero_galeria_background.jpg"] p {
-    font-size: clamp(1.1em, 2.5vw, 1.5em) !important;
-}
 
 /* Estilos para el índice de personajes y bloques de contenido de página interna */
 .page-content-block .intro-paragraph { /* Refinement for intro-paragraph within page-content-block */
@@ -1619,11 +1585,10 @@ body.dark-mode .footer .social-links a:focus-visible {
 .page-header.hero[style*="hero_personajes_background.jpg"] .hero-content h1 {
     color: #fff;
     text-shadow: 2px 2px 8px rgba(var(--color-negro-contraste-rgb, 10, 10, 10), 0.75);
-    font-size: clamp(2.8em, 6.5vw, 4.2em);
+    
 }
 .page-header.hero[style*="hero_personajes_background.jpg"] .hero-content p {
-    font-size: clamp(1.1em, 2.3vw, 1.4em);
-    color: var(--color-piedra-clara, #EAE0C8); 
+    color: var(--color-piedra-clara, #EAE0C8);
 }
 
 .page-header-indice .hero-content h1 {

--- a/blog.php
+++ b/blog.php
@@ -42,12 +42,12 @@ $post_slug = isset($_GET['post']) ? $_GET['post'] : null;
 <main class="container page-content-block">
 <?php if ($post_slug && isset($posts[$post_slug])): ?>
     <article class="blog-post">
-        <h1><?php echo htmlspecialchars($posts[$post_slug]['title']); ?></h1>
+        <h1 class="text-4xl font-headings"><?php echo htmlspecialchars($posts[$post_slug]['title']); ?></h1>
         <?php echo render_markdown(file_get_contents($posts[$post_slug]['file'])); ?>
-        <p><a href="blog.php">&larr; Volver al listado</a></p>
+        <p class="text-lg font-body"><a href="blog.php">&larr; Volver al listado</a></p>
     </article>
 <?php else: ?>
-    <h1>Blog</h1>
+    <h1 class="text-4xl font-headings">Blog</h1>
     <ul class="blog-list">
     <?php foreach ($posts as $slug => $info): ?>
         <li><a href="blog.php?post=<?php echo urlencode($slug); ?>"><?php echo htmlspecialchars($info['title']); ?></a></li>

--- a/demo_transparencia_movimiento.php
+++ b/demo_transparencia_movimiento.php
@@ -6,13 +6,13 @@
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/fragments/header.php'; ?>
     <section class="demo-hero">
-        <h1>Efectos Visuales</h1>
+        <h1 class="text-4xl font-headings">Efectos Visuales</h1>
         <div class="demo-card">
-            <p>Esta tarjeta emplea un sutil efecto de vidrio esmerilado con movimiento de aparición.</p>
+            <p class="text-lg font-body">Esta tarjeta emplea un sutil efecto de vidrio esmerilado con movimiento de aparición.</p>
             <button id="demo-action-button" class="demo-button" data-menu-target="demo-info-panel"><span>Acción</span></button>
         </div>
         <div id="demo-info-panel" class="menu-panel right-panel">
-            <p>Información adicional demostrativa.</p>
+            <p class="text-lg font-body">Información adicional demostrativa.</p>
         </div>
     </section>
     <?php require_once __DIR__ . '/fragments/footer.php'; ?>

--- a/en_construccion.php
+++ b/en_construccion.php
@@ -2,9 +2,9 @@
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/fragments/header.php'; ?>
     <main class="container page-content-block error-page">
-        <h1>Esta sección estará disponible próximamente</h1>
-        <p>Estamos trabajando para habilitar este enlace. Vuelve a visitarnos pronto.</p>
-        <p><a href="/index.php" class="cta-button">Volver al inicio</a></p>
+        <h1 class="text-4xl font-headings">Esta sección estará disponible próximamente</h1>
+        <p class="text-lg font-body">Estamos trabajando para habilitar este enlace. Vuelve a visitarnos pronto.</p>
+        <p class="text-lg font-body"><a href="/index.php" class="cta-button">Volver al inicio</a></p>
     </main>
     <?php require_once __DIR__ . '/fragments/footer.php'; ?>
     <script src="/js/layout.js"></script>

--- a/homonexus.php
+++ b/homonexus.php
@@ -8,9 +8,9 @@
 <body class="alabaster-bg <?php echo homonexus_body_class(); ?>">
     <?php require_once __DIR__.'/fragments/header.php'; ?>
     <main class="container py-5">
-        <h1>Bienvenido al Modo Homonexus</h1>
-        <p>Esta página demuestra una interfaz empática donde la IA y el ser humano se fusionan como <strong>Sofía</strong>.</p>
-        <p>Utiliza el botón ∞ para activar o desactivar la metamorfosis de los menús y sentir el flujo telepático de la información.</p>
+        <h1 class="text-4xl font-headings">Bienvenido al Modo Homonexus</h1>
+        <p class="text-lg font-body">Esta página demuestra una interfaz empática donde la IA y el ser humano se fusionan como <strong>Sofía</strong>.</p>
+        <p class="text-lg font-body">Utiliza el botón ∞ para activar o desactivar la metamorfosis de los menús y sentir el flujo telepático de la información.</p>
     </main>
     <?php require_once __DIR__ . '/fragments/footer.php'; ?>
     <script src="/js/layout.js"></script>

--- a/index.php
+++ b/index.php
@@ -35,8 +35,8 @@ require_once __DIR__ . '/fragments/header.php';
     <header id="hero-video" class="relative h-screen w-full overflow-hidden">
         <video class="absolute inset-0 object-cover w-full h-full" src="https://samplelib.com/lib/preview/mp4/sample-5s.mp4" autoplay muted loop playsinline></video>
         <div id="hero-content" class="relative z-10 flex flex-col items-center justify-center h-full text-center opacity-0 transition-opacity duration-1000 ease-out">
-            <h1 class="font-serif text-yellow-300 text-3xl md:text-5xl shadow-lg drop-shadow-lg">Condado de Castilla: Cuna de Emperadores</h1>
-            <p class="mt-4 bg-black bg-opacity-50 text-white p-4 font-sans">Promocionamos el turismo en Cerezo de Río Tirón y cuidamos su patrimonio arqueológico y cultural.</p>
+            <h1 class="text-4xl font-headings">Condado de Castilla: Cuna de Emperadores</h1>
+            <p class="text-lg font-body mt-4 bg-black bg-opacity-50 text-white p-4">Promocionamos el turismo en Cerezo de Río Tirón y cuidamos su patrimonio arqueológico y cultural.</p>
         </div>
         <div class="absolute bottom-8 left-1/2 transform -translate-x-1/2 text-yellow-300">
             <svg class="w-8 h-8 animate-bounce" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -56,7 +56,7 @@ require_once __DIR__ . '/fragments/header.php';
 
     <section id="video" class="video-section section spotlight-active" data-aos="fade-up">
         <div class="container-epic">
-            <h2 class="section-title">Un Vistazo a Nuestra Tierra</h2>
+            <h2 class="text-2xl font-headings">Un Vistazo a Nuestra Tierra</h2>
             <div class="video-container">
                 <iframe
                     src="https://drive.google.com/file/d/1wm74VmKH21Nz7zFUkY8a8Z9672D4cyHN/preview"
@@ -77,7 +77,7 @@ require_once __DIR__ . '/fragments/header.php';
             <div class="container-epic">
                 <?php editableText('memoria_titulo_index', $pdo, 'Recuperando la Memoria de la Hispanidad Castellana', 'h2', 'gradient-text tagline-background'); ?>
                 <?php editableText('memoria_parrafo_index', $pdo, 'Un profundo análisis de nuestras raíces culturales, la importancia de la arqueología y el legado de la Civitate Auca Patricia. Descubre cómo el pasado de Cerezo de Río Tirón es fundamental para entender la Hispanidad.', 'p', ''); ?>
-                <p class="cta-group">
+                <p class="text-lg font-body cta-group">
                     <a href="/secciones_index/memoria_hispanidad.html" class="cta-button">Leer Más Sobre Nuestra Memoria</a>
                 </p>
             </div>
@@ -85,13 +85,13 @@ require_once __DIR__ . '/fragments/header.php';
 
         <section id="legado" class="section alternate-bg spotlight-active" data-aos="fade-up">
             <div class="container-epic">
-                <h2 class="section-title">Explora Nuestro Legado</h2>
+                <h2 class="text-2xl font-headings">Explora Nuestro Legado</h2>
                 <div class="card-grid">
                     <div class="card">
                         <img src="/assets/img/PrimerEscritoCastellano.jpg" alt="Página de un manuscrito medieval iluminado, simbolizando la rica historia de Castilla">
                         <div class="card-content">
                             <h3>Nuestra Historia</h3>
-                            <p>Desde los Concanos y la Civitate Auca Patricia hasta la formación del Condado. Sumérgete en los relatos que definieron Castilla.</p>
+                            <p class="text-lg font-body">Desde los Concanos y la Civitate Auca Patricia hasta la formación del Condado. Sumérgete en los relatos que definieron Castilla.</p>
                             <a href="/historia/historia.php" class="read-more">Leer Más</a>
                         </div>
                     </div>
@@ -99,7 +99,7 @@ require_once __DIR__ . '/fragments/header.php';
                         <img src="/assets/img/RodrigoTabliegaCastillo.jpg" alt="Imponentes ruinas del Alcázar de Casio recortadas contra un cielo dramático">
                         <div class="card-content">
                             <h3>Lugares Emblemáticos</h3>
-                            <p>Descubre el imponente Alcázar de Casio, los secretos de la Civitate Auca y otros tesoros arqueológicos que esperan ser explorados.</p>
+                            <p class="text-lg font-body">Descubre el imponente Alcázar de Casio, los secretos de la Civitate Auca y otros tesoros arqueológicos que esperan ser explorados.</p>
                             <a href="/lugares/lugares.php" class="read-more">Explorar Sitios</a>
                         </div>
                     </div>
@@ -107,7 +107,7 @@ require_once __DIR__ . '/fragments/header.php';
                         <img src="/assets/img/Yanna.jpg" alt="Iglesia de Santa María de la Llana, ejemplo del patrimonio arquitectónico de Cerezo">
                         <div class="card-content">
                             <h3>Planifica Tu Visita</h3>
-                            <p>Encuentra toda la información que necesitas para tu aventura en Cerezo de Río Tirón: cómo llegar, dónde alojarte y qué no te puedes perder.</p>
+                            <p class="text-lg font-body">Encuentra toda la información que necesitas para tu aventura en Cerezo de Río Tirón: cómo llegar, dónde alojarte y qué no te puedes perder.</p>
                             <a href="/visitas/visitas.php" class="read-more">Organizar Viaje</a>
                         </div>
                     </div>
@@ -117,13 +117,13 @@ require_once __DIR__ . '/fragments/header.php';
 
         <section id="personajes" class="section" data-aos="fade-up">
             <div class="container-epic">
-                <h2 class="section-title">Personajes de la Historia</h2>
+                <h2 class="text-2xl font-headings">Personajes de la Historia</h2>
                 <div class="card-grid">
                     <div class="card">
                         <img src="/assets/img/Casio.png" alt="Retrato idealizado o ilustración del Conde Casio, figura histórica del siglo VIII">
                         <div class="card-content">
                             <h3>Conde Casio</h3>
-                            <p>Figura fundamental del siglo VIII, se le atribuye la construcción o refuerzo del Alcázar de Cerezo.</p>
+                            <p class="text-lg font-body">Figura fundamental del siglo VIII, se le atribuye la construcción o refuerzo del Alcázar de Cerezo.</p>
                             <a href="/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html" class="read-more">Saber Más</a>
                         </div>
                     </div>
@@ -131,7 +131,7 @@ require_once __DIR__ . '/fragments/header.php';
                         <img src="/assets/img/GonzaloTellez.png" alt="Ilustración representando a Gonzalo Téllez, Conde de Lantarón y Cerezo">
                         <div class="card-content">
                             <h3>Gonzalo Téllez</h3>
-                            <p>Conde de Lantarón y Cerezo (c. 897 - c. 913), personaje clave en la consolidación de los territorios.</p>
+                            <p class="text-lg font-body">Conde de Lantarón y Cerezo (c. 897 - c. 913), personaje clave en la consolidación de los territorios.</p>
                             <a href="/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html" class="read-more">Saber Más</a>
                         </div>
                     </div>
@@ -139,12 +139,12 @@ require_once __DIR__ . '/fragments/header.php';
                         <img src="/assets/img/FernandoDiaz.png" alt="Representación artística de Fernando Díaz, conde castellano">
                         <div class="card-content">
                             <h3>Fernando Díaz</h3>
-                            <p>Sucesor de Gonzalo Téllez, continuó la labor de defensa y organización en la primitiva Castilla.</p>
+                            <p class="text-lg font-body">Sucesor de Gonzalo Téllez, continuó la labor de defensa y organización en la primitiva Castilla.</p>
                             <a href="/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html" class="read-more">Saber Más</a>
                         </div>
                     </div>
                 </div>
-                 <p class="cta-group">
+                 <p class="text-lg font-body cta-group">
                     <a href="/personajes/indice_personajes.html" class="cta-button">Personajes</a>
                 </p>
             </div>
@@ -152,9 +152,9 @@ require_once __DIR__ . '/fragments/header.php';
         
         <section id="timeline" class="section timeline-section-summary alternate-bg" data-aos="fade-up">
             <div class="container-epic">
-                <h2 class="section-title">Nuestra Historia en el Tiempo</h2>
-                <p class="timeline-intro">Un recorrido conciso por los momentos más determinantes de nuestra región, desde la prehistoria hasta la consolidación del Condado. Cada época ha dejado una huella imborrable.</p>
-                <p class="cta-group">
+                <h2 class="text-2xl font-headings">Nuestra Historia en el Tiempo</h2>
+                <p class="text-lg font-body timeline-intro">Un recorrido conciso por los momentos más determinantes de nuestra región, desde la prehistoria hasta la consolidación del Condado. Cada época ha dejado una huella imborrable.</p>
+                <p class="text-lg font-body cta-group">
                     <a href="/secciones_index/historia_tiempo_resumen.html" class="cta-button">Explorar Resumen de la Historia</a>
                 </p>
             </div>
@@ -162,8 +162,8 @@ require_once __DIR__ . '/fragments/header.php';
 
         <section id="inmersion" class="section immersion-section" data-aos="fade-up">
             <div class="container-epic">
-                <h2>Sumérgete en la Historia Viva de Tu Cultura</h2>
-                <p>
+                <h2 class="text-2xl font-headings">Sumérgete en la Historia Viva de Tu Cultura</h2>
+                <p class="text-lg font-body">
                     Esta web es más que información; es una puerta a tus raíces. Un viaje al origen del castellano y la identidad hispana te espera.
                     Siente la llamada de la historia y conecta con el legado que nos une.
                 </p>


### PR DESCRIPTION
## Summary
- clean out font sizes from epic_theme.css
- update index, 404 and other templates to use Tailwind typography

## Testing
- `scripts/setup_environment.sh`
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py`
- `npm run test:puppeteer` *(fails: ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6854c8d2e0948329a948bbb6249e7d56