### PR TITLE
Switch to CSS font variables

### DIFF
--- a/assets/css/admin_theme.css
+++ b/assets/css/admin_theme.css
@@ -2,7 +2,7 @@
 
 /* Admin dashboard common styles */
 body.admin-page {
-    font-family: Arial, sans-serif;
+    font-family: var(--font-primary);
     margin: 0;
     padding: 0;
     background-color: var(--epic-alabaster-bg);

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -6,14 +6,14 @@
 }
 
 .article-content h3 {
-    font-family: 'Cinzel', serif;
+    font-family: var(--font-headings);
     color: var(--color-secundario-dorado);
     margin-top: 1.5em;
     margin-bottom: 0.5em;
 }
 
 .article-content h4 {
-    font-family: 'Lora', serif;
+    font-family: var(--font-primary);
     font-style: italic;
     color: var(--color-primario-purpura);
     margin-top: 1em;

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,5 +1,5 @@
 body {
-  font-family: "Lora", serif;
+  font-family: var(--font-primary);
   color: var(--epic-text-color);
   top: 0px !important; /* Prevent page content from shifting down */
 }

--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -1550,7 +1550,7 @@ body.dark-mode .footer .social-links a:focus-visible {
     background-color: var(--color-secundario-dorado, #B8860B); 
     color: var(--epic-purple-emperor) !important; 
     border-radius: 25px;
-    font-family: "Cinzel", serif; /* Use theme font */
+    font-family: var(--font-headings); /* Use theme font */
     font-weight: bold;
     text-align: center;
     text-decoration: none;
@@ -1716,7 +1716,7 @@ body.dark-mode .footer .social-links a:focus-visible {
 
 .form-group label {
     display: block;
-    font-family: var(--font-titulos); /* Use theme font */
+    font-family: var(--font-headings); /* Use theme font */
     font-weight: 700;
     color: var(--epic-purple-emperor); 
     margin-bottom: 8px;
@@ -1735,7 +1735,7 @@ body.dark-mode .footer .social-links a:focus-visible {
     padding: 12px 15px;
     border: 1px solid var(--color-piedra-media, #D2B48C); 
     border-radius: var(--border-radius-suave, 5px); 
-    font-family: var(--font-principal); /* Use theme font */
+    font-family: var(--font-primary); /* Use theme font */
     font-size: 1em;
     color: var(--color-texto-principal, #2c1d12); 
     background-color: rgba(var(--color-fondo-pagina-base-rgb, 253, 250, 246), 0.7); 
@@ -1920,7 +1920,7 @@ body.dark-mode .footer .social-links a:focus-visible {
   text-align: center;
   color: var(--color-piedra-clara, #EAE0C8); 
   padding: 15px 0;
-  font-family: var(--font-titulos); /* Use theme font */
+  font-family: var(--font-headings); /* Use theme font */
   font-size: 1.2em;
 }
 .modal-close-button {
@@ -2047,7 +2047,7 @@ body.dark-mode .footer .social-links a:focus-visible {
 
 .comment-item strong {
     color: var(--epic-purple-emperor); 
-    font-family: var(--font-titulos); /* Use theme font */
+    font-family: var(--font-headings); /* Use theme font */
 }
 
 .comment-item small {
@@ -2088,7 +2088,7 @@ body.dark-mode .footer .social-links a:focus-visible {
 }
 
 .quiz-question p strong { /* Question text */
-    font-family: var(--font-principal); /* Use theme font */
+    font-family: var(--font-primary); /* Use theme font */
     color: var(--color-texto-principal, #2c1d12); 
     text-align: left; /* Ensure question text is left aligned */
     display: block; /* Make it block for alignment */
@@ -2107,7 +2107,7 @@ body.dark-mode .footer .social-links a:focus-visible {
     display: block;
     width: 100%;
     padding: 10px 15px;
-    font-family: var(--font-principal); /* Use theme font */
+    font-family: var(--font-primary); /* Use theme font */
     font-size: 0.95em;
     background-color: var(--color-piedra-clara, #EAE0C8); 
     color: var(--color-texto-principal, #2c1d12); 
@@ -2187,14 +2187,14 @@ body.dark-mode .footer .social-links a:focus-visible {
     /* text-align: left; is default for p in epic_theme.css, so this is fine */
 }
 .article-content h3 {
-    font-family: 'Cinzel', serif; /* Matches --font-headings */
+    font-family: var(--font-headings); /* Matches --font-headings */
     color: var(--color-secundario-dorado, #B8860B); 
     margin-top: 1.5em;
     margin-bottom: 0.5em;
     text-align: left; /* Overrides global centering */
 }
 .article-content h4 {
-    font-family: 'Lora', serif; /* Matches --font-primary */
+    font-family: var(--font-primary); /* Matches --font-primary */
     font-style: italic;
     color: var(--epic-purple-emperor); 
     margin-top: 1em;

--- a/assets/css/pages/historia_subpaginas_auca_patricia_ubicacion.css
+++ b/assets/css/pages/historia_subpaginas_auca_patricia_ubicacion.css
@@ -11,7 +11,7 @@
             list-style: none;
             padding: 0;
             margin: 0;
-            font-family: 'Lora', serif;
+            font-family: var(--font-primary);
             font-size: 0.9em;
         }
         .breadcrumb li {

--- a/assets/css/pages/historia_subpaginas_indice.css
+++ b/assets/css/pages/historia_subpaginas_indice.css
@@ -11,13 +11,13 @@
             box-shadow: 0 4px 8px rgba(var(--color-negro-contraste-rgb), 0.05);
         }
         .subpage-index-item h3 {
-            font-family: 'Cinzel', serif;
+            font-family: var(--font-headings);
             color: var(--color-primario-purpura);
             margin-top: 0;
             margin-bottom: 0.5em;
         }
         .subpage-index-item p {
-            font-family: 'Lora', serif;
+            font-family: var(--font-primary);
             line-height: 1.6;
             color: var(--color-texto-principal);
             margin-bottom: 1em;

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -19,7 +19,7 @@
 }
 
 #fixed-header .site-title {
-    font-family: 'Cinzel', serif;
+    font-family: var(--font-headings);
     font-size: 1.4rem;
     background: linear-gradient(45deg, var(--primary-purple), var(--old-gold));
     -webkit-background-clip: text;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -50,7 +50,7 @@ html {
 }
 
 body {
-    font-family: 'Lora', serif;
+    font-family: var(--font-primary);
     background-color: transparent; /* MODIFIED: Was var(--current-bg) */
     color: var(--current-text);
     margin: 0;
@@ -218,7 +218,7 @@ header { /* New header for hamburger only */
 .ai-drawer-header h3 {
     margin: 0;
     font-size: 1.2em;
-    font-family: 'Cinzel', serif; /* Fuente más temática si se desea */
+    font-family: var(--font-headings); /* Fuente más temática si se desea */
 }
 
 #close-ai-drawer {


### PR DESCRIPTION
## Summary
- switch admin CSS to font variables
- use font variables in component and page styles
- replace obsolete font variables in epic_theme.css
- update other styles to reference `--font-primary` and `--font-headings`

## Testing
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*
- `npx tailwindcss@3.4.4 -i assets/css/tailwind_base.css -o assets/vendor/css/tailwind.min.css --minify` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_6854c8d39f648329883a8cf0c0b54c51