### PR TITLE
Use font variables across CSS

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -6,14 +6,14 @@
 }
 
 .article-content h3 {
-    font-family: 'Cinzel', serif;
+    font-family: var(--font-headings);
     color: var(--color-secundario-dorado);
     margin-top: 1.5em;
     margin-bottom: 0.5em;
 }
 
 .article-content h4 {
-    font-family: 'Lora', serif;
+    font-family: var(--font-primary);
     font-style: italic;
     color: var(--color-primario-purpura);
     margin-top: 1em;

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,5 +1,5 @@
 body {
-  font-family: "Lora", serif;
+  font-family: var(--font-primary);
   color: var(--epic-text-color);
   top: 0px !important; /* Prevent page content from shifting down */
 }

--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -1560,7 +1560,7 @@ body.dark-mode .footer .social-links a:focus-visible {
     background-color: var(--color-secundario-dorado, #B8860B); 
     color: var(--epic-purple-emperor) !important; 
     border-radius: 25px;
-    font-family: "Cinzel", serif; /* Use theme font */
+    font-family: var(--font-headings); /* Use theme font */
     font-weight: bold;
     text-align: center;
     text-decoration: none;
@@ -2197,14 +2197,14 @@ body.dark-mode .footer .social-links a:focus-visible {
     /* text-align: left; is default for p in epic_theme.css, so this is fine */
 }
 .article-content h3 {
-    font-family: 'Cinzel', serif; /* Matches --font-headings */
+    font-family: var(--font-headings); /* Matches --font-headings */
     color: var(--color-secundario-dorado, #B8860B); 
     margin-top: 1.5em;
     margin-bottom: 0.5em;
     text-align: left; /* Overrides global centering */
 }
 .article-content h4 {
-    font-family: 'Lora', serif; /* Matches --font-primary */
+    font-family: var(--font-primary); /* Matches --font-primary */
     font-style: italic;
     color: var(--epic-purple-emperor); 
     margin-top: 1em;

--- a/assets/css/pages/historia_subpaginas_auca_patricia_ubicacion.css
+++ b/assets/css/pages/historia_subpaginas_auca_patricia_ubicacion.css
@@ -11,7 +11,7 @@
             list-style: none;
             padding: 0;
             margin: 0;
-            font-family: 'Lora', serif;
+            font-family: var(--font-primary);
             font-size: 0.9em;
         }
         .breadcrumb li {

--- a/assets/css/pages/historia_subpaginas_indice.css
+++ b/assets/css/pages/historia_subpaginas_indice.css
@@ -11,13 +11,13 @@
             box-shadow: 0 4px 8px rgba(var(--color-negro-contraste-rgb), 0.05);
         }
         .subpage-index-item h3 {
-            font-family: 'Cinzel', serif;
+            font-family: var(--font-headings);
             color: var(--color-primario-purpura);
             margin-top: 0;
             margin-bottom: 0.5em;
         }
         .subpage-index-item p {
-            font-family: 'Lora', serif;
+            font-family: var(--font-primary);
             line-height: 1.6;
             color: var(--color-texto-principal);
             margin-bottom: 1em;

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -19,7 +19,7 @@
 }
 
 #fixed-header .site-title {
-    font-family: 'Cinzel', serif;
+    font-family: var(--font-headings);
     font-size: 1.4rem;
     background: linear-gradient(45deg, var(--primary-purple), var(--old-gold));
     -webkit-background-clip: text;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -50,7 +50,7 @@ html {
 }
 
 body {
-    font-family: 'Lora', serif;
+    font-family: var(--font-primary);
     background-color: transparent; /* MODIFIED: Was var(--current-bg) */
     color: var(--current-text);
     margin: 0;
@@ -218,7 +218,7 @@ header { /* New header for hamburger only */
 .ai-drawer-header h3 {
     margin: 0;
     font-size: 1.2em;
-    font-family: 'Cinzel', serif; /* Fuente más temática si se desea */
+    font-family: var(--font-headings); /* Fuente más temática si se desea */
 }
 
 #close-ai-drawer {

--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -1,3 +1,3 @@
 body {
-  font-family: 'Lora', serif;
+  font-family: var(--font-primary);
 }


### PR DESCRIPTION
## Summary
- replace explicit "Lora" and "Cinzel" fonts with CSS variables
- ensure SCSS base uses `var(--font-primary)`

## Testing
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6854cc3a5c2c832999954998081d52e1