### PR TITLE
Add responsive hero object position

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -642,6 +642,29 @@ body.dark-mode .footer .social-links a:focus-visible {
     box-shadow: 0 0 20px var(--epic-gold-main), inset 0 0 15px rgba(var(--epic-text-color-rgb),0.4);
 }
 
+/* Background media within hero sections */
+.hero > img.hero-bg,
+.page-header > img.hero-bg,
+.hero > video.hero-bg,
+.page-header > video.hero-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+    z-index: 0;
+}
+@media (min-width: 768px) {
+    .hero > img.hero-bg,
+    .page-header > img.hero-bg,
+    .hero > video.hero-bg,
+    .page-header > video.hero-bg {
+        object-position: top;
+    }
+}
+
 .cta-button { /* Call to Action button styling */
     display: inline-block;
     position: relative; /* For border animation pseudo-element */

--- a/camino_santiago/camino_santiago.php
+++ b/camino_santiago/camino_santiago.php
@@ -11,7 +11,8 @@ load_page_css();
 
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
 
-    <header class="page-header hero bg-[url('/assets/img/hero_camino_santiago.jpg')] bg-cover bg-center md:bg-center">
+    <header class="page-header hero relative overflow-hidden">
+        <img src="/assets/img/hero_camino_santiago.jpg" alt="" class="hero-bg object-cover object-center sm:object-center md:object-top">
         <div class="hero-content">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus" class="decorative-star-header">
             <h1>Cerezo de Río Tirón: Hito Histórico del Camino de Santiago</h1>

--- a/empresa/index.php
+++ b/empresa/index.php
@@ -14,7 +14,8 @@ require_admin_login();
 <body class="alabaster-bg">
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
 
-    <header class="page-header hero bg-[url('/assets/img/hero_contacto_background.jpg')] bg-cover bg-center md:bg-center">
+    <header class="page-header hero relative overflow-hidden">
+        <img src="/assets/img/hero_contacto_background.jpg" alt="" class="hero-bg object-cover object-center sm:object-center md:object-top">
         <div class="hero-content">
             <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
             <h1>Empresa de Gestión de Yacimientos</h1>

--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/fragments/header.php';
 ?>
 
     <header id="hero-video" class="relative h-screen w-full overflow-hidden">
-        <video class="absolute inset-0 object-cover w-full h-full" src="https://samplelib.com/lib/preview/mp4/sample-5s.mp4" autoplay muted loop playsinline></video>
+        <video class="absolute inset-0 object-cover object-center sm:object-center md:object-top w-full h-full" src="https://samplelib.com/lib/preview/mp4/sample-5s.mp4" autoplay muted loop playsinline></video>
         <div id="hero-content" class="relative z-10 flex flex-col items-center justify-center h-full text-center opacity-0 transition-opacity duration-1000 ease-out">
             <h1 class="font-serif text-yellow-300 text-3xl sm:text-4xl md:text-5xl lg:text-6xl shadow-lg drop-shadow-lg">Condado de Castilla: Cuna de Emperadores</h1>
             <p class="mt-4 bg-black bg-opacity-50 text-white p-4 sm:p-6 md:p-8 font-sans">Promocionamos el turismo en Cerezo de Río Tirón y cuidamos su patrimonio arqueológico y cultural.</p>

--- a/tests/HeroImagePositionTest.php
+++ b/tests/HeroImagePositionTest.php
@@ -1,0 +1,41 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class HeroImagePositionTest extends TestCase {
+    private function runPage(string $script): array {
+        $prepend = realpath(__DIR__.'/fixtures/page_prepend.php');
+        $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
+            escapeshellarg($prepend),
+            escapeshellarg($script)
+        );
+        $env = [
+            'PATH' => getenv('PATH'),
+            'REDIRECT_STATUS' => '1',
+            'SCRIPT_FILENAME' => $script
+        ];
+        $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        $status = proc_close($proc);
+        return [$status, $out, $err];
+    }
+
+    public static function pageProvider(): array {
+        return [
+            [__DIR__.'/../index.php'],
+            [__DIR__.'/../empresa/index.php'],
+            [__DIR__.'/../camino_santiago/camino_santiago.php']
+        ];
+    }
+
+    /**
+     * @dataProvider pageProvider
+     */
+    public function testHeroImagesHavePositionClasses(string $path): void {
+        [$status, $out, $err] = $this->runPage($path);
+        $this->assertSame(0, $status, $err);
+        $this->assertStringContainsString('object-center', $out);
+        $this->assertStringContainsString('md:object-top', $out);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- ensure hero video uses responsive object positioning
- convert hero backgrounds to `<img>` elements for empresa and camino_santiago templates
- add responsive object-fit and object-position rules in epic_theme.css
- test that hero images contain responsive object-position classes

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python3 -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test --silent` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_6854cd6ad0f48329b296475cfefbcc0b