### PR TITLE
Introduce reusable hero component

### DIFF
--- a/alfoz/alfoz.php
+++ b/alfoz/alfoz.php
@@ -26,15 +26,15 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 
     <?php
     require_once __DIR__ . '/../fragments/header.php';
+    require_once __DIR__ . '/../fragments/hero.php';
+    ob_start();
+    editableText('alfoz_hero_titulo', $pdo, 'El Alfoz de Cerasio y Lantarón', 'h1');
+    $hero_heading = ob_get_clean();
+    ob_start();
+    editableText('alfoz_hero_subtitulo', $pdo, 'Cimientos de Castilla, Génesis de la Hispanidad.', 'p');
+    $hero_subheading = ob_get_clean();
+    render_hero($hero_heading, $hero_subheading, '/assets/img/hero_mis_tierras.jpg');
     ?>
-
-    <header class="page-header hero bg-[url('/assets/img/hero_mis_tierras.jpg')] bg-cover bg-center md:bg-center">
-        <div class="hero-content">
-            <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <?php editableText('alfoz_hero_titulo', $pdo, 'El Alfoz de Cerasio y Lantarón', 'h1'); ?>
-            <?php editableText('alfoz_hero_subtitulo', $pdo, 'Cimientos de Castilla, Génesis de la Hispanidad.', 'p'); ?>
-        </div>
-    </header>
 
     <main>
         <section class="section">

--- a/camino_santiago/camino_santiago.php
+++ b/camino_santiago/camino_santiago.php
@@ -9,15 +9,13 @@ load_page_css();
 </head>
 <body class="alabaster-bg">
 
-    <?php require_once __DIR__ . '/../fragments/header.php'; ?>
-
-    <header class="page-header hero bg-[url('/assets/img/hero_camino_santiago.jpg')] bg-cover bg-center md:bg-center">
-        <div class="hero-content">
-            <img src="/assets/img/estrella.png" alt="Estrella de Venus" class="decorative-star-header">
-            <h1>Cerezo de Río Tirón: Hito Histórico del Camino de Santiago</h1>
-            <p>Descubre el antiguo trazado jacobeo que atravesaba nuestras tierras y el legado hospitalario que marcó nuestra historia.</p>
-        </div>
-    </header>
+    <?php
+    require_once __DIR__ . '/../fragments/header.php';
+    require_once __DIR__ . '/../fragments/hero.php';
+    $hero_heading = '<h1>Cerezo de Río Tirón: Hito Histórico del Camino de Santiago</h1>';
+    $hero_subheading = '<p>Descubre el antiguo trazado jacobeo que atravesaba nuestras tierras y el legado hospitalario que marcó nuestra historia.</p>';
+    render_hero($hero_heading, $hero_subheading, '/assets/img/hero_camino_santiago.jpg');
+    ?>
 
     <main>
         <section class="section detailed-intro-section">

--- a/contacto/contacto.php
+++ b/contacto/contacto.php
@@ -26,15 +26,15 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 
     <?php
     require_once __DIR__ . '/../fragments/header.php';
+    require_once __DIR__ . '/../fragments/hero.php';
+    ob_start();
+    editableText('contacto_hero_titulo', $pdo, 'Ponte en Contacto', 'h1');
+    $hero_heading = ob_get_clean();
+    ob_start();
+    editableText('contacto_hero_subtitulo', $pdo, '¿Preguntas, sugerencias o deseas colaborar? Estamos aquí para escucharte.', 'p');
+    $hero_subheading = ob_get_clean();
+    render_hero($hero_heading, $hero_subheading, '/assets/img/hero_contacto_background.jpg');
     ?>
-
-    <header class="page-header hero bg-[url('/assets/img/hero_contacto_background.jpg')] bg-cover bg-center md:bg-center">
-        <div class="hero-content">
-            <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <?php editableText('contacto_hero_titulo', $pdo, 'Ponte en Contacto', 'h1'); ?>
-            <?php editableText('contacto_hero_subtitulo', $pdo, '¿Preguntas, sugerencias o deseas colaborar? Estamos aquí para escucharte.', 'p'); ?>
-        </div>
-    </header>
 
     <main>
         <section class="section contact-section"> <div class="container page-content-block"> <div class="contact-info">

--- a/cultura/cultura.php
+++ b/cultura/cultura.php
@@ -26,15 +26,15 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 
     <?php
     require_once __DIR__ . '/../fragments/header.php';
+    require_once __DIR__ . '/../fragments/hero.php';
+    ob_start();
+    editableText('cultura_hero_titulo', $pdo, 'Cultura Viva y Legado Perenne', 'h1');
+    $hero_heading = ob_get_clean();
+    ob_start();
+    editableText('cultura_hero_subtitulo', $pdo, 'Las tradiciones, el idioma y el espíritu de una tierra forjada en la historia.', 'p');
+    $hero_subheading = ob_get_clean();
+    render_hero($hero_heading, $hero_subheading, '/assets/img/hero_cultura_background.jpg');
     ?>
-
-    <header class="page-header hero bg-[url('/assets/img/hero_cultura_background.jpg')] bg-cover bg-center md:bg-center">
-        <div class="hero-content">
-            <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <?php editableText('cultura_hero_titulo', $pdo, 'Cultura Viva y Legado Perenne', 'h1'); ?>
-            <?php editableText('cultura_hero_subtitulo', $pdo, 'Las tradiciones, el idioma y el espíritu de una tierra forjada en la historia.', 'p'); ?>
-        </div>
-    </header>
 
     <main>
         <section class="section"> <div class="container page-content-block"> <?php editableText('cultura_intro_p1', $pdo, 'El Condado de Castilla no solo es un crisol de historia, sino también una fuente inagotable de cultura

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -18,6 +18,19 @@ Para usar anclas basta con añadir `id="..."` a cada elemento. Por ejemplo:
 <section id="video" class="video-section section spotlight-active">...
 ```
 
+## Parcial `fragments/hero.php`
+
+Para mantener un estilo homogéneo en los encabezados principales se creó el archivo `fragments/hero.php`. La función `render_hero($headingHtml, $subheadingHtml = '', $backgroundUrl = '')` genera el bloque `<header class="page-header hero">` con la imagen de la estrella, el título y un subtítulo opcional.
+
+Ejemplo de uso básico:
+
+```php
+require_once __DIR__ . '/fragments/hero.php';
+$heading = '<h1>Lugares Emblemáticos</h1>';
+$sub = '<p>Un recorrido por los vestigios que narran nuestra historia.</p>';
+render_hero($heading, $sub, '/assets/img/hero_lugares_background.jpg');
+```
+
 ## Cómo `fragments/header.php` carga los menús
 El archivo `fragments/header.php` genera el panel deslizante derecho e inserta las diferentes secciones de menú leyendo los archivos de `fragments/menus/`:
 ```php

--- a/empresa/index.php
+++ b/empresa/index.php
@@ -12,15 +12,13 @@ require_admin_login();
     <!-- Google Fonts, FontAwesome, and epic_theme.css are now in head_common.php -->
 </head>
 <body class="alabaster-bg">
-    <?php require_once __DIR__ . '/../fragments/header.php'; ?>
-
-    <header class="page-header hero bg-[url('/assets/img/hero_contacto_background.jpg')] bg-cover bg-center md:bg-center">
-        <div class="hero-content">
-            <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <h1>Empresa de Gestión de Yacimientos</h1>
-            <p>Descubre cómo administramos y conservamos el patrimonio arqueológico de la región.</p>
-        </div>
-    </header>
+    <?php
+    require_once __DIR__ . '/../fragments/header.php';
+    require_once __DIR__ . '/../fragments/hero.php';
+    $hero_heading = '<h1>Empresa de Gestión de Yacimientos</h1>';
+    $hero_subheading = '<p>Descubre cómo administramos y conservamos el patrimonio arqueológico de la región.</p>';
+    render_hero($hero_heading, $hero_subheading, '/assets/img/hero_contacto_background.jpg');
+    ?>
 
     <main>
         <section class="section">

--- a/fragments/hero.php
+++ b/fragments/hero.php
@@ -1,0 +1,17 @@
+<?php
+function render_hero(string $heading_html, string $subheading_html = '', string $bg_url = '', bool $show_star = true, string $id = ''): void {
+    $id_attr = $id !== '' ? ' id="' . htmlspecialchars($id) . '"' : '';
+    $style_attr = $bg_url !== '' ? ' style="background-image: url(' . "'" . htmlspecialchars($bg_url) . "')" . ';"' : '';
+    echo "<header{$id_attr} class=\"page-header hero bg-cover bg-center md:bg-center\"{$style_attr}>";
+    echo '<div class="hero-content">';
+    if ($show_star) {
+        echo '<img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">';
+    }
+    echo $heading_html;
+    if ($subheading_html !== '') {
+        echo $subheading_html;
+    }
+    echo '</div>';
+    echo '</header>';
+}
+?>

--- a/galeria/galeria_colaborativa.php
+++ b/galeria/galeria_colaborativa.php
@@ -57,15 +57,16 @@ if (is_dir($gallery_dir)) {
     
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
 
-    <header class="page-header hero hero-galeria">
-        <!-- IMPORTANTE: Asegúrate de tener /imagenes/hero_galeria_background.jpg -->
-        <div class="hero-content">
-            <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <span class="blend-screen" style="display:none"></span>
-            <?php editableText('galeria_colab_header_titulo', $pdo, 'Galería Colaborativa del Condado', 'h1', 'blend-overlay'); ?>
-            <?php editableText('galeria_colab_header_parrafo', $pdo, 'Un mosaico de miradas sobre la belleza, historia y rincones de nuestra tierra, creado por todos.', 'p', ''); ?>
-        </div>
-    </header>
+    <?php
+    require_once __DIR__ . '/../fragments/hero.php';
+    ob_start();
+    editableText('galeria_colab_header_titulo', $pdo, 'Galería Colaborativa del Condado', 'h1', 'blend-overlay');
+    $hero_heading = ob_get_clean();
+    ob_start();
+    editableText('galeria_colab_header_parrafo', $pdo, 'Un mosaico de miradas sobre la belleza, historia y rincones de nuestra tierra, creado por todos.', 'p', '');
+    $hero_subheading = ob_get_clean();
+    render_hero($hero_heading, $hero_subheading, '/imagenes/hero_galeria_background.jpg');
+    ?>
 
     <main>
         <section class="section upload-section-galeria">

--- a/historia/historia.php
+++ b/historia/historia.php
@@ -5,14 +5,13 @@
 </head>
 <body class="alabaster-bg">
 
-    <?php require_once __DIR__ . '/../fragments/header.php'; ?>
-
-    <header class="page-header hero bg-[url('/assets/img/hero_historia_background.jpg')] bg-cover bg-center md:bg-center">
-        <div class="hero-content">
-            <h1 class="gradient-text">Línea de Tiempo de Nuestra Historia</h1>
-            <p>Un recorrido cronológico por los eventos y eras que forjaron el Condado de Castilla y la identidad de Cerezo de Río Tirón.</p>
-        </div>
-    </header>
+    <?php
+    require_once __DIR__ . '/../fragments/header.php';
+    require_once __DIR__ . '/../fragments/hero.php';
+    $hero_heading = '<h1 class="gradient-text">Línea de Tiempo de Nuestra Historia</h1>';
+    $hero_subheading = '<p>Un recorrido cronológico por los eventos y eras que forjaron el Condado de Castilla y la identidad de Cerezo de Río Tirón.</p>';
+    render_hero($hero_heading, $hero_subheading, '/assets/img/hero_historia_background.jpg');
+    ?>
 
     <main>
         <section class="section timeline-section alternate-bg">

--- a/lugares/lugares.php
+++ b/lugares/lugares.php
@@ -10,15 +10,13 @@
 
 </head>
 <body class="alabaster-bg">
-    <?php require_once __DIR__ . '/../fragments/header.php'; ?>
-
-    <header class="page-header hero bg-[url('/assets/img/hero_lugares_background.jpg')] bg-cover bg-center md:bg-center">
-        <div class="hero-content">
-            <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <h1>Lugares Emblemáticos: Huellas de la Historia</h1>
-            <p>Un recorrido por los vestigios que narran el pasado milenario de Cerezo de Río Tirón y el Condado de Castilla.</p>
-        </div>
-    </header>
+    <?php
+    require_once __DIR__ . '/../fragments/header.php';
+    require_once __DIR__ . '/../fragments/hero.php';
+    $hero_heading = '<h1>Lugares Emblemáticos: Huellas de la Historia</h1>';
+    $hero_subheading = '<p>Un recorrido por los vestigios que narran el pasado milenario de Cerezo de Río Tirón y el Condado de Castilla.</p>';
+    render_hero($hero_heading, $hero_subheading, '/assets/img/hero_lugares_background.jpg');
+    ?>
 
     <main>
         <section class="section detailed-intro-section"> <div class="container page-content-block"> <p class="intro-paragraph">

--- a/museo/museo.php
+++ b/museo/museo.php
@@ -30,15 +30,13 @@
     <div id="crosshair" class="crosshair"></div>
     <div id="linterna-condado" class="bg-linterna-gradient"></div>
     
-    <?php require_once __DIR__ . '/../fragments/header.php'; ?>
-
-    <header class="page-header hero hero-museo">
-        <div class="hero-content">
-            <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <h1>Museo Colaborativo del Alfoz</h1>
-            <p>Un espacio para compartir y descubrir los tesoros históricos y arqueológicos de nuestra tierra, aportados por la comunidad.</p>
-        </div>
-    </header>
+    <?php
+    require_once __DIR__ . '/../fragments/header.php';
+    require_once __DIR__ . '/../fragments/hero.php';
+    $hero_heading = '<h1>Museo Colaborativo del Alfoz</h1>';
+    $hero_subheading = '<p>Un espacio para compartir y descubrir los tesoros históricos y arqueológicos de nuestra tierra, aportados por la comunidad.</p>';
+    render_hero($hero_heading, $hero_subheading, '/imagenes/hero_museo_background.jpg');
+    ?>
 
     <main>
         <section class="section upload-section">

--- a/visitas/visitas.php
+++ b/visitas/visitas.php
@@ -9,15 +9,13 @@ load_page_css();
 </head>
 <body class="alabaster-bg">
 
-    <?php require_once __DIR__ . '/../fragments/header.php'; ?>
-
-    <header class="page-header hero bg-[url('/assets/img/hero_visitas_background.jpg')] bg-cover bg-center md:bg-center">
-        <div class="hero-content">
-            <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <h1>Planifica Tu Viaje al Corazón de Castilla</h1>
-            <p>Todo lo que necesitas saber para una experiencia inolvidable en Cerezo de Río Tirón.</p>
-        </div>
-    </header>
+    <?php
+    require_once __DIR__ . '/../fragments/header.php';
+    require_once __DIR__ . '/../fragments/hero.php';
+    $hero_heading = '<h1>Planifica Tu Viaje al Corazón de Castilla</h1>';
+    $hero_subheading = '<p>Todo lo que necesitas saber para una experiencia inolvidable en Cerezo de Río Tirón.</p>';
+    render_hero($hero_heading, $hero_subheading, '/assets/img/hero_visitas_background.jpg');
+    ?>
 
     <main>
         <section class="section"> <div class="container page-content-block"> <p class="intro-paragraph">


### PR DESCRIPTION
## Summary
- create `fragments/hero.php` with `render_hero` helper
- replace inline hero markup with partial usage on several pages
- document hero usage in `docs/index-guide.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854cd6b1ed08329b8965cc29015c6e2