### PR TITLE
Update testing docs and setup script

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,9 +4,10 @@ Esta guía explica cómo preparar el entorno y ejecutar las pruebas automatizada
 
 ## Configurar el entorno
 
-Ejecuta el script `setup_environment.sh` para instalar de una sola vez las dependencias de PHP, Python y Node.
+Antes de lanzar **cualquier** suite de pruebas ejecuta `setup_environment.sh`. Este script instala de una sola vez las dependencias de PHP, Python y Node.
 Si alguno de estos gestores no está disponible, el script mostrará una advertencia y continuará con el resto, de modo que la configuración puede completarse de forma parcial.
-Más adelante podrás instalar la herramienta faltante y ejecutar manualmente el paso correspondiente.
+El proyecto requiere como mínimo **PHP&nbsp;8.1**, **Node&nbsp;18** y **Python&nbsp;3.10**. El propio script comprueba estas versiones y avisa en caso de no encontrarlas o si son antiguas.
+Tras solventar cualquier ausencia podrás ejecutar manualmente el paso correspondiente y repetir la preparación.
 
 ```bash
 ./scripts/setup_environment.sh

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -6,6 +6,34 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
+# Required tool versions
+REQUIRED_PHP_VERSION="8.1"
+REQUIRED_NODE_VERSION="18"
+REQUIRED_PYTHON_VERSION="3.10"
+
+# Basic version check helper
+check_version() {
+    local cmd="$1"
+    local required="$2"
+    local name="$3"
+
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: $name $required or higher is required but not found." >&2
+        return 1
+    fi
+
+    local current="$($cmd --version | head -n1 | grep -oE '[0-9]+(\.[0-9]+)+')"
+    if [ "$(printf '%s\n' "$required" "$current" | sort -V | head -n1)" != "$required" ]; then
+        echo "Error: $name $required or higher is required, but $current is installed." >&2
+        return 1
+    fi
+}
+
+# Check language runtimes
+check_version php "$REQUIRED_PHP_VERSION" "PHP" || true
+check_version node "$REQUIRED_NODE_VERSION" "Node.js" || true
+check_version python3 "$REQUIRED_PYTHON_VERSION" "Python" || true
+
 # Verify Composer is available before proceeding
 if ! command -v composer >/dev/null 2>&1; then
     echo "Error: Composer is required to run this script. Please install it first." >&2


### PR DESCRIPTION
## Summary
- require running `setup_environment.sh` before any test suite
- document minimum PHP, Node and Python versions
- check PHP, Node and Python versions in the setup script

## Testing
- `bash scripts/setup_environment.sh`
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py`
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6854cddcbaec8329ba7e58c25b21ccc1