### PR TITLE
Remove heading font sizes and add Tailwind classes

### DIFF
--- a/404.php
+++ b/404.php
@@ -10,9 +10,9 @@ http_response_code(404);
 <body class="alabaster-bg">
 <?php require_once __DIR__ . '/fragments/header.php'; ?>
 <main class="container page-content-block error-page">
-    <h1 class="font-headings">Página no encontrada</h1>
-    <p class="font-body">Lo sentimos, la página que buscas no existe.</p>
-    <p class="font-body"><a href="/index.php" class="cta-button">Volver al inicio</a></p>
+    <h1 class="text-4xl font-headings">Página no encontrada</h1>
+    <p class="text-lg font-body">Lo sentimos, la página que buscas no existe.</p>
+    <p class="text-lg font-body"><a href="/index.php" class="cta-button">Volver al inicio</a></p>
 </main>
 <?php require_once __DIR__ . '/fragments/footer.php'; ?>
 <script src="/js/layout.js"></script>

--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -200,7 +200,7 @@ h1, h2, h3 {
     animation: slideUpFadeIn 0.6s ease-out forwards;
 }
 
-h1 { font-size: clamp(2.8em, 6vw, 4.2em); }
+/* h1 { font-size: clamp(2.8em, 6vw, 4.2em); } */
 
 /* Gradient Text for H1 */
 h1 {
@@ -211,11 +211,11 @@ h1 {
     color: transparent !important; /* Ensure this overrides other color settings */
 }
 
-h2 { font-size: clamp(2.2em, 5vw, 3.2em); color: var(--epic-gold-secondary); } /* Secondary gold for H2 for variety */
-h3 { font-size: clamp(1.8em, 4vw, 2.5em); }
-h4 { font-size: clamp(1.4em, 3.5vw, 2em); }
-h5 { font-size: clamp(1.2em, 3vw, 1.7em); }
-h6 { font-size: clamp(1em, 2.5vw, 1.4em); }
+/* h2 { font-size: clamp(2.2em, 5vw, 3.2em); color: var(--epic-gold-secondary); }  Secondary gold for H2 for variety */
+/* h3 { font-size: clamp(1.8em, 4vw, 2.5em); } */
+/* h4 { font-size: clamp(1.4em, 3.5vw, 2em); } */
+/* h5 { font-size: clamp(1.2em, 3vw, 1.7em); } */
+/* h6 { font-size: clamp(1em, 2.5vw, 1.4em); } */
 
 .gradient-text {
     background-image: linear-gradient(45deg, var(--epic-purple-emperor), var(--epic-gold-main));
@@ -404,7 +404,7 @@ th {
 #overlay-content h3 { /* #overlay-titulo */
     font-family: var(--font-headings);
     color: var(--epic-purple-emperor);
-    font-size: clamp(1.8em, 4vw, 2.5em);
+    /* font-size: clamp(1.8em, 4vw, 2.5em); */
     margin-top: 0;
     margin-bottom: 0.7em;
     border-bottom: 2px solid var(--epic-gold-secondary);
@@ -607,7 +607,7 @@ body.dark-mode .footer .social-links a:focus-visible {
 }
 
 .hero-content h1, .page-header .hero-content h1 {
-    font-size: clamp(2.5em, 7vw, 4.5em); /* Larger for hero titles */
+    /* font-size: clamp(2.5em, 7vw, 4.5em);  Larger for hero titles */
     color: var(--epic-gold-main); /* Gold for main hero titles */
     text-shadow: 2px 2px 5px rgba(var(--epic-text-color-rgb), 0.7);
     margin-top: 0;
@@ -1023,7 +1023,7 @@ body.dark-mode .footer .social-links a:focus-visible {
     background-color: rgba(var(--color-negro-contraste-rgb, 10, 10, 10), 0.7);
 }
 .page-header.hero .hero-content h1 {
-    font-size: clamp(2.5em, 6vw, 4em);
+    /* font-size: clamp(2.5em, 6vw, 4em); */
     margin-bottom: 0.3em;
 }
 .page-header.hero .hero-content p {
@@ -1084,8 +1084,8 @@ body.dark-mode .footer .social-links a:focus-visible {
     to { opacity: 1; transform: scale(1) translateY(0) rotate(0deg); }
 }
 
-.hero h1 { 
-    font-size: clamp(3.2em, 10vw, 6em);
+.hero h1 {
+    /* font-size: clamp(3.2em, 10vw, 6em); */
     color: var(--color-alabastro, #fdfaf6); 
     margin-top: 0;
     margin-bottom: 0.5em;
@@ -1379,7 +1379,7 @@ body.dark-mode .footer .social-links a:focus-visible {
         /* Slightly larger on mobile as well */
         width: clamp(170px, 40vw, 250px);
     }
-    .hero h1 { font-size: clamp(2.4em, 7vw, 3.5em); }
+    /* .hero h1 { font-size: clamp(2.4em, 7vw, 3.5em); } */
     .hero p { font-size: clamp(1.05em, 3.5vw, 1.4em); max-width: 90%;}
 
     .detailed-intro-section p { text-align: justify !important; }
@@ -1395,10 +1395,10 @@ body.dark-mode .footer .social-links a:focus-visible {
     }
 }
 @media (max-width: 480px) {
-    .hero h1 { font-size: clamp(2.2em, 10vw, 3em); }
+    /* .hero h1 { font-size: clamp(2.2em, 10vw, 3em); } */
     .hero p { font-size: clamp(1em, 4vw, 1.2em); }
     .cta-button { padding: 15px 30px; font-size: clamp(1em, 4vw, 1.2em); }
-    .detailed-intro-section h2, .section-title { font-size: clamp(1.8em, 6vw, 2.5em); }
+    /* .detailed-intro-section h2, .section-title { font-size: clamp(1.8em, 6vw, 2.5em); } */
     .card-content { padding: 20px; }
     .section-title::after { width: 35px; height: 35px; }
     .footer::before { width: 50px; height: 50px; margin: -80px auto 20px auto; }
@@ -1477,7 +1477,7 @@ body.dark-mode .footer .social-links a:focus-visible {
 .page-header.hero[style*="/imagenes/hero_contacto_background.jpg"] h1,
 .page-header.hero[style*="/imagenes/hero_museo_background.jpg"] h1,
 .page-header.hero[style*="/imagenes/hero_galeria_background.jpg"] h1 {
-    font-size: clamp(2.8em, 7vw, 4.5em) !important;
+    /* font-size: clamp(2.8em, 7vw, 4.5em) !important; */
 }
 .page-header.hero[style*="/imagenes/hero_historia_background.jpg"] p,
 .page-header.hero[style*="/imagenes/hero_alfoz_background.jpg"] p,
@@ -1629,7 +1629,7 @@ body.dark-mode .footer .social-links a:focus-visible {
 .page-header.hero[style*="hero_personajes_background.jpg"] .hero-content h1 {
     color: var(--epic-text-light);
     text-shadow: 2px 2px 8px rgba(var(--color-negro-contraste-rgb, 10, 10, 10), 0.75);
-    font-size: clamp(2.8em, 6.5vw, 4.2em);
+    /* font-size: clamp(2.8em, 6.5vw, 4.2em); */
 }
 .page-header.hero[style*="hero_personajes_background.jpg"] .hero-content p {
     font-size: clamp(1.1em, 2.3vw, 1.4em);

--- a/index.php
+++ b/index.php
@@ -35,8 +35,8 @@ require_once __DIR__ . '/fragments/header.php';
     <header id="hero-video" class="relative h-screen w-full overflow-hidden">
         <video class="absolute inset-0 object-cover w-full h-full" src="https://samplelib.com/lib/preview/mp4/sample-5s.mp4" autoplay muted loop playsinline></video>
         <div id="hero-content" class="relative z-10 flex flex-col items-center justify-center h-full text-center opacity-0 transition-opacity duration-1000 ease-out">
-            <h1 class="font-headings text-yellow-300 text-3xl sm:text-4xl md:text-5xl lg:text-6xl shadow-lg drop-shadow-lg">Condado de Castilla: Cuna de Emperadores</h1>
-            <p class="mt-4 bg-black bg-opacity-50 text-white p-4 sm:p-6 md:p-8 font-body">Promocionamos el turismo en Cerezo de Río Tirón y cuidamos su patrimonio arqueológico y cultural.</p>
+            <h1 class="text-4xl font-headings text-yellow-300 sm:text-4xl md:text-5xl lg:text-6xl shadow-lg drop-shadow-lg">Condado de Castilla: Cuna de Emperadores</h1>
+            <p class="text-lg font-body mt-4 bg-black bg-opacity-50 text-white p-4 sm:p-6 md:p-8">Promocionamos el turismo en Cerezo de Río Tirón y cuidamos su patrimonio arqueológico y cultural.</p>
         </div>
         <div class="absolute bottom-8 left-1/2 transform -translate-x-1/2 text-yellow-300">
             <svg class="w-8 h-8 animate-bounce" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -56,7 +56,7 @@ require_once __DIR__ . '/fragments/header.php';
 
     <section id="video" class="video-section section spotlight-active py-12 sm:py-16 lg:py-20" data-aos="fade-up">
         <div class="container-epic px-4 sm:px-6 lg:px-8">
-            <h2 class="section-title font-headings">Un Vistazo a Nuestra Tierra</h2>
+            <h2 class="section-title text-2xl font-headings">Un Vistazo a Nuestra Tierra</h2>
             <div class="video-container mx-auto">
                 <iframe class="w-full h-full"
                     src="https://drive.google.com/file/d/1wm74VmKH21Nz7zFUkY8a8Z9672D4cyHN/preview"
@@ -75,8 +75,8 @@ require_once __DIR__ . '/fragments/header.php';
     <main>
         <section id="memoria" class="section detailed-intro-section spotlight-active py-12 sm:py-16 lg:py-20" data-aos="fade-up">
             <div class="container-epic px-4 sm:px-6 lg:px-8">
-                <?php editableText('memoria_titulo_index', $pdo, 'Recuperando la Memoria de la Hispanidad Castellana', 'h2', 'gradient-text tagline-background font-headings'); ?>
-                <?php editableText('memoria_parrafo_index', $pdo, 'Un profundo análisis de nuestras raíces culturales, la importancia de la arqueología y el legado de la Civitate Auca Patricia. Descubre cómo el pasado de Cerezo de Río Tirón es fundamental para entender la Hispanidad.', 'p', 'font-body'); ?>
+                <?php editableText('memoria_titulo_index', $pdo, 'Recuperando la Memoria de la Hispanidad Castellana', 'h2', 'gradient-text tagline-background text-2xl font-headings'); ?>
+                <?php editableText('memoria_parrafo_index', $pdo, 'Un profundo análisis de nuestras raíces culturales, la importancia de la arqueología y el legado de la Civitate Auca Patricia. Descubre cómo el pasado de Cerezo de Río Tirón es fundamental para entender la Hispanidad.', 'p', 'text-lg font-body'); ?>
                 <p class="cta-group">
                     <a href="/secciones_index/memoria_hispanidad.html" class="cta-button">Leer Más Sobre Nuestra Memoria</a>
                 </p>
@@ -85,13 +85,13 @@ require_once __DIR__ . '/fragments/header.php';
 
         <section id="legado" class="section alternate-bg spotlight-active py-12 sm:py-16 lg:py-20" data-aos="fade-up">
             <div class="container-epic px-4 sm:px-6 lg:px-8">
-                <h2 class="section-title font-headings">Explora Nuestro Legado</h2>
+                <h2 class="section-title text-2xl font-headings">Explora Nuestro Legado</h2>
                 <div class="card-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
                     <div class="card">
                         <img class="w-full h-auto" src="/assets/img/PrimerEscritoCastellano.jpg" alt="Página de un manuscrito medieval iluminado, simbolizando la rica historia de Castilla">
                         <div class="card-content">
                             <h3 class="font-headings">Nuestra Historia</h3>
-                            <p class="font-body">Desde los Concanos y la Civitate Auca Patricia hasta la formación del Condado. Sumérgete en los relatos que definieron Castilla.</p>
+                            <p class="text-lg font-body">Desde los Concanos y la Civitate Auca Patricia hasta la formación del Condado. Sumérgete en los relatos que definieron Castilla.</p>
                             <a href="/historia/historia.php" class="read-more">Leer Más</a>
                         </div>
                     </div>
@@ -99,7 +99,7 @@ require_once __DIR__ . '/fragments/header.php';
                         <img class="w-full h-auto" src="/assets/img/RodrigoTabliegaCastillo.jpg" alt="Imponentes ruinas del Alcázar de Casio recortadas contra un cielo dramático">
                         <div class="card-content">
                             <h3 class="font-headings">Lugares Emblemáticos</h3>
-                            <p class="font-body">Descubre el imponente Alcázar de Casio, los secretos de la Civitate Auca y otros tesoros arqueológicos que esperan ser explorados.</p>
+                            <p class="text-lg font-body">Descubre el imponente Alcázar de Casio, los secretos de la Civitate Auca y otros tesoros arqueológicos que esperan ser explorados.</p>
                             <a href="/lugares/lugares.php" class="read-more">Explorar Sitios</a>
                         </div>
                     </div>
@@ -107,7 +107,7 @@ require_once __DIR__ . '/fragments/header.php';
                         <img class="w-full h-auto" src="/assets/img/Yanna.jpg" alt="Iglesia de Santa María de la Llana, ejemplo del patrimonio arquitectónico de Cerezo">
                         <div class="card-content">
                             <h3 class="font-headings">Planifica Tu Visita</h3>
-                            <p class="font-body">Encuentra toda la información que necesitas para tu aventura en Cerezo de Río Tirón: cómo llegar, dónde alojarte y qué no te puedes perder.</p>
+                            <p class="text-lg font-body">Encuentra toda la información que necesitas para tu aventura en Cerezo de Río Tirón: cómo llegar, dónde alojarte y qué no te puedes perder.</p>
                             <a href="/visitas/visitas.php" class="read-more">Organizar Viaje</a>
                         </div>
                     </div>
@@ -117,13 +117,13 @@ require_once __DIR__ . '/fragments/header.php';
 
         <section id="personajes" class="section py-12 sm:py-16 lg:py-20" data-aos="fade-up">
             <div class="container-epic px-4 sm:px-6 lg:px-8">
-                <h2 class="section-title font-headings">Personajes de la Historia</h2>
+                <h2 class="section-title text-2xl font-headings">Personajes de la Historia</h2>
                 <div class="card-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
                     <div class="card">
                         <img class="w-full h-auto" src="/assets/img/Casio.png" alt="Retrato idealizado o ilustración del Conde Casio, figura histórica del siglo VIII">
                         <div class="card-content">
                             <h3 class="font-headings">Conde Casio</h3>
-                            <p class="font-body">Figura fundamental del siglo VIII, se le atribuye la construcción o refuerzo del Alcázar de Cerezo.</p>
+                            <p class="text-lg font-body">Figura fundamental del siglo VIII, se le atribuye la construcción o refuerzo del Alcázar de Cerezo.</p>
                             <a href="/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html" class="read-more">Saber Más</a>
                         </div>
                     </div>
@@ -131,7 +131,7 @@ require_once __DIR__ . '/fragments/header.php';
                         <img class="w-full h-auto" src="/assets/img/GonzaloTellez.png" alt="Ilustración representando a Gonzalo Téllez, Conde de Lantarón y Cerezo">
                         <div class="card-content">
                             <h3 class="font-headings">Gonzalo Téllez</h3>
-                            <p class="font-body">Conde de Lantarón y Cerezo (c. 897 - c. 913), personaje clave en la consolidación de los territorios.</p>
+                            <p class="text-lg font-body">Conde de Lantarón y Cerezo (c. 897 - c. 913), personaje clave en la consolidación de los territorios.</p>
                             <a href="/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html" class="read-more">Saber Más</a>
                         </div>
                     </div>
@@ -139,7 +139,7 @@ require_once __DIR__ . '/fragments/header.php';
                         <img class="w-full h-auto" src="/assets/img/FernandoDiaz.png" alt="Representación artística de Fernando Díaz, conde castellano">
                         <div class="card-content">
                             <h3 class="font-headings">Fernando Díaz</h3>
-                            <p class="font-body">Sucesor de Gonzalo Téllez, continuó la labor de defensa y organización en la primitiva Castilla.</p>
+                            <p class="text-lg font-body">Sucesor de Gonzalo Téllez, continuó la labor de defensa y organización en la primitiva Castilla.</p>
                             <a href="/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html" class="read-more">Saber Más</a>
                         </div>
                     </div>
@@ -152,8 +152,8 @@ require_once __DIR__ . '/fragments/header.php';
         
         <section id="timeline" class="section timeline-section-summary alternate-bg py-12 sm:py-16 lg:py-20" data-aos="fade-up">
             <div class="container-epic px-4 sm:px-6 lg:px-8">
-                <h2 class="section-title font-headings">Nuestra Historia en el Tiempo</h2>
-                <p class="timeline-intro font-body">Un recorrido conciso por los momentos más determinantes de nuestra región, desde la prehistoria hasta la consolidación del Condado. Cada época ha dejado una huella imborrable.</p>
+                <h2 class="section-title text-2xl font-headings">Nuestra Historia en el Tiempo</h2>
+                <p class="timeline-intro text-lg font-body">Un recorrido conciso por los momentos más determinantes de nuestra región, desde la prehistoria hasta la consolidación del Condado. Cada época ha dejado una huella imborrable.</p>
                 <p class="cta-group">
                     <a href="/secciones_index/historia_tiempo_resumen.html" class="cta-button">Explorar Resumen de la Historia</a>
                 </p>
@@ -162,8 +162,8 @@ require_once __DIR__ . '/fragments/header.php';
 
         <section id="inmersion" class="section immersion-section py-12 sm:py-16 lg:py-20" data-aos="fade-up">
             <div class="container-epic px-4 sm:px-6 lg:px-8">
-                <h2 class="font-headings">Sumérgete en la Historia Viva de Tu Cultura</h2>
-                <p class="font-body">
+                <h2 class="text-2xl font-headings">Sumérgete en la Historia Viva de Tu Cultura</h2>
+                <p class="text-lg font-body">
                     Esta web es más que información; es una puerta a tus raíces. Un viaje al origen del castellano y la identidad hispana te espera.
                     Siente la llamada de la historia y conecta con el legado que nos une.
                 </p>

--- a/museo/editar_pieza.php
+++ b/museo/editar_pieza.php
@@ -65,7 +65,7 @@ try {
     <a href="../dashboard/index.php">Dashboard</a>
     <a href="../dashboard/logout.php">Cerrar sesión</a>
 </nav>
-<h1>Editar Posición y Escala de Piezas</h1>
+<h1 class="text-4xl font-headings">Editar Posición y Escala de Piezas</h1>
 <?php if ($feedback_message): ?>
     <div class="feedback <?php echo htmlspecialchars($feedback_type); ?>">
         <?php echo htmlspecialchars($feedback_message); ?>

--- a/museo/galeria.php
+++ b/museo/galeria.php
@@ -13,17 +13,17 @@
     <header class="page-header hero hero-museo">
         <div class="hero-content">
             <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <h1>Galería del Museo</h1>
-            <p>Explora las piezas compartidas por nuestra comunidad.</p>
+            <h1 class="text-4xl font-headings">Galería del Museo</h1>
+            <p class="text-lg font-body">Explora las piezas compartidas por nuestra comunidad.</p>
         </div>
     </header>
 
     <main>
         <section class="section museum-gallery-section alternate-bg" id="gallery-2d-section">
             <div class="container-epic">
-                <h2 class="section-title">Galería del Museo <i class="fas fa-landmark"></i></h2>
+                <h2 class="section-title text-2xl font-headings">Galería del Museo <i class="fas fa-landmark"></i></h2>
                 <div id="museumGalleryGrid" class="card-grid museum-gallery-grid">
-                    <p class="no-pieces-message" id="noPiecesMessage">Cargando piezas del museo...</p>
+                    <p class="no-pieces-message text-lg font-body" id="noPiecesMessage">Cargando piezas del museo...</p>
                 </div>
             </div>
         </section>

--- a/museo/museo.php
+++ b/museo/museo.php
@@ -35,16 +35,16 @@
     <header class="page-header hero hero-museo">
         <div class="hero-content">
             <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <h1>Museo Colaborativo del Alfoz</h1>
-            <p>Un espacio para compartir y descubrir los tesoros históricos y arqueológicos de nuestra tierra, aportados por la comunidad.</p>
+            <h1 class="text-4xl font-headings">Museo Colaborativo del Alfoz</h1>
+            <p class="text-lg font-body">Un espacio para compartir y descubrir los tesoros históricos y arqueológicos de nuestra tierra, aportados por la comunidad.</p>
         </div>
     </header>
 
     <main>
         <section class="section upload-section">
             <div class="container page-content-block">
-                <h2 class="section-title">Aporta tu Pieza al Museo <i class="fas fa-upload"></i></h2>
-                <p class="intro-paragraph">
+                <h2 class="section-title text-2xl font-headings">Aporta tu Pieza al Museo <i class="fas fa-upload"></i></h2>
+                <p class="intro-paragraph text-lg font-body">
                     ¿Tienes una fotografía de un objeto, ruina o documento histórico relacionado con el Alfoz de Cerasio y Lantarón o el Condado de Castilla? ¡Compártelo con nosotros! 
                     <br><small>(Las piezas subidas se guardarán si el backend está correctamente configurado y en funcionamiento).</small>
                 </p>
@@ -116,9 +116,9 @@
 
         <section class="section museum-gallery-section alternate-bg" id="gallery-2d-section">
             <div class="container-epic">
-                <h2 class="section-title">Galería del Museo <i class="fas fa-landmark"></i></h2>
+                <h2 class="section-title text-2xl font-headings">Galería del Museo <i class="fas fa-landmark"></i></h2>
                 <div id="museumGalleryGrid" class="card-grid museum-gallery-grid">
-                    <p class="no-pieces-message" id="noPiecesMessage">Cargando piezas del museo...</p>
+                    <p class="no-pieces-message text-lg font-body" id="noPiecesMessage">Cargando piezas del museo...</p>
                 </div>
             </div>
         </section>
@@ -126,8 +126,8 @@
 
     <section id="museo-3d-section" class="section museo-3d-section alternate-bg">
         <div class="container page-content-block">
-            <h2 class="section-title">Explora el Museo en 3D <i class="fas fa-vr-cardboard"></i></h2>
-            <p class="intro-paragraph">Visualiza algunas piezas destacadas en un entorno tridimensional interactivo. Usa el ratón para orbitar, hacer zoom y seleccionar piezas para ver sus detalles. (Funcionalidad en desarrollo)</p>
+            <h2 class="section-title text-2xl font-headings">Explora el Museo en 3D <i class="fas fa-vr-cardboard"></i></h2>
+            <p class="intro-paragraph text-lg font-body">Visualiza algunas piezas destacadas en un entorno tridimensional interactivo. Usa el ratón para orbitar, hacer zoom y seleccionar piezas para ver sus detalles. (Funcionalidad en desarrollo)</p>
             <div id="museo-3d-container">
                 <!-- Three.js canvas will be injected here -->
             </div>
@@ -156,10 +156,10 @@
 
     <div id="pointer-lock-instructions" class="pointer-lock-instructions">
         <div>
-            <h1>Exploración del Museo</h1>
-            <p class="intro-big">Haz clic en esta pantalla para empezar a explorar.</p>
-            <p>Usa las teclas <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> para moverte y el <kbd>RATÓN</kbd> para mirar alrededor.</p>
-            <p class="ai-note">Presiona <kbd>ESC</kbd> para liberar el cursor.</p>
+            <h1 class="text-4xl font-headings">Exploración del Museo</h1>
+            <p class="intro-big text-lg font-body">Haz clic en esta pantalla para empezar a explorar.</p>
+            <p class="text-lg font-body">Usa las teclas <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> para moverte y el <kbd>RATÓN</kbd> para mirar alrededor.</p>
+            <p class="ai-note text-lg font-body">Presiona <kbd>ESC</kbd> para liberar el cursor.</p>
         </div>
     </div>
 

--- a/museo/museo_3d.php
+++ b/museo/museo_3d.php
@@ -23,15 +23,15 @@
     <header class="page-header hero hero-museo">
         <div class="hero-content">
             <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <h1>Explora el Museo en 3D</h1>
-            <p>Recorre un entorno tridimensional con nuestras piezas destacadas.</p>
+            <h1 class="text-4xl font-headings">Explora el Museo en 3D</h1>
+            <p class="text-lg font-body">Recorre un entorno tridimensional con nuestras piezas destacadas.</p>
         </div>
     </header>
 
     <section id="museo-3d-section" class="section museo-3d-section alternate-bg">
         <div class="container page-content-block">
-            <h2 class="section-title">Museo 3D <i class="fas fa-vr-cardboard"></i></h2>
-            <p class="intro-paragraph">Usa las teclas WASD y el ratón para moverte por el museo virtual.</p>
+            <h2 class="section-title text-2xl font-headings">Museo 3D <i class="fas fa-vr-cardboard"></i></h2>
+            <p class="intro-paragraph text-lg font-body">Usa las teclas WASD y el ratón para moverte por el museo virtual.</p>
             <div id="museo-3d-container"></div>
         </div>
     </section>
@@ -49,10 +49,10 @@
 
     <div id="pointer-lock-instructions" class="pointer-lock-instructions">
         <div>
-            <h1>Exploración del Museo</h1>
-            <p class="intro-big">Haz clic en esta pantalla para empezar a explorar.</p>
-            <p>Usa las teclas <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> para moverte y el <kbd>RATÓN</kbd> para mirar alrededor.</p>
-            <p class="ai-note">Presiona <kbd>ESC</kbd> para liberar el cursor.</p>
+            <h1 class="text-4xl font-headings">Exploración del Museo</h1>
+            <p class="intro-big text-lg font-body">Haz clic en esta pantalla para empezar a explorar.</p>
+            <p class="text-lg font-body">Usa las teclas <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> para moverte y el <kbd>RATÓN</kbd> para mirar alrededor.</p>
+            <p class="ai-note text-lg font-body">Presiona <kbd>ESC</kbd> para liberar el cursor.</p>
         </div>
     </div>
 

--- a/museo/subir_pieza.php
+++ b/museo/subir_pieza.php
@@ -19,16 +19,16 @@
     <header class="page-header hero hero-museo">
         <div class="hero-content">
             <img src="/imagenes/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
-            <h1>Sube una Pieza al Museo</h1>
-            <p>Comparte objetos o documentos históricos relacionados con el Alfoz y el Condado de Castilla.</p>
+            <h1 class="text-4xl font-headings">Sube una Pieza al Museo</h1>
+            <p class="text-lg font-body">Comparte objetos o documentos históricos relacionados con el Alfoz y el Condado de Castilla.</p>
         </div>
     </header>
 
     <main>
         <section class="section upload-section">
             <div class="container page-content-block">
-                <h2 class="section-title">Aporta tu Pieza <i class="fas fa-upload"></i></h2>
-                <p class="intro-paragraph">
+                <h2 class="section-title text-2xl font-headings">Aporta tu Pieza <i class="fas fa-upload"></i></h2>
+                <p class="intro-paragraph text-lg font-body">
                     ¿Tienes una fotografía de un objeto, ruina o documento? ¡Compártelo con nosotros!
                     <br><small>(Las piezas se guardarán si el backend está configurado correctamente).</small>
                 </p>


### PR DESCRIPTION
## Summary
- comment out font-size rules for headings in `epic_theme.css`
- apply text size classes to heading and paragraph elements
- update Museo templates to use Tailwind typography classes
- ensure 404 page and index use new classes

## Testing
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6854ce0a2f9c83299d6f115a6d557fe2