### PR TITLE
Remove hero video

### DIFF
--- a/index.php
+++ b/index.php
@@ -33,7 +33,6 @@ require_once __DIR__ . '/fragments/header.php';
 ?>
 
     <header id="hero-video" class="relative h-screen w-full overflow-hidden">
-        <video class="absolute inset-0 object-cover object-center sm:object-center md:object-top w-full h-full" src="https://samplelib.com/lib/preview/mp4/sample-5s.mp4" autoplay muted loop playsinline></video>
         <div id="hero-content" class="relative z-10 flex flex-col items-center justify-center h-full text-center opacity-0 transition-opacity duration-1000 ease-out">
             <h1 class="text-4xl font-headings text-yellow-300 sm:text-4xl md:text-5xl lg:text-6xl shadow-lg drop-shadow-lg">Condado de Castilla: Cuna de Emperadores</h1>
             <p class="text-lg font-body mt-4 bg-black bg-opacity-50 text-white p-4 sm:p-6 md:p-8">Promocionamos el turismo en Cerezo de Río Tirón y cuidamos su patrimonio arqueológico y cultural.</p>


### PR DESCRIPTION
## Summary
- eliminate header video element so hero only contains static text and callouts

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py` *(fails: missing Flask and filelock)*
- `npm run test:puppeteer` *(fails: missing Puppeteer module)*

------
https://chatgpt.com/codex/tasks/task_e_6855320d15f08329bfa486373bd5141b