### PR TITLE
Add link check step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,17 @@ jobs:
       - name: Install project dependencies
         run: ./scripts/setup_environment.sh
 
+      - name: Check internal links
+        run: |
+          ./check_links_extended.sh
+          if grep -q "BROKEN" broken_links_report_extended.txt; then
+            echo "::error ::Broken links found"
+            cat broken_links_report_extended.txt
+            exit 1
+          else
+            echo "No broken links found"
+          fi
+
       - name: Verificar atributos alt
         run: ./scripts/check_alt_texts.sh
 


### PR DESCRIPTION
## Summary
- run `check_links_extended.sh` in CI
- fail CI when any broken links are detected

## Testing
- `./check_links_extended.sh > /tmp/link_report.txt && tail -n 5 /tmp/link_report.txt`

------
https://chatgpt.com/codex/tasks/task_e_685532f6b6988329b8ede7a69c3bcb3f