### PR TITLE
Remove decorative star icon from header

### DIFF
--- a/fragments/header.php
+++ b/fragments/header.php
@@ -1,7 +1,6 @@
 <div id="cave-mask"></div>
 <div id="fixed-header-elements" style="height: var(--header-footer-height);">
     <div class="header-action-buttons">
-        <img src="/assets/icons/star-of-venus.svg" class="header-icon" alt="Star of Venus icon" />
         <img src="/assets/icons/columna.svg" class="header-icon" alt="Roman column icon" />
         <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
         <button id="flag-toggle" data-menu-target="language-panel" aria-label="Seleccionar idioma" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>


### PR DESCRIPTION
## Summary
- tweak header to remove star icon, leaving the column icon in place

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68553310f7b88329aa750892cba5c3a6