### PR TITLE
Include epic theme in Tailwind demo

### DIFF
--- a/tailwind_index.html
+++ b/tailwind_index.html
@@ -7,6 +7,7 @@
     <title>Condado de Castilla - Página Principal</title>
     <link rel="stylesheet" href="/assets/vendor/css/tailwind.min.css">
     <link rel="stylesheet" href="/assets/css/tailwind_custom.css">
+    <link rel="stylesheet" href="/assets/css/epic_theme.css">
 </head>
 <body class="font-body bg-[color:var(--epic-alabaster-bg)] text-gray-900">
     <header class="fixed w-full bg-imperial-purple bg-opacity-90 text-old-gold shadow z-20">


### PR DESCRIPTION
## Summary
- include `epic_theme.css` stylesheet on `tailwind_index.html` so it uses the same purple, gold and alabaster palette as the rest of the site

## Testing
- `./scripts/setup_environment.sh` *(fails: PHP 8.1 and Composer not found)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py` *(fails: missing Flask and FileLock)*
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*


------
https://chatgpt.com/codex/tasks/task_e_68553316b8308329b8dae5fcd05aa765