### PR TITLE
Add admin header fragment and integrate

### DIFF
--- a/dashboard/create_user.php
+++ b/dashboard/create_user.php
@@ -58,6 +58,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <link rel="stylesheet" href="../assets/css/admin_theme.css">
 </head>
 <body class="alabaster-bg admin-page centered">
+    <?php require_once __DIR__ . '/../fragments/admin_header.php'; ?>
     <div class="admin-container narrow">
         <h2>Crear Nuevo Usuario</h2>
 

--- a/dashboard/edit_texts.php
+++ b/dashboard/edit_texts.php
@@ -49,11 +49,8 @@ $edit_id_highlight = $_GET['edit_id'] ?? null;
     <link rel="stylesheet" href="../assets/css/admin_theme.css">
 </head>
 <body class="alabaster-bg admin-page">
+    <?php require_once __DIR__ . '/../fragments/admin_header.php'; ?>
     <div class="admin-container wide">
-        <nav class="admin-nav">
-            <a href="../index.php">Volver al Inicio</a>
-            <a href="logout.php">Cerrar Sesión</a>
-        </nav>
         <h1>Editor de Textos del Sitio</h1>
 
         <?php if ($feedback_message): ?>

--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -20,17 +20,11 @@ require_admin_login();
     <script src="https://cdn.jsdelivr.net/npm/chart.js@3.7.0/dist/chart.min.js"></script> <!-- Specific version for stability -->
 </head>
 <body class="alabaster-bg admin-page">
+    <?php require_once __DIR__ . '/../fragments/admin_header.php'; ?>
     <header class="admin-header">
         <h1>Panel de Estadísticas de Visitas</h1>
     </header>
-    <nav class="admin-nav">
-        <a href="../index.php">Inicio</a>
-        <a href="edit_texts.php">Textos</a>
-        <a href="tienda_admin.php">Tienda</a>
-        <a href="../museo/editar_pieza.php">Piezas Museo</a>
-        <a href="create_user.php">Crear Usuario</a>
-        <a href="logout.php">Cerrar sesión</a>
-    </nav>
+
     
     <div class="chart-container">
         <canvas id="visitsChart"></canvas>

--- a/dashboard/login.php
+++ b/dashboard/login.php
@@ -96,6 +96,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     <link rel="stylesheet" href="../assets/css/admin_theme.css">
 </head>
 <body class="alabaster-bg admin-page centered">
+    <?php require_once __DIR__ . '/../fragments/admin_header.php'; ?>
     <div class="admin-container narrow login-container">
         <h1>Acceso de Administrador</h1>
         <?php if ($error_message): ?>

--- a/dashboard/tienda_admin.php
+++ b/dashboard/tienda_admin.php
@@ -107,11 +107,8 @@ try {
     <link rel="stylesheet" href="../assets/css/admin_theme.css">
 </head>
 <body class="alabaster-bg admin-page">
+    <?php require_once __DIR__ . '/../fragments/admin_header.php'; ?>
 <div class="admin-container wide">
-    <nav class="admin-nav">
-        <a href="../index.php">Inicio</a>
-        <a href="logout.php">Cerrar sesión</a>
-    </nav>
     <h1>Administrar Productos</h1>
     <?php if ($feedback_message): ?>
         <div class="feedback <?php echo htmlspecialchars($feedback_type); ?>">

--- a/foro/manage_comments.php
+++ b/foro/manage_comments.php
@@ -50,12 +50,8 @@ if ($pdo) {
     <link rel="stylesheet" href="/assets/css/pages/manage_comments.css">
 </head>
 <body class="alabaster-bg p-5">
+    <?php require_once __DIR__ . '/../fragments/admin_header.php'; ?>
     <h1>Administrar Comentarios del Foro</h1>
-    <nav>
-        <a href="../index.php">Inicio</a>
-        <a href="index.php">Volver al Foro</a>
-        <a href="../dashboard/logout.php">Cerrar sesión</a>
-    </nav>
     <?php if ($feedback): ?>
         <div class="feedback <?php echo htmlspecialchars($feedback_type); ?>"><?php echo htmlspecialchars($feedback); ?></div>
     <?php endif; ?>

--- a/fragments/admin_header.php
+++ b/fragments/admin_header.php
@@ -1,0 +1,52 @@
+<div id="cave-mask"></div>
+<div id="fixed-header-elements" style="height: var(--header-footer-height);">
+    <div class="header-action-buttons">
+        <img src="/assets/icons/star-of-venus.svg" class="header-icon" alt="Star of Venus icon" />
+        <img src="/assets/icons/columna.svg" class="header-icon" alt="Roman column icon" />
+        <button id="admin-menu-button" data-menu-target="admin-menu-items" aria-label="Abrir menú administrador" aria-expanded="false" role="button" aria-controls="admin-menu-items">☰</button>
+    </div>
+</div>
+
+<!-- Sliding panel with admin links -->
+<div id="admin-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="admin-menu-button">
+    <div class="menu-section">
+        <h4 class="gradient-text">Administración</h4>
+        <ul class="nav-links">
+            <li><a href="/dashboard/index.php">Dashboard</a></li>
+            <li><a href="/dashboard/edit_texts.php">Textos</a></li>
+            <li><a href="/dashboard/tienda_admin.php">Tienda</a></li>
+            <li><a href="/museo/editar_pieza.php">Piezas Museo</a></li>
+            <li><a href="/foro/manage_comments.php">Comentarios</a></li>
+            <li><a href="/dashboard/create_user.php">Crear Usuario</a></li>
+            <li><a href="/dashboard/logout.php">Cerrar sesión</a></li>
+            <li><a href="/index.php">Inicio Sitio</a></li>
+        </ul>
+    </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const btn = document.getElementById('admin-menu-button');
+    const menu = document.getElementById('admin-menu-items');
+    if (!btn || !menu) return;
+    btn.addEventListener('click', function(e) {
+        e.preventDefault();
+        const open = menu.classList.toggle('active');
+        btn.setAttribute('aria-expanded', open);
+        document.body.classList.toggle('menu-open-left', open);
+    });
+    document.addEventListener('click', function(e) {
+        if (!menu.contains(e.target) && !btn.contains(e.target)) {
+            menu.classList.remove('active');
+            btn.setAttribute('aria-expanded', 'false');
+            document.body.classList.remove('menu-open-left');
+        }
+    });
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+            menu.classList.remove('active');
+            btn.setAttribute('aria-expanded', 'false');
+            document.body.classList.remove('menu-open-left');
+        }
+    });
+});
+</script>

--- a/museo/editar_pieza.php
+++ b/museo/editar_pieza.php
@@ -60,11 +60,7 @@ try {
     <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
 </head>
 <body class="alabaster-bg admin-page edit-pieza-page">
-<nav>
-    <a href="../index.php">Inicio</a>
-    <a href="../dashboard/index.php">Dashboard</a>
-    <a href="../dashboard/logout.php">Cerrar sesión</a>
-</nav>
+    <?php require_once __DIR__ . '/../fragments/admin_header.php'; ?>
 <h1 class="text-4xl font-headings">Editar Posición y Escala de Piezas</h1>
 <?php if ($feedback_message): ?>
     <div class="feedback <?php echo htmlspecialchars($feedback_type); ?>">


### PR DESCRIPTION
## Summary
- create `fragments/admin_header.php` with simplified sliding menu for admin pages
- include new admin header on login, dashboard and admin tools
- drop old inline navigation markup

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685533177cec8329a44ded32a8356cc0