### PR TITLE
Fix menu transparency

### DIFF
--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -29,7 +29,7 @@
     width: 300px; /* Adjust width as needed */
     max-width: 80%; /* Max width for smaller screens */
     /* Purple translucent backdrop for the sliding menu */
-    background-color: rgba(var(--epic-purple-emperor-rgb), 0.9); /* Semi-transparent purple */
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.6); /* Semi-transparent purple */
     backdrop-filter: blur(5px); /* Blur effect for transparency */
     box-shadow: 0 0 15px rgba(0,0,0,0.2);
     z-index: 1000;

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -47,7 +47,7 @@
     top: 0;
     bottom: 0;
     width: 260px;
-    background: rgba(var(--epic-alabaster-bg-rgb, 253,250,246), 0.95);
+    background: rgba(var(--epic-alabaster-bg-rgb, 253,250,246), 0.6);
     backdrop-filter: blur(6px);
     overflow-y: auto;
     transition: transform 0.3s ease;


### PR DESCRIPTION
## Summary
- tweak consolidated menu alpha to 0.6
- match sliding menu background opacity with 0.6 for alabaster backdrop

## Testing
- `vendor/bin/phpunit` *(fails: php-cgi not found)*
- `python -m unittest tests/test_flask_api.py`
- `npm test` *(fails: waiting for selector #google_translate_element)*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_685533232da0832992067d06f9f3fa77