### PR TITLE
Enable custom path for GraphDBInterface

### DIFF
--- a/docs/graph_db.md
+++ b/docs/graph_db.md
@@ -42,7 +42,8 @@ El archivo contiene dos claves principales:
 ```python
 from graph_db_interface import GraphDBInterface
 
-db = GraphDBInterface()
+# Se puede especificar una ruta alternativa con el parámetro ``db_filepath``
+db = GraphDBInterface(db_filepath="mi_ruta/graph.json")
 ```
 
 2. Añade recursos o enlaces:

--- a/graph_db_interface.py
+++ b/graph_db_interface.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime
 import json
 import logging
+import os
 from filelock import FileLock
 
 # Configure module-level logger. This basic configuration writes
@@ -15,7 +16,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 class GraphDBInterface:
-    def __init__(self, config=None):
+    def __init__(self, config=None, db_filepath: str | None = None):
         """
         Initializes in-memory storage for nodes (resources) and edges (links).
         _nodes stores resources keyed by their URL for quick lookup.
@@ -23,7 +24,10 @@ class GraphDBInterface:
         """
         self._nodes = {}  # Key: URL, Value: resource_data dictionary
         self._edges = []  # List of link_data dictionaries
-        self.db_filepath = "knowledge_graph_db.json"
+        self.db_filepath = (
+            db_filepath
+            or os.environ.get("GRAPH_DB_PATH", "knowledge_graph_db.json")
+        )
         self._lock = FileLock(f"{self.db_filepath}.lock")
         # Config is not used for now, but can be for future DB connections
         logger.info("GraphDBInterface initializing...")

--- a/tests/test_graph_db_interface.py
+++ b/tests/test_graph_db_interface.py
@@ -7,14 +7,12 @@ from graph_db_interface import GraphDBInterface
 
 class GraphDBInterfaceTestCase(unittest.TestCase):
     def setUp(self):
-        # create temporary directory and switch into it so the DB file is isolated
-        self.orig_cwd = os.getcwd()
+        # create temporary directory for isolated DB file
         self.temp_dir = tempfile.TemporaryDirectory()
-        os.chdir(self.temp_dir.name)
-        self.db = GraphDBInterface()
+        db_path = os.path.join(self.temp_dir.name, "test_graph.json")
+        self.db = GraphDBInterface(db_filepath=db_path)
 
     def tearDown(self):
-        os.chdir(self.orig_cwd)
         self.temp_dir.cleanup()
 
     def test_add_or_update_resource_and_resource_exists(self):


### PR DESCRIPTION
## Summary
- allow GraphDBInterface to read a custom db path argument or env var
- adjust tests to specify a temp file
- update docs for the new parameter

## Testing
- `PYTHONPATH=. pytest tests/test_graph_db_interface.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685533a748d88329851fc849f510c487