### PR TITLE
Improve menu accessibility

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -24,8 +24,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const closeMenu = (menu) => {
         menu.classList.remove('active');
+        menu.setAttribute('aria-hidden', 'true');
         const btn = document.querySelector(`[data-menu-target="${menu.id}"]`);
-        if (btn) btn.setAttribute('aria-expanded', 'false');
+        if (btn) {
+            btn.setAttribute('aria-expanded', 'false');
+            btn.focus();
+        }
         const side = menu.classList.contains('left-panel') ? 'left'
                     : (menu.classList.contains('right-panel') ? 'right' : '');
         if (side) document.body.classList.remove(`menu-open-${side}`);
@@ -47,9 +51,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const open = !menu.classList.contains('active');
         menu.classList.toggle('active', open);
         btn.setAttribute('aria-expanded', open);
+        menu.setAttribute('aria-hidden', !open);
         if (side) document.body.classList.toggle(`menu-open-${side}`, open);
         if (open && menu.id === 'language-panel' && typeof primeTranslateLoad === 'function') {
             primeTranslateLoad();
+        }
+        if (open) {
+            const first = menu.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+            (first || menu).focus();
         }
 
         const anyOpen = document.querySelectorAll('.menu-panel.active').length > 0;

--- a/fragments/header.php
+++ b/fragments/header.php
@@ -3,15 +3,15 @@
     <div class="header-action-buttons">
         <img src="/assets/icons/star-of-venus.svg" class="header-icon" alt="Star of Venus icon" />
         <img src="/assets/icons/columna.svg" class="header-icon" alt="Roman column icon" />
-        <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
-        <button id="flag-toggle" data-menu-target="language-panel" aria-label="Seleccionar idioma" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>
+        <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-haspopup="true" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
+        <button id="flag-toggle" data-menu-target="language-panel" aria-label="Seleccionar idioma" aria-haspopup="true" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>
         <button id="mute-toggle" aria-pressed="false" aria-label="Silenciar">🔊</button>
     </div>
 </div>
 
 <!-- Left Sliding Panel for Main Menu -->
-<div id="consolidated-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="consolidated-menu-button">
-    <button id="ai-chat-trigger" class="menu-item-button" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA"><i class="fas fa-comments"></i> <span>Chat IA</span></button>
+<div id="consolidated-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="consolidated-menu-button" tabindex="-1" aria-hidden="true">
+    <button id="ai-chat-trigger" class="menu-item-button" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA" aria-haspopup="dialog"><i class="fas fa-comments"></i> <span>Chat IA</span></button>
     <button id="theme-toggle" class="menu-item-button" aria-label="Cambiar tema"><i class="fas fa-moon"></i> <span>Modo</span></button>
     <button id="moon-toggle" class="menu-item-button">🌙 Modo luna</button>
     <button id="palette-toggle" class="menu-item-button" aria-label="Cambiar paleta"><i class="fas fa-palette"></i> <span>Paleta</span></button>
@@ -40,7 +40,7 @@
 </div>
 
 <!-- Right Sliding Panel for AI Chat -->
-<div id="ai-chat-panel" class="menu-panel right-panel" role="dialog" aria-labelledby="ai-chat-title">
+<div id="ai-chat-panel" class="menu-panel right-panel" role="dialog" aria-modal="true" aria-labelledby="ai-chat-title" tabindex="-1" aria-hidden="true">
     <?php
     // Content from ai-drawer.html will go here
     // It includes the header, response area, input, and submit button for AI chat
@@ -59,6 +59,6 @@
     if (file_exists(__DIR__ . '/header/language-flags.html')) {
         echo file_get_contents(__DIR__ . '/header/language-flags.html');
     } else {
-        echo '<div id="language-panel" class="menu-panel right-panel"><p>Flags not found.</p></div>';
+        echo '<div id="language-panel" class="menu-panel right-panel" role="dialog" aria-labelledby="flag-toggle" tabindex="-1" aria-hidden="true"><p>Flags not found.</p></div>';
     }
 ?>

--- a/fragments/header/language-flags.html
+++ b/fragments/header/language-flags.html
@@ -1,4 +1,4 @@
-<div id="language-panel" class="menu-panel right-panel">
+<div id="language-panel" class="menu-panel right-panel" role="dialog" aria-labelledby="flag-toggle" tabindex="-1" aria-hidden="true">
     <div id="google_translate_element"></div>
     <div class="flag-list">
         <img src="/assets/flags/es.svg" alt="Español" data-lang="es">

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start:php": "sh -c 'php -S localhost:8080 >/dev/null 2>&1 & echo $! > .php_server.pid'",
     "stop:php": "sh -c 'if [ -f .php_server.pid ]; then kill $(cat .php_server.pid); rm .php_server.pid; fi'",
-    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js",
+    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuKeyboardNavigationTest.js",
     "test": "npm run start:php && npm run test:puppeteer; npm run stop:php"
   }
 }

--- a/tests/menuKeyboardNavigationTest.js
+++ b/tests/menuKeyboardNavigationTest.js
@@ -1,0 +1,31 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/index.php');
+  await page.waitForSelector('#consolidated-menu-button');
+  await page.focus('#consolidated-menu-button');
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(300);
+  const open = await page.$eval('#consolidated-menu-items', el => el.classList.contains('active'));
+  const focusedInside = await page.evaluate(() => {
+    const menu = document.getElementById('consolidated-menu-items');
+    return menu.contains(document.activeElement);
+  });
+  if (!open || !focusedInside) {
+    console.error('Menu did not open via keyboard');
+    await browser.close();
+    process.exit(1);
+  }
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(300);
+  const closed = await page.$eval('#consolidated-menu-items', el => !el.classList.contains('active'));
+  if (!closed) {
+    console.error('Menu did not close via Escape');
+    await browser.close();
+    process.exit(1);
+  }
+  console.log('Keyboard navigation for menu works');
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- add ARIA and tabindex attributes to header menus
- focus menu items when opened and restore focus when closed
- create Puppeteer test for keyboard navigation
- include new test in npm script

## Testing
- `npm install`
- `npm test` *(fails: TimeoutError Waiting for selector `#google_translate_element`)*
- `phpunit --configuration phpunit.xml` *(fails: php-cgi not found)*

------
https://chatgpt.com/codex/tasks/task_e_685533a6ca6c8329848d5d9bd52487cb