### PR TITLE
Add combined test workflow

### DIFF
--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -1,0 +1,40 @@
+name: Test Suites
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: ./scripts/setup_environment.sh
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit
+
+      - name: Run Python tests
+        run: python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py
+
+      - name: Run Node tests
+        run: npm test


### PR DESCRIPTION
## Summary
- run setup, PHPUnit, Python, and Node tests in a new workflow

## Testing
- `./scripts/setup_environment.sh` *(fails: PHP/composer not found)*
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py` *(fails: ModuleNotFoundError)*
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685533aad80c8329b7af1afbe6671db2