### PR TITLE
Remove Star of Venus icon

### DIFF
--- a/fragments/admin_header.php
+++ b/fragments/admin_header.php
@@ -1,7 +1,6 @@
 <div id="cave-mask"></div>
 <div id="fixed-header-elements" style="height: var(--header-footer-height);">
     <div class="header-action-buttons">
-        <img src="/assets/icons/star-of-venus.svg" class="header-icon" alt="Star of Venus icon" />
         <img src="/assets/icons/columna.svg" class="header-icon" alt="Roman column icon" />
         <button id="admin-menu-button" data-menu-target="admin-menu-items" aria-label="Abrir menú administrador" aria-expanded="false" role="button" aria-controls="admin-menu-items">☰</button>
     </div>

--- a/fragments/header.php
+++ b/fragments/header.php
@@ -1,7 +1,6 @@
 <div id="cave-mask"></div>
 <div id="fixed-header-elements" style="height: var(--header-footer-height);">
     <div class="header-action-buttons">
-        <img src="/assets/icons/star-of-venus.svg" class="header-icon" alt="Star of Venus icon" />
         <img src="/assets/icons/columna.svg" class="header-icon" alt="Roman column icon" />
         <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-haspopup="true" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
         <button id="flag-toggle" data-menu-target="language-panel" aria-label="Seleccionar idioma" aria-haspopup="true" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>


### PR DESCRIPTION
## Summary
- remove the Star of Venus icon from user-facing header
- remove the Star of Venus icon from admin header

## Testing
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError for Flask)*
- `npm test` *(fails: MODULE_NOT_FOUND for puppeteer and PHP server)*

------
https://chatgpt.com/codex/tasks/task_e_685536b67cc483298f65f0423f6edc19