### PR TITLE
Add escudo overlay to header

### DIFF
--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -94,3 +94,12 @@ body.dark-mode #theme-toggle i {
 body.dark-mode #theme-toggle:hover i {
     color: var(--epic-icon-hover);
 }
+
+#header-escudo-overlay {
+    position: fixed;
+    top: calc(var(--menu-top-offset) + 4px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 4010;
+    pointer-events: none;
+}

--- a/fragments/admin_header.php
+++ b/fragments/admin_header.php
@@ -1,4 +1,5 @@
 <div id="cave-mask"></div>
+<img id="header-escudo-overlay" class="hero-escudo" src="/assets/img/escudo.jpg" alt="Escudo de Cerezo de Río Tirón">
 <div id="fixed-header-elements" style="height: var(--header-footer-height);">
     <div class="header-action-buttons">
         <img src="/assets/icons/star-of-venus.svg" class="header-icon" alt="Star of Venus icon" />

--- a/fragments/header.php
+++ b/fragments/header.php
@@ -1,4 +1,5 @@
 <div id="cave-mask"></div>
+<img id="header-escudo-overlay" class="hero-escudo" src="/assets/img/escudo.jpg" alt="Escudo de Cerezo de Río Tirón">
 <div id="fixed-header-elements" style="height: var(--header-footer-height);">
     <div class="header-action-buttons">
         <img src="/assets/icons/star-of-venus.svg" class="header-icon" alt="Star of Venus icon" />


### PR DESCRIPTION
## Summary
- show escudo overlay in all headers
- style new overlay image above the transparent header background

## Testing
- `composer install` *(fails: missing DOM extension)*
- `vendor/bin/phpunit --dont-report-useless-tests` *(fails: php-cgi not found)*

------
https://chatgpt.com/codex/tasks/task_e_68553665a7008329be99d91dbac95af0