### PR TITLE
Add Homonexus toggle button

### DIFF
--- a/fragments/footer.php
+++ b/fragments/footer.php
@@ -27,3 +27,4 @@
 <script src="/js/lang-bar.js"></script>
 <script src="/assets/js/audio-controller.js"></script>
 <script defer src="/assets/js/custom-pointer.js"></script>
+<script src="/assets/js/homonexus-toggle.js"></script>

--- a/fragments/header.php
+++ b/fragments/header.php
@@ -6,6 +6,7 @@
         <button id="consolidated-menu-button" data-menu-target="consolidated-menu-items" aria-label="Abrir menú principal" aria-haspopup="true" aria-expanded="false" role="button" aria-controls="consolidated-menu-items">☰</button>
         <button id="flag-toggle" data-menu-target="language-panel" aria-label="Seleccionar idioma" aria-haspopup="true" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>
         <button id="mute-toggle" aria-pressed="false" aria-label="Silenciar">🔊</button>
+        <button id="homonexus-toggle" aria-label="Activar Homonexus" aria-pressed="false">👥</button>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- add a `homonexus-toggle` button in the header next to other menu controls
- load `homonexus-toggle.js` in the footer

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_685545a6eb0883298655fc239c3b381f