### PR TITLE
Improve setup script

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,10 +4,14 @@ Esta guía explica cómo preparar el entorno y ejecutar las pruebas automatizada
 
 ## Configurar el entorno
 
-Antes de lanzar **cualquier** suite de pruebas ejecuta `setup_environment.sh`. Este script instala de una sola vez las dependencias de PHP, Python y Node.
-Si alguno de estos gestores no está disponible, el script mostrará una advertencia y continuará con el resto, de modo que la configuración puede completarse de forma parcial.
-El proyecto requiere como mínimo **PHP&nbsp;8.1**, **Node&nbsp;18** y **Python&nbsp;3.10**. El propio script comprueba estas versiones y avisa en caso de no encontrarlas o si son antiguas.
-Tras solventar cualquier ausencia podrás ejecutar manualmente el paso correspondiente y repetir la preparación.
+Antes de lanzar **cualquier** suite de pruebas ejecuta `setup_environment.sh`.
+Este script instala de una sola vez las dependencias de PHP, Python y Node. Si
+detecta que alguna de estas herramientas no está presente intentará instalarla
+mediante `apt-get` (por ejemplo **PHP CLI**, **Composer** o **Node.js 18**).
+El proyecto requiere como mínimo **PHP&nbsp;8.1**, **Node&nbsp;18** y
+**Python&nbsp;3.10**. El propio script comprueba estas versiones y avisa en caso
+de no encontrarlas o si son antiguas. Tras solventar cualquier ausencia podrás
+ejecutar manualmente el paso correspondiente y repetir la preparación.
 
 ```bash
 ./scripts/setup_environment.sh

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 set -uo pipefail
 
+# Attempt to install missing runtimes using apt-get when possible
+install_pkg() {
+    local pkg="$1"
+    if dpkg -s "$pkg" >/dev/null 2>&1; then
+        return
+    fi
+    echo "Installing $pkg..."
+    if ! apt-get update -y >/dev/null 2>&1; then
+        echo "Warning: apt-get update failed" >&2
+        return 1
+    fi
+    if ! apt-get install -y "$pkg" >/dev/null 2>&1; then
+        echo "Warning: failed to install $pkg" >&2
+    fi
+}
+
 # Determine repository root and switch to it
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -33,6 +49,44 @@ check_version() {
 check_version php "$REQUIRED_PHP_VERSION" "PHP" || true
 check_version node "$REQUIRED_NODE_VERSION" "Node.js" || true
 check_version python3 "$REQUIRED_PYTHON_VERSION" "Python" || true
+
+# Install runtimes if they are missing
+if ! command -v php >/dev/null 2>&1; then
+    install_pkg php-cli
+    install_pkg php
+fi
+
+if ! command -v composer >/dev/null 2>&1; then
+    if apt-get install -y composer >/dev/null 2>&1; then
+        echo "Composer installed via apt"
+    else
+        echo "Downloading composer.phar..."
+        if curl -sS https://getcomposer.org/installer | php >/dev/null 2>&1; then
+            mv composer.phar /usr/local/bin/composer
+            chmod +x /usr/local/bin/composer
+        else
+            echo "Warning: failed to install Composer" >&2
+        fi
+    fi
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+    echo "Node.js not found. Installing..."
+    if curl -fsSL https://deb.nodesource.com/setup_${REQUIRED_NODE_VERSION}.x | bash - >/dev/null 2>&1 && \
+       apt-get install -y nodejs >/dev/null 2>&1; then
+        echo "Node.js installed"
+    else
+        echo "Warning: failed to install Node.js" >&2
+    fi
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    install_pkg python3
+fi
+
+if ! command -v pip >/dev/null 2>&1; then
+    install_pkg python3-pip
+fi
 
 # Verify Composer is available before proceeding
 if ! command -v composer >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- update setup_environment.sh to automatically install PHP, Node and Python tooling
- mention the new behaviour in the testing guide

## Testing
- `bash scripts/setup_environment.sh`
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py`
- `npm test` *(fails: Waiting for selector `#google_translate_element` failed)*

------
https://chatgpt.com/codex/tasks/task_e_685545a6e954832986f4615f17211a7e