### PR TITLE
Fix mobile contrast

### DIFF
--- a/assets/css/mobile_contrast.css
+++ b/assets/css/mobile_contrast.css
@@ -1,0 +1,12 @@
+@media (max-width: 768px) {
+  body {
+    color: var(--color-negro-contraste);
+  }
+  .gradient-text {
+    background-image: none;
+    color: var(--epic-purple-emperor);
+    -webkit-background-clip: initial;
+    background-clip: initial;
+    text-shadow: none;
+  }
+}

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -27,6 +27,7 @@ require_once __DIR__ . '/env_loader.php';
 <script defer src="/assets/js/torch_cursor.js"></script>
 <link rel="stylesheet" href="/assets/css/glow_filter.css">
 <link rel="stylesheet" href="/assets/css/custom-pointer.css">
+<link rel="stylesheet" href="/assets/css/mobile_contrast.css" media="(max-width: 768px)">
 <?php
 $svgFilterPath = __DIR__ . '/../fragments/header/svg_filters.html';
 if (file_exists($svgFilterPath)) {


### PR DESCRIPTION
## Summary
- add new mobile-only CSS for better readability
- load mobile contrast stylesheet in the global head

## Testing
- `scripts/setup_environment.sh` *(fails: PHP and Composer not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*


------
https://chatgpt.com/codex/tasks/task_e_6855466ac84083299dd5dacca0ced300