### PR TITLE
Add responsive CSS breakpoints

### DIFF
--- a/assets/css/header/nav.css
+++ b/assets/css/header/nav.css
@@ -330,6 +330,38 @@ body.sidebar-active {
     }
 }
 
+@media (max-width: 992px) {
+    .navbar {
+        padding: 0.5em 0;
+    }
+    .navbar .logo-image {
+        max-height: 40px;
+    }
+    .nav-links a {
+        font-size: 0.8em;
+        padding: 0.5em 0.3em;
+    }
+    #sidebar {
+        width: 70vw;
+    }
+}
+
+@media (max-width: 480px) {
+    .navbar {
+        padding: 0.4em 0;
+    }
+    .nav-links {
+        flex-direction: column;
+    }
+    .navbar .logo-image {
+        max-width: 150px;
+    }
+    #sidebar {
+        width: 85vw;
+        max-width: 260px;
+    }
+}
+
 /* Mute Toggle Button */
 #mute-toggle {
     padding: 6px 10px;

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -245,3 +245,26 @@
         right: 8px;
     }
 }
+
+@media (max-width: 992px) {
+    .menu-panel {
+        width: 260px;
+    }
+    #consolidated-menu-button {
+        padding: 7px 11px;
+    }
+}
+
+@media (max-width: 480px) {
+    .menu-panel {
+        width: 240px;
+        padding: 8px;
+        padding-top: 40px;
+    }
+    .menu-panel .menu-item-button {
+        font-size: 0.85em;
+    }
+    #consolidated-menu-button {
+        font-size: 0.9em;
+    }
+}

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -104,3 +104,25 @@ body.menu-open-right {
     display: none !important;
   }
 }
+
+@media (max-width: 992px) {
+  #slide-menu-right,
+  #slide-menu-left {
+    width: 260px;
+  }
+}
+
+@media (max-width: 480px) {
+  #slide-menu-right,
+  #slide-menu-left {
+    width: 230px;
+  }
+  #fixed-header {
+    padding: 0.4rem 0.6rem;
+  }
+  #menu-button,
+  #tools-button {
+    font-size: 1rem;
+    padding: 0.3rem 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak nav menu CSS for breakpoints at 992px and 480px
- refine consolidated menu CSS for tablet and phone widths
- adjust sliding menu for new responsive ranges

## Testing
- `npm test` *(fails: Waiting for selector `#google_translate_element` failed)*
- `vendor/bin/phpunit` *(fails: could not find driver; php-cgi not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555bd6565c83298b6b739db259790e