### PR TITLE
Improve menu compression; log test results

### DIFF
--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -60,7 +60,8 @@
 /* Slightly scale down the page when any slide menu is active */
 body.menu-compressed {
     transition: transform 0.3s ease;
-    transform: scaleX(0.95);
+    transform: scaleX(0.92);
+    transform-origin: center;
 }
 
 body.menu-open-left,
@@ -68,10 +69,12 @@ body.menu-open-right {
     transition: transform 0.3s ease;
 }
 body.menu-open-left {
-    transform: translateX(260px) scaleX(0.95);
+    transform: translateX(260px) scaleX(0.92);
+    transform-origin: left center;
 }
 body.menu-open-right {
-    transform: translateX(-260px) scaleX(0.95);
+    transform: translateX(-260px) scaleX(0.92);
+    transform-origin: right center;
 }
 
 #slide-menu-right ul {

--- a/docs/test-results.md
+++ b/docs/test-results.md
@@ -1,26 +1,12 @@
-# Test Results - Automated Run
-
-This document summarizes the outcome of the automated test commands executed in the Codex environment.
+# Test Results - 2025-06-20
 
 ## `npm test`
-- **Status:** Failed
-- **Reason:** Puppeteer attempted to navigate to `http://localhost:8080/tests/manual/test_lang.html` but the connection was refused. The local PHP server required for the tests was not running.
+The test suite failed with a timeout while waiting for `#google_translate_element`.
+Log excerpt:
+
+17:            this.#timeoutError = new Errors_js_1.TimeoutError(`Waiting failed: ${options.timeout}ms exceeded`);
+20:TimeoutError: Waiting for selector `#google_translate_element` failed: Waiting failed: 30000ms exceeded
+
 
 ## `vendor/bin/phpunit`
-- **Status:** Not executed
-- **Reason:** `composer` is not installed in the environment, so `vendor/bin/phpunit` is missing. Installing dependencies via `composer install` is required before running PHPUnit.
-
-## `python -m unittest tests/test_flask_api.py`
-- **Status:** Failed
-- **Reason:** The `flask` module was not found. Install dependencies from `requirements.txt` before running the Python tests.
-
-## Suggested Adjustments
-1. Install project dependencies:
-   - Run `npm install` to fetch Node packages (already done in this run).
-   - Ensure `composer` is installed, then run `composer install` for PHP dependencies.
-   - Install Python packages with `pip install -r requirements.txt`.
-2. Start a local PHP server on port 8080 before executing Puppeteer tests:
-   ```bash
-   php -S localhost:8080
-   ```
-3. Run the test suites in the order described in `docs/testing.md`.
+PHPUnit did not run because `composer install` failed and the `vendor` directory was not created.


### PR DESCRIPTION
## Summary
- tweak slide menu compression to scale content more noticeably
- update automated test run results

## Testing
- `./scripts/setup_environment.sh`
- `npm test` *(fails: TimeoutError waiting for #google_translate_element)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555bd107c08329af1b4032298073e6