### PR TITLE
Enable global Homonexus and AI chat

### DIFF
--- a/docs/tareas.md
+++ b/docs/tareas.md
@@ -7,8 +7,8 @@
 ## Nuevas tareas
  - [x] Documentar el crawler y la base de datos de grafo de conocimiento.
 - [ ] Revisar la accesibilidad y el rendimiento en dispositivos móviles.
-- [ ] Integrar el modo Homonexus y el chat IA en todas las páginas.
-- [ ] Garantizar que los menús y botones permanezcan fijos al hacer scroll para que solo el contenido sea desplazable.
+ - [x] Integrar el modo Homonexus y el chat IA en todas las páginas.
+ - [x] Garantizar que los menús y botones permanezcan fijos al hacer scroll para que solo el contenido sea desplazable.
  - [x] Documentar la nueva gráfica de Influencia Romana realizada con D3 y compatible con modo oscuro.
 - [x] Añadir tests de `GraphDBInterface` para `add_or_update_resource`, `resource_exists` y `add_link`.
 - [x] Añadir test de Puppeteer `linternaGradientTest.js` para verificar `bg-linterna-gradient` en la galería.

--- a/fragments/admin_header.php
+++ b/fragments/admin_header.php
@@ -4,11 +4,13 @@
     <div class="header-action-buttons">
         <img src="/assets/icons/columna.svg" class="header-icon" alt="Roman column icon" />
         <button id="admin-menu-button" data-menu-target="admin-menu-items" aria-label="Abrir menú administrador" aria-expanded="false" role="button" aria-controls="admin-menu-items">☰</button>
+        <button id="homonexus-toggle" aria-label="Activar Homonexus" aria-pressed="false">👥</button>
     </div>
 </div>
 
 <!-- Sliding panel with admin links -->
 <div id="admin-menu-items" class="menu-panel left-panel" role="navigation" aria-labelledby="admin-menu-button">
+    <button id="ai-chat-trigger" class="menu-item-button" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA" aria-haspopup="dialog"><i class="fas fa-comments"></i> <span>Chat IA</span></button>
     <div class="menu-section">
         <h4 class="gradient-text">Administración</h4>
         <ul class="nav-links">
@@ -22,6 +24,17 @@
             <li><a href="/index.php">Inicio Sitio</a></li>
         </ul>
     </div>
+</div>
+
+<!-- Right Sliding Panel for AI Chat -->
+<div id="ai-chat-panel" class="menu-panel right-panel" role="dialog" aria-modal="true" aria-labelledby="ai-chat-title" tabindex="-1" aria-hidden="true">
+    <?php
+    if (file_exists(__DIR__ . '/header/ai-drawer.html')) {
+        echo file_get_contents(__DIR__ . '/header/ai-drawer.html');
+    } else {
+        echo '<p>Error: AI Chat interface not found.</p>';
+    }
+    ?>
 </div>
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/fragments/footer.php
+++ b/fragments/footer.php
@@ -28,3 +28,4 @@
 <script src="/assets/js/audio-controller.js"></script>
 <script defer src="/assets/js/custom-pointer.js"></script>
 <script src="/assets/js/homonexus-toggle.js"></script>
+<script src="/js/layout.js"></script>


### PR DESCRIPTION
## Summary
- add Homonexus toggle and AI chat panel to the admin header
- include `layout.js` from the footer so IA features load everywhere
- mark completed tasks in `docs/tareas.md`

## Testing
- `bash scripts/setup_environment.sh` *(fails: PHP missing)*
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68555bd2a00c83299bf0b83d53bbf5b4