### PR TITLE
Add aria-expanded styling for navigation

### DIFF
--- a/assets/css/header/nav.css
+++ b/assets/css/header/nav.css
@@ -147,6 +147,19 @@
 .nav-toggle:focus-visible {
     outline: 2px solid var(--epic-gold-main);
 }
+/* Toggle button expanded state */
+
+.header-action-buttons [aria-expanded="true"],
+.nav-toggle[aria-expanded="true"] {
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+}
+.header-action-buttons [aria-expanded="false"],
+.nav-toggle[aria-expanded="false"] {
+    background-color: var(--epic-purple-emperor);
+    color: var(--epic-gold-main);
+}
+
 
 /* --- Sidebar Navigation (#sidebar, #sidebar-toggle from fragments/header.php) --- */
 #sidebar {
@@ -171,6 +184,14 @@
 #sidebar.sidebar-visible {
     transform: translateX(0); /* Shown on-screen */
 }
+#sidebar[aria-expanded="true"] {
+    transform: translateX(0);
+}
+
+#sidebar[aria-expanded="false"] {
+    transform: translateX(-100%);
+}
+
 
 #sidebar-toggle {
     /* position: fixed; */

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -68,6 +68,24 @@
     opacity: 1;
 }
 
+#consolidated-menu-items.left-panel[aria-expanded="true"],
+#ai-chat-panel.right-panel[aria-expanded="true"],
+#demo-info-panel.right-panel[aria-expanded="true"] {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+#consolidated-menu-items.left-panel[aria-expanded="false"] {
+    transform: translateX(-100%);
+    opacity: 0;
+}
+
+#ai-chat-panel.right-panel[aria-expanded="false"],
+#demo-info-panel.right-panel[aria-expanded="false"] {
+    transform: translateX(100%);
+    opacity: 0;
+}
+
 /* Styling for buttons and content within panels */
 .menu-panel .menu-item-button {
     display: block;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -33,6 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
             btn.focus();
         }
         menu.setAttribute('aria-hidden', 'true');
+        menu.setAttribute("aria-expanded", "false");
         // Recalculate anyOpen and update body classes
         updateGlobalMenuState();
     };
@@ -49,6 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
         document.body.classList.toggle('sidebar-active', open);
         btn.setAttribute('aria-expanded', open);
         menu.setAttribute('aria-hidden', !open);
+        menu.setAttribute('aria-expanded', open);
 
         if (open) {
             const first = menu.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
@@ -61,6 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const closeMenu = (menu, triggerButton = null) => { // Added triggerButton for focus
         menu.classList.remove('active');
         menu.setAttribute('aria-hidden', 'true');
+        menu.setAttribute("aria-expanded", "false");
         const btn = triggerButton || document.querySelector(`[data-menu-target="${menu.id}"]`);
         if (btn) {
             btn.setAttribute('aria-expanded', 'false');
@@ -97,6 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
         menu.classList.toggle('active', open);
         btn.setAttribute('aria-expanded', open);
         menu.setAttribute('aria-hidden', !open);
+        menu.setAttribute("aria-expanded", open);
         if (side) document.body.classList.toggle(`menu-open-${side}`, open);
 
         if (open && menu.id === 'language-panel' && typeof primeTranslateLoad === 'function') {

--- a/docs/tareas.md
+++ b/docs/tareas.md
@@ -7,6 +7,7 @@
 ## Nuevas tareas
  - [x] Documentar el crawler y la base de datos de grafo de conocimiento.
 - [ ] Revisar la accesibilidad y el rendimiento en dispositivos móviles.
+  - [ ] Añadir selectores `[aria-expanded="true"]` y `[aria-expanded="false"]` para destacar botones activos y controlar la visibilidad de los menús.
 - [ ] Integrar el modo Homonexus y el chat IA en todas las páginas.
 - [ ] Garantizar que los menús y botones permanezcan fijos al hacer scroll para que solo el contenido sea desplazable.
  - [x] Documentar la nueva gráfica de Influencia Romana realizada con D3 y compatible con modo oscuro.


### PR DESCRIPTION
## Summary
- style nav buttons when `[aria-expanded]` changes
- add accessibility-friendly menu selectors
- track new work in mobile accessibility tasks

## Testing
- `npm install`
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68555bd4caec832992acc88f8ab1a719