### PR TITLE
Centralize CSS breakpoints

### DIFF
--- a/assets/css/components/breakpoints.css
+++ b/assets/css/components/breakpoints.css
@@ -1,0 +1,6 @@
+/* Centralized responsive breakpoints */
+:root {
+    --breakpoint-xs: 480px;
+    --breakpoint-md: 768px;
+    --breakpoint-lg: 992px;
+}

--- a/assets/css/header/nav.css
+++ b/assets/css/header/nav.css
@@ -1,3 +1,4 @@
+@import url("../components/breakpoints.css");
 /* --- Navbar Styles ----------------------------------------------------- */
 /*
 .navbar {
@@ -307,7 +308,7 @@ body.sidebar-active {
 
 
 /* Responsive adjustments */
-@media (max-width: 768px) {
+@media (max-width: var(--breakpoint-md)) {
     .navbar .nav-toggle,
     .navbar .nav-links {
         /* Sidebar handles mobile navigation */
@@ -330,7 +331,7 @@ body.sidebar-active {
     }
 }
 
-@media (max-width: 992px) {
+@media (max-width: var(--breakpoint-lg)) {
     .navbar {
         padding: 0.5em 0;
     }
@@ -346,7 +347,7 @@ body.sidebar-active {
     }
 }
 
-@media (max-width: 480px) {
+@media (max-width: var(--breakpoint-xs)) {
     .navbar {
         padding: 0.4em 0;
     }

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -1,3 +1,4 @@
+@import url("../components/breakpoints.css");
 /* assets/css/menus/consolidated-menu.css */
 
 /* Main toggle button for the consolidated menu */
@@ -229,7 +230,7 @@
 
 
 /* Responsive adjustments */
-@media (max-width: 768px) {
+@media (max-width: var(--breakpoint-md)) {
     .menu-panel {
         width: 280px; /* Slightly narrower for mobile */
         padding: 10px; /* Compacted */
@@ -246,7 +247,7 @@
     }
 }
 
-@media (max-width: 992px) {
+@media (max-width: var(--breakpoint-lg)) {
     .menu-panel {
         width: 260px;
     }
@@ -255,7 +256,7 @@
     }
 }
 
-@media (max-width: 480px) {
+@media (max-width: var(--breakpoint-xs)) {
     .menu-panel {
         width: 240px;
         padding: 8px;


### PR DESCRIPTION
## Summary
- add a shared `breakpoints.css` with CSS variables for common breakpoints
- import the shared breakpoints into `nav.css` and `consolidated-menu.css`
- replace hard-coded pixel breakpoints with variables

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555e0be33083298126a20ddc8bf2f3