### PR TITLE
docs: clarify testing workflow

### DIFF
--- a/docs/test-results.md
+++ b/docs/test-results.md
@@ -1,12 +1,11 @@
 # Test Results - 2025-06-20
 
-## `npm test`
-The test suite failed with a timeout while waiting for `#google_translate_element`.
-Log excerpt:
-
-17:            this.#timeoutError = new Errors_js_1.TimeoutError(`Waiting failed: ${options.timeout}ms exceeded`);
-20:TimeoutError: Waiting for selector `#google_translate_element` failed: Waiting failed: 30000ms exceeded
-
-
 ## `vendor/bin/phpunit`
-PHPUnit did not run because `composer install` failed and the `vendor` directory was not created.
+34 tests executed with 3 errors and 27 failures. Most failures stem from `php-cgi` not being available and database drivers missing.
+
+## `python -m unittest`
+All tests passed.
+
+## `npm run test:puppeteer`
+The suite failed with a timeout while waiting for `#google_translate_element`.
+

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,3 +39,12 @@ python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py
 # 3. Pruebas de interfaz con Puppeteer
 npm run test:puppeteer
 ```
+
+
+## Solucion de problemas
+
+- Si al ejecutar `npm run test:puppeteer` obtienes un TimeoutError, comprueba que tienes un servidor PHP en marcha con:
+```bash
+php -S localhost:8080
+```
+- Si las dependencias fallaron al instalarse, vuelve a lanzar `./scripts/setup_environment.sh`.


### PR DESCRIPTION
## Summary
- note the PHP server requirement in new Troubleshooting section
- mention `scripts/setup_environment.sh`
- record latest automated test results

## Testing
- `vendor/bin/phpunit` *(fails: php-cgi not found)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py`
- `npm run test:puppeteer` *(fails: TimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_68555e0c91008329b2507a549f6eb424