### PR TITLE
Ensure menu ARIA state updates

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -25,14 +25,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const sidebarMenuId = 'sidebar'; // Assuming 'sidebar' is the ID of your sidebar
 
+    const updateAria = (btn, menu, open) => {
+        if (btn) btn.setAttribute('aria-expanded', String(open));
+        if (menu) menu.setAttribute('aria-hidden', String(!open));
+    };
+
     const closeMobileSidebar = (menu, btn) => {
         menu.classList.remove('sidebar-visible');
         document.body.classList.remove('sidebar-active');
-        if (btn) {
-            btn.setAttribute('aria-expanded', 'false');
-            btn.focus();
-        }
-        menu.setAttribute('aria-hidden', 'true');
+        updateAria(btn, menu, false);
+        if (btn) btn.focus();
         // Recalculate anyOpen and update body classes
         updateGlobalMenuState();
     };
@@ -47,8 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const open = !menu.classList.contains('sidebar-visible');
         menu.classList.toggle('sidebar-visible', open);
         document.body.classList.toggle('sidebar-active', open);
-        btn.setAttribute('aria-expanded', open);
-        menu.setAttribute('aria-hidden', !open);
+        updateAria(btn, menu, open);
 
         if (open) {
             const first = menu.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
@@ -60,12 +61,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const closeMenu = (menu, triggerButton = null) => { // Added triggerButton for focus
         menu.classList.remove('active');
-        menu.setAttribute('aria-hidden', 'true');
         const btn = triggerButton || document.querySelector(`[data-menu-target="${menu.id}"]`);
-        if (btn) {
-            btn.setAttribute('aria-expanded', 'false');
-            if (triggerButton) btn.focus(); // Only focus if we passed the button explicitly
-        }
+        updateAria(btn, menu, false);
+        if (btn && triggerButton) btn.focus(); // Only focus if we passed the button explicitly
         const side = menu.classList.contains('left-panel') ? 'left'
                     : (menu.classList.contains('right-panel') ? 'right' : '');
         if (side) document.body.classList.remove(`menu-open-${side}`);
@@ -95,8 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     : (menu.classList.contains('right-panel') ? 'right' : '');
         const open = !menu.classList.contains('active');
         menu.classList.toggle('active', open);
-        btn.setAttribute('aria-expanded', open);
-        menu.setAttribute('aria-hidden', !open);
+        updateAria(btn, menu, open);
         if (side) document.body.classList.toggle(`menu-open-${side}`, open);
 
         if (open && menu.id === 'language-panel' && typeof primeTranslateLoad === 'function') {

--- a/tests/menuKeyboardNavigationTest.js
+++ b/tests/menuKeyboardNavigationTest.js
@@ -9,11 +9,13 @@ const puppeteer = require('puppeteer');
   await page.keyboard.press('Enter');
   await page.waitForTimeout(300);
   const open = await page.$eval('#consolidated-menu-items', el => el.classList.contains('active'));
+  const ariaOpen = await page.$eval('#consolidated-menu-items', el => el.getAttribute('aria-hidden') === 'false');
+  const btnExpanded = await page.$eval('#consolidated-menu-button', el => el.getAttribute('aria-expanded') === 'true');
   const focusedInside = await page.evaluate(() => {
     const menu = document.getElementById('consolidated-menu-items');
     return menu.contains(document.activeElement);
   });
-  if (!open || !focusedInside) {
+  if (!open || !ariaOpen || !btnExpanded || !focusedInside) {
     console.error('Menu did not open via keyboard');
     await browser.close();
     process.exit(1);
@@ -21,7 +23,9 @@ const puppeteer = require('puppeteer');
   await page.keyboard.press('Escape');
   await page.waitForTimeout(300);
   const closed = await page.$eval('#consolidated-menu-items', el => !el.classList.contains('active'));
-  if (!closed) {
+  const ariaClosed = await page.$eval('#consolidated-menu-items', el => el.getAttribute('aria-hidden') === 'true');
+  const btnCollapsed = await page.$eval('#consolidated-menu-button', el => el.getAttribute('aria-expanded') === 'false');
+  if (!closed || !ariaClosed || !btnCollapsed) {
     console.error('Menu did not close via Escape');
     await browser.close();
     process.exit(1);


### PR DESCRIPTION
## Summary
- DRY up `aria-expanded`/`aria-hidden` logic in `main.js`
- extend keyboard navigation test to verify ARIA attributes

## Testing
- `scripts/setup_environment.sh`
- `npm test` *(fails: TimeoutError waiting for `#google_translate_element`)*
- `node tests/menuKeyboardNavigationTest.js` *(fails: `page.waitForTimeout` not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68555e0edcf0832986be85c55f0bbdad