### PR TITLE
Add ARIA states styling

### DIFF
--- a/assets/css/header/nav.css
+++ b/assets/css/header/nav.css
@@ -229,6 +229,20 @@ body.sidebar-active #sidebar-toggle:hover .bar {
     background-color: var(--epic-purple-emperor); /* Or whatever the X color should be on hover */
 }
 
+/* ARIA states for accessibility */
+#sidebar-toggle[aria-expanded="true"] {
+    background-color: var(--epic-gold-main);
+}
+
+#sidebar-toggle[aria-expanded="true"] .bar {
+    background-color: var(--epic-purple-emperor);
+}
+
+#sidebar[aria-hidden="false"] {
+    border-right-color: var(--epic-gold-main);
+    box-shadow: 3px 0 15px rgba(var(--epic-purple-emperor-rgb), 0.4);
+}
+
 
 #sidebar .logo-link {
     display: block;

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -20,6 +20,19 @@
     color: var(--epic-gold-main);
 }
 
+/* ARIA active states */
+#consolidated-menu-button[aria-expanded="true"],
+#flag-toggle[aria-expanded="true"],
+#admin-menu-button[aria-expanded="true"] {
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+}
+
+.menu-panel[aria-hidden="false"] {
+    border: 2px solid var(--epic-gold-main);
+    box-shadow: 0 0 15px rgba(var(--epic-gold-main-rgb), 0.6);
+}
+
 /* Common styles for both sliding panels */
 .menu-panel {
     position: fixed;

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -100,3 +100,20 @@ Para agilizar la carga se recomienda emplear formatos modernos y limitar las dim
 - Utiliza el script [`scripts/compress_images.sh`](../scripts/compress_images.sh) para generar versiones optimizadas o miniaturas.
 
 Actualmente existen archivos superiores a 2&nbsp;MB en `assets/img/` (por ejemplo `GonzaloTellez.png`), conviene reconvertirlos a WebP o aplicar compresión.
+
+
+## Accesibilidad
+
+Para resaltar los estados activos se emplean los atributos `aria-expanded` y `aria-hidden`.
+Cuando un botón está expandido (`aria-expanded="true"`) o un panel visible
+(`aria-hidden="false"`), se aplican colores variables para mayor contraste.
+
+```css
+#consolidated-menu-button[aria-expanded="true"] {
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+}
+.menu-panel[aria-hidden="false"] {
+    border: 2px solid var(--epic-gold-main);
+}
+```


### PR DESCRIPTION
## Summary
- highlight sidebar and menu elements when aria attributes mark them as active
- use theme colors to style expanded buttons and visible panels
- document the ARIA states in the style guide

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68555e138fbc832995cef905ace59488