### PR TITLE
Add Gemini key warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ python flask_app.py
 
 Esto iniciará la API en `http://localhost:5000`, que puede ejecutarse en paralelo al servidor PHP.
 
+### Configuración rápida de GEMINI_API_KEY
+
+1. Copia `.env.example` a `.env`.
+2. Edita `.env` y reemplaza `your_key` por tu clave real de Gemini.
+3. Ejecuta `source .env` antes de iniciar los servidores.
+
+Si no defines la clave se mostrará un aviso en el panel de administración y las respuestas de IA serán simuladas.
+
 ### Variable de entorno `FLASK_DEBUG`
 
 Establece `FLASK_DEBUG=1` para arrancar la API en modo depuración:

--- a/fragments/admin_header.php
+++ b/fragments/admin_header.php
@@ -1,3 +1,11 @@
+<?php
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
+$geminiNotice = $_SESSION['gemini_api_key_notice'] ?? '';
+if ($geminiNotice) {
+    echo "<div class='notice-error' role='alert'>" . htmlspecialchars($geminiNotice) . "</div>";
+}
+?>
 <div id="cave-mask"></div>
 <img id="header-escudo-overlay" class="hero-escudo" src="/assets/img/escudo.jpg" alt="Escudo de Cerezo de Río Tirón">
 <div id="fixed-header-elements" style="height: var(--header-footer-height);">

--- a/includes/ai_utils.php
+++ b/includes/ai_utils.php
@@ -4,6 +4,9 @@
 require_once __DIR__ . '/env_loader.php';
 // Cargar variables de entorno desde .env
 
+require_once __DIR__ . '/session.php';
+ensure_session_started();
+
 // Read Gemini API settings from environment variables when available
 if (!defined('GEMINI_API_KEY')) {
     $envKey = getenv('GEMINI_API_KEY');
@@ -17,6 +20,11 @@ if (!defined('GEMINI_API_ENDPOINT')) {
 
 if (!defined('AI_UTILS_LOADED')) {
     define('AI_UTILS_LOADED', true);
+}
+
+if (GEMINI_API_KEY === 'YOUR_GEMINI_API_KEY_NOT_SET' || GEMINI_API_KEY === '') {
+    error_log('GEMINI_API_KEY is missing. Using simulator responses.');
+    $_SESSION['gemini_api_key_notice'] = 'La clave de la API de Gemini no está configurada. Las funciones de IA usan un simulador.';
 }
 
 


### PR DESCRIPTION
## Summary
- log a warning if GEMINI_API_KEY isn't configured
- display the warning banner in the admin header
- explain how to set up the Gemini key in the README

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*
- `pytest tests/test_flask_api.py` *(fails: ModuleNotFoundError for flask_app)*

------
https://chatgpt.com/codex/tasks/task_e_68558471ca7c8329bc620ac10280ca3a