### PR TITLE
Add inline AI disclaimers

### DIFF
--- a/fragments/header/ai-drawer.html
+++ b/fragments/header/ai-drawer.html
@@ -10,6 +10,10 @@
         <button id="ia-research-btn">Investigar</button>
         <button id="ia-websearch-btn">Buscar web</button>
     </div>
+    <p class="ai-notice-inline">
+      Texto generado automáticamente. Consulta nuestra
+      <a href="/docs/responsible-ai.md">política de uso de IA</a>.
+    </p>
     <div id="gemini-chat-area" aria-live="polite" tabindex="0"></div>
     <div id="gemini-chat-input-container">
       <input id="gemini-chat-input" type="text" placeholder="Escribe tu consulta...">

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -43,6 +43,10 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                     <button class="lang-btn" data-lang="fr-ai" title="Simular traducción al Francés por IA">Francés (Traducción IA)</button>
                     <button class="lang-btn" data-lang="de-ai" title="Simular traducción al Alemán por IA">Alemán (Traducción IA)</button>
                 </div>
+                <p class="ai-notice-inline">
+                    Texto generado automáticamente. Consulta nuestra
+                    <a href="/docs/responsible-ai.md">política de uso de IA</a>.
+                </p>
                 <article class="content-article"> <!-- Using a generic class for content styling -->
                     <div id="textoPrincipalAtapuerca">
                         <h3><?php editableText('atapuerca_ctx_geo_titulo', $pdo, 'Contexto Geográfico y Geológico'); ?></h3>
@@ -64,6 +68,10 @@ require_once __DIR__ . '/../includes/ai_utils.php';
                 <div class="text-center my-30"> <!-- Contenedor para centrar el botón -->
                     <button id="btnResumenIA" class="cta-button cta-large">Ver Resumen Inteligente</button>
                 </div>
+                <p class="ai-notice-inline">
+                    Texto generado automáticamente. Consulta nuestra
+                    <a href="/docs/responsible-ai.md">política de uso de IA</a>.
+                </p>
                 <div id="resumenIAContenedor">
                     <!-- El resumen generado por IA se insertará aquí -->
                 </div>


### PR DESCRIPTION
## Summary
- note AI use after translation controls
- note AI use after the intelligent summary button
- add same notice to the global AI drawer

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558473ad6083299e6131383bec5b5e