### PR TITLE
Improve testing docs with explicit requirements

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,6 +17,24 @@ ejecutar manualmente el paso correspondiente y repetir la preparación.
 ./scripts/setup_environment.sh
 ```
 
+
+## Dependencias manuales
+
+Si `setup_environment.sh` no está disponible, instala las dependencias básicas:
+
+```bash
+pip install flask
+npm install puppeteer jsdom
+composer install
+```
+
+Todos los paquetes están listados en `requirements.txt` y `package.json`:
+
+```bash
+pip install -r requirements.txt
+npm install
+```
+
 ## Servidor PHP local para Puppeteer
 
 Las pruebas de Puppeteer requieren servir los archivos PHP de forma local. Inicia un servidor en otro terminal antes de lanzar la suite:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   },
   "devDependencies": {
     "puppeteer": "^24.10.2",
+    "jsdom": "^24.0.0",
     "svgo": "^3.3.2",
     "tailwindcss": "^4.1.10"
   },


### PR DESCRIPTION
## Summary
- document manual installation steps for Flask and Node dependencies
- note requirements.txt and package.json installation commands
- add `jsdom` as a dev dependency

## Testing
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py`

------
https://chatgpt.com/codex/tasks/task_e_6855847dd7108329abb286f54c755b32