### PR TITLE
Update test docs after environment setup

### DIFF
--- a/docs/test-results.md
+++ b/docs/test-results.md
@@ -1,7 +1,9 @@
 # Test Results - 2025-06-20
 
 ## `vendor/bin/phpunit`
-34 tests executed with 3 errors and 27 failures. Most failures stem from `php-cgi` not being available and database drivers missing.
+34 tests executed with 3 errors and 19 failures. Tras instalar `php-cgi` y
+`pdo_pgsql` las pruebas que requieren conexión a PostgreSQL siguen fallando
+porque la base de datos no está disponible.
 
 ## `python -m unittest`
 All tests passed.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,6 +40,18 @@ python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py
 npm run test:puppeteer
 ```
 
+### Requisitos adicionales de PHP
+
+Las pruebas de PHP necesitan la interfaz **php-cgi** y la extensión
+**pdo_pgsql** para acceder a la base de datos de pruebas. Instálalas con:
+
+```bash
+sudo apt-get install php-cgi php-pgsql php-xml
+```
+
+Además asegúrate de que un servidor de PostgreSQL esté disponible y las
+credenciales se definan en `.env` antes de lanzar PHPUnit.
+
 
 ## Solucion de problemas
 


### PR DESCRIPTION
## Summary
- document extra PHP requirements in testing guide
- record latest test results

## Testing
- `vendor/bin/phpunit`
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py`
- `npm run test:puppeteer`

------
https://chatgpt.com/codex/tasks/task_e_68559c08c7188329aba4db32dd0f5af4