### PR TITLE
Fix mobile language panel sliding

### DIFF
--- a/assets/css/language-panel.css
+++ b/assets/css/language-panel.css
@@ -18,6 +18,12 @@
     z-index: 1000;
 }
 
+@media (max-width: 480px) {
+    #language-panel {
+        width: 90%;
+    }
+}
+
 #language-panel #google_translate_element {
     margin-bottom: 15px;
     display: none;

--- a/assets/css/menus/language-panel.css
+++ b/assets/css/menus/language-panel.css
@@ -19,6 +19,12 @@
     z-index: 1000;
 }
 
+@media (max-width: 480px) {
+    #language-panel {
+        width: 90%;
+    }
+}
+
 #language-panel.active {
     transform: translateX(0);
     opacity: 1;

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -97,12 +97,7 @@ body.menu-open-right {
 }
 
 @media (max-width: 768px) {
-  body.menu-compressed,
-  body.menu-open-left,
-  body.menu-open-right {
-    transform: none;
-  }
-
+  /* Preserve the compression effect also on small screens */
   #consolidated-menu-items {
     display: none !important;
   }


### PR DESCRIPTION
## Summary
- keep compression effect for slide menus on small screens
- improve language panel width on narrow displays

## Testing
- `npm test --silent` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6855a28621f083299ef1cbc4c128cb35