### PR TITLE
Fix moon mode button

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -235,7 +235,23 @@ document.addEventListener('DOMContentLoaded', () => {
                 icon.classList.toggle('fa-moon', !isDark);
                 icon.classList.toggle('fa-sun', isDark);
             }
-            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    });
+}
+
+    const moonToggle = document.getElementById('moon-toggle');
+    if (moonToggle) {
+        const storedMoon = localStorage.getItem('moon');
+        if (storedMoon === 'on') {
+            document.body.classList.add('luna');
+        }
+        moonToggle.addEventListener('click', () => {
+            const active = document.body.classList.toggle('luna');
+            if (active) {
+                localStorage.setItem('moon', 'on');
+            } else {
+                localStorage.removeItem('moon');
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- add missing moon mode toggle script in `assets/js/main.js`

## Testing
- `vendor/bin/phpunit` *(fails: php-cgi not found)*
- `python3 -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: timeout waiting for selector)*

------
https://chatgpt.com/codex/tasks/task_e_6855a2b9d0c883299074584df51fd8c8