### PR TITLE
Increase header menu transparency

### DIFF
--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -8,7 +8,7 @@
     z-index: 4000;
     /* Combine alabaster texture with a semi-transparent purple overlay */
     height: var(--header-footer-height);
-    background-image: linear-gradient(rgba(var(--epic-purple-emperor-rgb), 0.85), rgba(var(--epic-purple-emperor-rgb), 0.85)), var(--alabaster-background-image);
+    background-image: linear-gradient(rgba(var(--epic-purple-emperor-rgb), 0.6), rgba(var(--epic-purple-emperor-rgb), 0.6)), var(--alabaster-background-image);
     background-size: cover;
     padding: 5px 10px;
     display: flex;
@@ -29,7 +29,7 @@
     left: 0;
     right: 0;
     height: 48px;
-    background: rgba(var(--epic-purple-emperor-rgb), 0.85);
+    background: rgba(var(--epic-purple-emperor-rgb), 0.6);
     z-index: 3000;
 }
 

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -7,7 +7,7 @@
     margin-top: 0; /* Align button with top header */
     z-index: 1005 !important; /* keep above menu */
     padding: 8px 12px; /* Slightly more compact */
-    background-color: rgba(var(--epic-purple-emperor-rgb), 0.66);
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.5);
     color: var(--epic-alabaster-bg);
     border: none;
     border-radius: 5px;
@@ -17,7 +17,7 @@
 }
 
 #consolidated-menu-button:hover {
-    background-color: rgba(var(--epic-purple-emperor-rgb), 0.9);
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.75);
     color: var(--epic-gold-main);
 }
 
@@ -43,7 +43,7 @@
     width: 300px; /* Adjust width as needed */
     max-width: 80%; /* Max width for smaller screens */
     /* Purple translucent backdrop for the sliding menu */
-    background-color: rgba(var(--epic-purple-emperor-rgb), 0.6); /* Semi-transparent purple */
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.5); /* Increased transparency */
     backdrop-filter: blur(5px); /* Blur effect for transparency */
     box-shadow: 0 0 15px rgba(0,0,0,0.2);
     z-index: 1000;
@@ -88,7 +88,7 @@
     width: 100%;
     padding: 10px 12px; /* Compacted */
     margin-bottom: 8px; /* Compacted */
-    background-color: rgba(var(--epic-purple-emperor-rgb), 0.66);
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.5);
     border: 1px solid var(--epic-purple-emperor);
     border-radius: 4px;
     text-align: left;
@@ -100,7 +100,7 @@
 }
 
 .menu-panel .menu-item-button:hover {
-    background-color: rgba(var(--epic-purple-emperor-rgb), 0.9);
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.75);
     color: var(--epic-gold-main);
 }
 

--- a/assets/css/menus/homonexus.css
+++ b/assets/css/menus/homonexus.css
@@ -1,6 +1,6 @@
 /* Homonexus mode styling for a metaphoric AI-human synergy */
 body.homonexus-active #sidebar {
-    background: linear-gradient(135deg, rgba(var(--epic-purple-emperor-rgb),0.95), rgba(var(--epic-gold-secondary-rgb),0.95));
+    background: linear-gradient(135deg, rgba(var(--epic-purple-emperor-rgb),0.85), rgba(var(--epic-gold-secondary-rgb),0.85));
 }
 body.homonexus-active #sidebar .nav-links a {
     color: var(--epic-text-light);

--- a/assets/css/menus/language-panel.css
+++ b/assets/css/menus/language-panel.css
@@ -9,7 +9,7 @@
     max-width: 80%;
     bottom: 0;
     /* Match the menu's purple backdrop for consistency */
-    background-color: rgba(var(--epic-purple-emperor-rgb), 0.9);
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.7);
     backdrop-filter: blur(5px);
     box-shadow: 0 0 15px rgba(0,0,0,0.2);
     padding: 15px;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -60,7 +60,9 @@ body {
 }
 
 header { /* New header for hamburger only */
-    background-color: var(--current-sidebar-bg); /* Match sidebar or be distinct */
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.5); /* Slightly transparent purple */
+    backdrop-filter: blur(5px);
+    color: var(--epic-gold-main);
     padding: 0.5rem 1rem;
     position: fixed; /* Keep it at the top */
     top: 0;
@@ -73,7 +75,7 @@ header { /* New header for hamburger only */
 #menu-toggle {
     background: none;
     border: none;
-    color: var(--current-text);
+    color: var(--epic-gold-main);
     font-size: 2rem;
     cursor: pointer;
     padding: 0.5rem;
@@ -86,7 +88,7 @@ header { /* New header for hamburger only */
     z-index: 1040; /* Debajo del header del menú hamburguesa si es fijo */
     top: 0;
     left: -280px; /* Comienza oculto */
-    background-color: var(--current-sidebar-bg);
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.5);
     color: var(--current-text);
     padding-top: 60px; /* Espacio para el header fijo */
     transition: left 0.3s ease-in-out;
@@ -204,7 +206,7 @@ header { /* New header for hamburger only */
     justify-content: space-between;
     align-items: center;
     padding: 10px 15px;
-    background-color: rgba(var(--epic-purple-emperor-rgb), 0.85); /* Color distintivo para el header del AI */
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.7); /* More transparent for the AI header */
     color: var(--light-text);
     border-bottom: 1px solid var(--old-gold); /* Detalle con el otro color de la paleta */
 }
@@ -338,7 +340,7 @@ header { /* New header for hamburger only */
     gap: 10px; /* Espacio entre la sección de idiomas y la de botones */
 
     /* Estilo visual tipo "cristal" (opcional pero moderno) */
-    background-color: rgba(var(--epic-purple-emperor-rgb), 0.8); /* Tu morado emperador con transparencia */
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.6); /* Increased transparency */
     backdrop-filter: blur(5px);
     padding: 10px;
     border-radius: 8px;


### PR DESCRIPTION
## Summary
- soften header overlay colors
- make menus and language panels more see-through
- lighten homonexus sidebar gradient
- tweak general styles with more translucent purple tones

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6855a2e9d72c83298d41c21258148644