### PR TITLE
Add escudo sound via remote link

### DIFF
--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -101,5 +101,13 @@ body.dark-mode #theme-toggle:hover i {
     left: 50%;
     transform: translate(-50%, -50%);
     z-index: 4010;
-    pointer-events: none;
+    pointer-events: auto;
+}
+#header-escudo-overlay.reveal {
+    animation: escudoReveal 0.6s ease-in-out;
+}
+@keyframes escudoReveal {
+    0% { transform: translate(-50%, -50%) scale(1) rotate(0deg); }
+    50% { transform: translate(-50%, -50%) scale(1.2) rotate(5deg); }
+    100% { transform: translate(-50%, -50%) scale(1) rotate(0deg); }
 }

--- a/assets/js/escudo-reveal.js
+++ b/assets/js/escudo-reveal.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const escudo = document.getElementById('header-escudo-overlay');
+  if (!escudo) return;
+  const audio = new Audio('https://actions.google.com/sounds/v1/cartoon/cartoon_boing.ogg');
+  escudo.addEventListener('click', () => {
+    escudo.classList.remove('reveal');
+    void escudo.offsetWidth; // trigger reflow for replay
+    escudo.classList.add('reveal');
+    audio.currentTime = 0;
+    audio.play().catch(err => console.error('Audio play failed', err));
+  });
+});

--- a/fragments/footer.php
+++ b/fragments/footer.php
@@ -26,6 +26,7 @@
 <script src="/assets/js/parallax.js"></script>
 <script src="/js/lang-bar.js"></script>
 <script src="/assets/js/audio-controller.js"></script>
+<script src="/assets/js/escudo-reveal.js"></script>
 <script defer src="/assets/js/custom-pointer.js"></script>
 <script src="/assets/js/homonexus-toggle.js"></script>
 <script src="/js/layout.js"></script>


### PR DESCRIPTION
## Summary
- make the header escudo clickable and animate on click
- play a short sound from an external source instead of a local mp3

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6855a2564ee08329b0b41c23ccf9d4f6