### PR TITLE
Update test setup docs and add helper script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install project dependencies
         run: ./scripts/setup_environment.sh
+      - name: Install test dependencies
+        run: ./scripts/install_dev_deps.sh
 
       - name: Check internal links
         run: |

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Install dependencies
         run: ./scripts/setup_environment.sh
+      - name: Install test dependencies
+        run: ./scripts/install_dev_deps.sh
 
       - name: Run PHPUnit
         run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Consulta la [guía de index.php](docs/index-guide.md#configuracion-de-los-agente
 - **Composer** 2.x para gestionar las dependencias.
 - **PostgreSQL** 9.6 o superior.
 - **PHPUnit** se instala como dependencia de desarrollo con Composer.
+- Para ejecutar las pruebas necesitas las dependencias de Composer y los paquetes de Python listados en `requirements.txt`. Ejecuta `./scripts/install_dev_deps.sh` para instalarlas.
 
 ### Instalación rápida en Linux
 
@@ -186,6 +187,8 @@ La forma recomendada de instalar todas las dependencias de PHP, Node.js y Python
 ./scripts/setup_environment.sh
 ```
 
+También puedes usar `./scripts/install_dev_deps.sh` para instalar solo las librerías de Composer y los paquetes de Python necesarios para los tests.
+
 Este script comprueba que tu sistema cumpla las versiones mínimas indicadas en la sección [Requisitos](#requisitos). Si alguno de los gestores no está disponible, mostrará una advertencia y continuará con los restantes.
 
 Asegúrate primero de tener instalado **PHP CLI** y **Composer**. En sistemas basados en Debian puedes usar:
@@ -199,10 +202,12 @@ bibliotecas de JavaScript necesarias ejecutando:
 
 ```bash
 composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml
+pip install -r requirements.txt
 ./scripts/setup_frontend_libs.sh
 ```
 
 `composer install` descargará todas las librerías de PHP necesarias, incluido **PHPUnit**, que quedará disponible en `vendor/bin/phpunit`.
+pip install -r requirements.txt
 
 Este proyecto utiliza la librería **league/commonmark** para transformar a HTML los archivos Markdown del blog. La dependencia se instala automáticamente con el comando anterior.
 
@@ -293,9 +298,11 @@ Antes de ejecutar `npm test` o cualquier suite de PHPUnit asegúrate de haber in
 ```bash
 npm install
 composer install
+pip install -r requirements.txt
 ```
 
 Si el repositorio incluye el script `./scripts/setup_environment.sh`, ejecútalo para automatizar la instalación de los paquetes de PHP, Python y Node.
+También puedes usar `./scripts/install_dev_deps.sh` para instalar solo las librerías de Composer y los paquetes de Python necesarios para los tests.
 
 Asegúrate además de tener **Composer** y **PHPUnit** instalados. `PHPUnit` puede utilizarse de forma global o mediante el binario que se genera en `vendor/bin/phpunit` tras `composer install`. Las pruebas no se ejecutarán correctamente sin la interfaz de línea de comandos de PHP (PHP CLI).
 
@@ -314,6 +321,7 @@ php -S localhost:8080
 ```
 
 `composer install` descarga **PHPUnit** en `vendor/bin` y `npm install` instala **Puppeteer**, ambas necesarias para las suites de tests.
+pip install -r requirements.txt
 
 Con las dependencias ya instaladas, ejecuta cada conjunto de tests de forma explícita:
 
@@ -342,6 +350,7 @@ Si las pruebas muestran errores de módulos no encontrados, verifica que las car
 ```bash
 npm install
 composer install
+pip install -r requirements.txt
 ```
 
 Además se proporcionan scripts auxiliares para validar el estado del código:

--- a/scripts/install_dev_deps.sh
+++ b/scripts/install_dev_deps.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+if command -v composer >/dev/null 2>&1; then
+    composer install --no-interaction --prefer-dist
+else
+    echo "Error: Composer not found" >&2
+    exit 1
+fi
+
+if command -v pip >/dev/null 2>&1; then
+    pip install -r requirements.txt
+else
+    echo "Error: pip not found" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- mention Composer and Python deps for tests in README
- add `scripts/install_dev_deps.sh` for Composer and pip install
- reference the new script in CI workflows

## Testing
- `./scripts/check_alt_texts.sh`
- `./check_links_extended.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855b61161208329a002d295b2ee41d3