### PR TITLE
Enable draggable hero shield

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -639,6 +639,15 @@ body.dark-mode .footer .social-links a:focus-visible {
     box-shadow: 0 0 20px var(--epic-gold-main), inset 0 0 15px rgba(var(--epic-text-color-rgb),0.4);
 }
 
+.hero-escudo.draggable {
+    cursor: grab;
+    position: absolute;
+}
+
+.hero-escudo.dragging {
+    cursor: grabbing;
+}
+
 /* Background media within hero sections */
 .hero > img.hero-bg,
 .page-header > img.hero-bg,

--- a/assets/js/escudo-drag.js
+++ b/assets/js/escudo-drag.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const escudo = document.getElementById('header-escudo-overlay');
+  if (!escudo) return;
+
+  escudo.classList.add('draggable');
+
+  let offsetX = 0;
+  let offsetY = 0;
+  let dragging = false;
+
+  const onPointerDown = (e) => {
+    dragging = true;
+    escudo.setPointerCapture(e.pointerId);
+    escudo.classList.add('dragging');
+    const rect = escudo.getBoundingClientRect();
+    offsetX = e.clientX - rect.left;
+    offsetY = e.clientY - rect.top;
+  };
+
+  const onPointerMove = (e) => {
+    if (!dragging) return;
+    const x = e.clientX - offsetX;
+    const y = e.clientY - offsetY;
+    escudo.style.left = `${x}px`;
+    escudo.style.top = `${y}px`;
+  };
+
+  const endDrag = (e) => {
+    if (!dragging) return;
+    dragging = false;
+    escudo.releasePointerCapture(e.pointerId);
+    escudo.classList.remove('dragging');
+  };
+
+  escudo.addEventListener('pointerdown', onPointerDown);
+  escudo.addEventListener('pointermove', onPointerMove);
+  escudo.addEventListener('pointerup', endDrag);
+  escudo.addEventListener('pointercancel', endDrag);
+});

--- a/fragments/footer.php
+++ b/fragments/footer.php
@@ -27,6 +27,7 @@
 <script src="/js/lang-bar.js"></script>
 <script src="/assets/js/audio-controller.js"></script>
 <script src="/assets/js/escudo-reveal.js"></script>
+<script src="/assets/js/escudo-drag.js"></script>
 <script defer src="/assets/js/custom-pointer.js"></script>
 <script src="/assets/js/homonexus-toggle.js"></script>
 <script src="/js/layout.js"></script>


### PR DESCRIPTION
## Summary
- enable drag interactions for the shield overlay
- load the new drag script in the footer
- update epic theme CSS to show grab cursor and use absolute positioning when dragging

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit` *(fails: command not found)*
- `node tests/moonToggleTest.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6855b611f03883299fe8395c2f980996