### PR TITLE
Update testing docs with PHP and Node setup

### DIFF
--- a/docs/test-results.md
+++ b/docs/test-results.md
@@ -11,3 +11,6 @@ All tests passed.
 ## `npm run test:puppeteer`
 The suite failed with a timeout while waiting for `#google_translate_element`.
 
+Consulta la sección [Solución de problemas](testing.md#solucion-de-problemas) de
+la guía de testing para intentar corregir estos fallos.
+

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -52,6 +52,17 @@ sudo apt-get install php-cgi php-pgsql php-xml
 Además asegúrate de que un servidor de PostgreSQL esté disponible y las
 credenciales se definan en `.env` antes de lanzar PHPUnit.
 
+### Dependencias de Node para Puppeteer
+
+Antes de lanzar la suite de interfaz instala las dependencias de Node:
+
+```bash
+npm ci
+```
+
+Esto descargará `puppeteer` y los binarios de Chrome.
+
+
 
 ## Solucion de problemas
 
@@ -60,3 +71,4 @@ credenciales se definan en `.env` antes de lanzar PHPUnit.
 php -S localhost:8080
 ```
 - Si las dependencias fallaron al instalarse, vuelve a lanzar `./scripts/setup_environment.sh`.
+- Si Puppeteer informa que no se encuentra Chromium, ejecuta `npm ci` para reinstalar las dependencias.


### PR DESCRIPTION
## Summary
- document installing `php-cgi` and `pdo_pgsql`
- explain how to install Puppeteer's Node dependencies
- add troubleshooting note about Puppeteer
- link test results page to troubleshooting section

## Testing
- `vendor/bin/phpunit` *(fails: PDOException could not find driver)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py`
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6855ba505bfc8329952523ea49bb9500