### PR TITLE
Add Playwright status check

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,15 @@
   "devDependencies": {
     "puppeteer": "^24.10.2",
     "svgo": "^3.3.2",
-    "tailwindcss": "^4.1.10"
+    "tailwindcss": "^4.1.10",
+    "@playwright/test": "^1.42.1"
   },
   "scripts": {
     "start:php": "sh -c 'php -S localhost:8080 >/dev/null 2>&1 & echo $! > .php_server.pid'",
     "stop:php": "sh -c 'if [ -f .php_server.pid ]; then kill $(cat .php_server.pid); rm .php_server.pid; fi'",
     "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuKeyboardNavigationTest.js",
-    "test": "npm run start:php && npm run test:puppeteer; npm run stop:php",
+    "test:playwright": "playwright test tests/phpRoutes.spec.js",
+    "test": "npm run start:php && npm run test:puppeteer && npm run test:playwright; npm run stop:php",
     "build": "npx tailwindcss -i assets/css/tailwind_base.css -o assets/vendor/css/tailwind.min.css --minify && npx sass assets/scss/custom.scss assets/css/custom.css --no-source-map"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,12 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  webServer: {
+    command: 'php -S localhost:8080',
+    port: 8080,
+    reuseExistingServer: true,
+  },
+  use: {
+    baseURL: 'http://localhost:8080',
+  },
+});

--- a/tests/phpRoutes.spec.js
+++ b/tests/phpRoutes.spec.js
@@ -1,0 +1,25 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+function getPhpRoutes() {
+  const xml = fs.readFileSync(path.join(__dirname, '../sitemap.xml'), 'utf8');
+  const regex = /<loc>https?:\/\/[^<]+(\/[^<]+\.php)<\/loc>/g;
+  const routes = [];
+  let match;
+  while ((match = regex.exec(xml)) !== null) {
+    routes.push(match[1]);
+  }
+  return routes;
+}
+
+const routes = getPhpRoutes();
+
+test.describe('PHP routes return 200', () => {
+  for (const route of routes) {
+    test(`GET ${route}`, async ({ page }) => {
+      const response = await page.goto(route);
+      expect(response.status()).toBe(200);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add Playwright test to verify all PHP routes return status 200
- configure Playwright to start the PHP server automatically
- include Playwright as a dev dependency and run it from `npm test`

## Testing
- `npm run test:playwright` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855bffeba4483298b3d5d9d9efbfa79