### PR TITLE
Add forum agents admin page

### DIFF
--- a/backend/php/admin/forum_agents_admin.php
+++ b/backend/php/admin/forum_agents_admin.php
@@ -1,0 +1,64 @@
+<?php
+require_once __DIR__ . '/../../../includes/session.php';
+ensure_session_started();
+require_once __DIR__ . '/../../../includes/auth.php';
+require_admin_login();
+
+$agents_file = __DIR__ . '/../../../config/forum_agents.php';
+$agents = require $agents_file;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $updatedAgents = [];
+    if (isset($_POST['agent']) && is_array($_POST['agent'])) {
+        foreach ($_POST['agent'] as $id => $data) {
+            $updatedAgents[$id] = [
+                'name' => trim($data['name'] ?? ''),
+                'bio' => trim($data['bio'] ?? ''),
+                'expertise' => trim($data['expertise'] ?? '')
+            ];
+        }
+    }
+
+    $newId = trim($_POST['new_agent_id'] ?? '');
+    if ($newId !== '') {
+        $updatedAgents[$newId] = [
+            'name' => trim($_POST['new_agent_name'] ?? ''),
+            'bio' => trim($_POST['new_agent_bio'] ?? ''),
+            'expertise' => trim($_POST['new_agent_expertise'] ?? '')
+        ];
+    }
+
+    $export = "<?php\nreturn " . var_export($updatedAgents, true) . ";\n";
+    file_put_contents($agents_file, $export);
+    $agents = $updatedAgents;
+    $saved = true;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Administrar Agentes del Foro</title>
+    <link rel="stylesheet" href="/assets/css/admin_theme.css">
+</head>
+<body class="alabaster-bg admin-page">
+<?php if (!empty($saved)) echo '<p class="success">Cambios guardados.</p>'; ?>
+<form method="post">
+    <h1>Editar Agentes Existentes</h1>
+    <?php foreach ($agents as $id => $agent): ?>
+        <fieldset>
+            <legend><?php echo htmlspecialchars($id); ?></legend>
+            <label>Nombre:<br><input type="text" name="agent[<?php echo htmlspecialchars($id); ?>][name]" value="<?php echo htmlspecialchars($agent['name']); ?>"></label><br>
+            <label>Biografía:<br><textarea name="agent[<?php echo htmlspecialchars($id); ?>][bio]" rows="3" cols="40"><?php echo htmlspecialchars($agent['bio']); ?></textarea></label><br>
+            <label>Experiencia:<br><input type="text" name="agent[<?php echo htmlspecialchars($id); ?>][expertise]" value="<?php echo htmlspecialchars($agent['expertise']); ?>"></label>
+        </fieldset>
+    <?php endforeach; ?>
+    <h2>Añadir Nuevo Agente</h2>
+    <label>ID:<br><input type="text" name="new_agent_id"></label><br>
+    <label>Nombre:<br><input type="text" name="new_agent_name"></label><br>
+    <label>Biografía:<br><textarea name="new_agent_bio" rows="3" cols="40"></textarea></label><br>
+    <label>Experiencia:<br><input type="text" name="new_agent_expertise"></label><br>
+    <button type="submit">Guardar</button>
+</form>
+</body>
+</html>

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -174,3 +174,14 @@ el script enfoca `#gemini-chat-area` y permite cerrarlo al pulsar
 3. Recarga los archivos JavaScript y CSS tras realizar los cambios para que
    tengan efecto en la web.
 
+
+## Administración de agentes del foro
+
+Existe una página protegida para modificar el archivo `config/forum_agents.php` de forma sencilla. Se encuentra en `backend/php/admin/forum_agents_admin.php` y solo es accesible tras iniciar sesión como administrador.
+
+1. Abre `/backend/php/admin/forum_agents_admin.php` en tu navegador.
+2. El formulario lista cada agente actual con campos para nombre, biografía y experiencia.
+3. Cambia los datos que necesites y pulsa **Guardar** para actualizar el archivo.
+4. Para añadir un nuevo agente rellena los campos del apartado *Añadir Nuevo Agente* indicando un identificador único.
+
+Al enviar el formulario se regenerará `config/forum_agents.php` con la nueva información.


### PR DESCRIPTION
## Summary
- add simple admin page under `backend/php/admin` for editing forum agents
- document how to use the admin page in `index-guide.md`

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855ca1ea85c832999b0cf7e9785eabf