### PR TITLE
Update testing docs

### DIFF
--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -61,11 +61,7 @@ comprimiéndose hacia el lado opuesto al menú abierto. Al cerrar todos
 los paneles, el script elimina estas clases y la vista vuelve a su
 posición original.
 
-Tras cualquier modificación ejecuta las pruebas de PHP y Python si las dependencias están instaladas:
-```bash
-vendor/bin/phpunit
-python -m unittest tests/test_flask_api.py
-```
+Tras cualquier modificacion consulta la [Guia de Testing](testing.md) para ejecutar las pruebas.
 
 ## Contenedor `#fixed-header-elements`
 Este bloque fijo aparece al inicio de cada página y mantiene visibles los controles principales.

--- a/docs/test-results.md
+++ b/docs/test-results.md
@@ -10,7 +10,6 @@ All tests passed.
 
 ## `npm run test:puppeteer`
 The suite failed with a timeout while waiting for `#google_translate_element`.
+Consulta la [Guia de Testing](testing.md) para revisar el paso a paso y la seccion de solucion de problemas.
 
-Consulta la sección [Solución de problemas](testing.md#solucion-de-problemas) de
-la guía de testing para intentar corregir estos fallos.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,45 +1,27 @@
 # Guía de Testing
 
 Esta guía explica cómo preparar el entorno y ejecutar las pruebas automatizadas del proyecto.
-
-## Configurar el entorno
-
-Antes de lanzar **cualquier** suite de pruebas ejecuta `setup_environment.sh`.
-Este script instala de una sola vez las dependencias de PHP, Python y Node. Si
-detecta que alguna de estas herramientas no está presente intentará instalarla
-mediante `apt-get` (por ejemplo **PHP CLI**, **Composer** o **Node.js 18**).
-El proyecto requiere como mínimo **PHP&nbsp;8.1**, **Node&nbsp;18** y
-**Python&nbsp;3.10**. El propio script comprueba estas versiones y avisa en caso
-de no encontrarlas o si son antiguas. Tras solventar cualquier ausencia podrás
-ejecutar manualmente el paso correspondiente y repetir la preparación.
-
+## Paso a paso
+1. Prepara el entorno y sus dependencias:
 ```bash
 ./scripts/setup_environment.sh
 ```
-
-## Servidor PHP local para Puppeteer
-
-Las pruebas de Puppeteer requieren servir los archivos PHP de forma local. Inicia un servidor en otro terminal antes de lanzar la suite:
-
+2. Si vas a ejecutar la suite de interfaz, abre otro terminal y arranca un servidor PHP local:
 ```bash
 php -S localhost:8080
 ```
-
-## Orden de ejecución de las pruebas
-
-Con las dependencias instaladas y el servidor en marcha, ejecuta las suites en el siguiente orden:
-
+3. Ejecuta las pruebas de PHP:
 ```bash
-# 1. Pruebas de PHP
 vendor/bin/phpunit
-
-# 2. Pruebas de Python
+```
+4. Ejecuta las pruebas de Python:
+```bash
 python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py
-
-# 3. Pruebas de interfaz con Puppeteer
+```
+5. Ejecuta las pruebas de interfaz con Puppeteer:
+```bash
 npm run test:puppeteer
 ```
-
 ### Requisitos adicionales de PHP
 
 Las pruebas de PHP necesitan la interfaz **php-cgi** y la extensión
@@ -72,3 +54,12 @@ php -S localhost:8080
 ```
 - Si las dependencias fallaron al instalarse, vuelve a lanzar `./scripts/setup_environment.sh`.
 - Si Puppeteer informa que no se encuentra Chromium, ejecuta `npm ci` para reinstalar las dependencias.
+## Resultados del 20/06/2025
+
+- `vendor/bin/phpunit`: 34 tests executed with 3 errors and 19 failures. Tras instalar `php-cgi` y `pdo_pgsql` las pruebas que requieren conexión a PostgreSQL siguieron fallando porque la base de datos no estaba disponible.
+
+- `python -m unittest`: todas las pruebas pasaron.
+
+- `npm run test:puppeteer`: la suite falló por un tiempo de espera mientras esperaba `#google_translate_element`.
+
+Consulta la sección [Solucion de problemas](#solucion-de-problemas) para intentar corregir estos fallos.


### PR DESCRIPTION
## Summary
- merge instructions from index-guide and test-results into `docs/testing.md`
- point index docs to the testing guide
- cross-link from test-results to consolidated testing guide

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6855ca2157d483298234363ad4266222