### PR TITLE
Add structure analyzer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Además se proporcionan scripts auxiliares para validar el estado del código:
 - `./check_links.sh` revisa enlaces rotos en las páginas principales.
 - `./check_links_extended.sh` amplía la comprobación a los fragmentos HTML.
 - `./scripts/check_alt_texts.sh` detecta imágenes sin atributo `alt`.
+- `./scripts/structure_analyzer.py` revisa duplicados y la ubicación de etiquetas `<link>` y `<script>`.
 
 ## Elementos del menú principal
 
@@ -387,6 +388,16 @@ Ejecuta el script `check_alt_texts.sh` para detectar imágenes sin atributo `alt
 Esta comprobación se ejecuta automáticamente en cada pull request gracias a la configuración de GitHub Actions.
 
 Puedes indicar una ruta concreta como argumento si solo quieres escanear una carpeta determinada. El comando mostrará las líneas problemáticas y devolverá un código de salida distinto de cero si encuentra imágenes sin descripción.
+
+### Análisis de estructura
+
+Para revisar archivos duplicados y detectar etiquetas mal ubicadas ejecuta:
+
+```bash
+python scripts/structure_analyzer.py
+```
+
+El informe resume los duplicados encontrados y señala si hay `<link>` o `<script>` fuera de su posición recomendada. Complementa las comprobaciones básicas de los demás scripts.
 
 ## Tema predeterminado
 

--- a/scripts/structure_analyzer.py
+++ b/scripts/structure_analyzer.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Analyze repository structure for duplicates and misplaced CSS/JS.
+
+This script scans PHP and HTML files to detect duplicated content and improper
+placement of <link> and <script> tags.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+from collections import defaultdict
+from bs4 import BeautifulSoup
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+FILE_PATTERNS = ["**/*.php", "**/*.html"]
+
+
+def find_files() -> list[Path]:
+    files: list[Path] = []
+    for pattern in FILE_PATTERNS:
+        files.extend(REPO_ROOT.glob(pattern))
+    return files
+
+
+def sha1_of(path: Path) -> str:
+    data = path.read_bytes()
+    return hashlib.sha1(data).hexdigest()
+
+
+def detect_duplicates(paths: list[Path]) -> dict[str, list[Path]]:
+    hashes: dict[str, list[Path]] = defaultdict(list)
+    for p in paths:
+        hashes[sha1_of(p)].append(p)
+    return {h: ps for h, ps in hashes.items() if len(ps) > 1}
+
+
+def repeated_header_footer(paths: list[Path]) -> tuple[list[Path], list[Path]]:
+    header_file = REPO_ROOT / "_header.php"
+    footer_file = REPO_ROOT / "_footer.php"
+    header_content = header_file.read_text(encoding="utf-8", errors="ignore").strip()
+    footer_content = footer_file.read_text(encoding="utf-8", errors="ignore").strip()
+
+    repeated_headers: list[Path] = []
+    repeated_footers: list[Path] = []
+    for p in paths:
+        if p in {header_file, footer_file}:
+            continue
+        text = p.read_text(encoding="utf-8", errors="ignore")
+        if header_content and header_content in text and "_header.php" not in text:
+            repeated_headers.append(p)
+        if footer_content and footer_content in text and "_footer.php" not in text:
+            repeated_footers.append(p)
+    return repeated_headers, repeated_footers
+
+
+def check_css_js_placement(paths: list[Path]) -> dict[str, list[str]]:
+    issues: dict[str, list[str]] = defaultdict(list)
+    for p in paths:
+        content = p.read_text(encoding="utf-8", errors="ignore")
+        soup = BeautifulSoup(content, "html.parser")
+        head = soup.head
+        body = soup.body
+        if not head or not body:
+            continue
+
+        for link in soup.find_all("link"):
+            if link.parent != head:
+                issues[str(p)].append("<link> fuera de <head>")
+                break
+
+        for script in soup.find_all("script"):
+            if script.parent == head:
+                continue
+            if script.parent != body:
+                issues[str(p)].append("<script> fuera de <head> o <body>")
+                break
+            # must be last meaningful element in body
+            siblings = []
+            for s in script.next_siblings:
+                if str(s).strip():
+                    siblings.append(s)
+            if siblings:
+                issues[str(p)].append("<script> no al final de <body>")
+                break
+    return issues
+
+
+def generate_report() -> str:
+    paths = find_files()
+    duplicates = detect_duplicates(paths)
+    repeated_headers, repeated_footers = repeated_header_footer(paths)
+    css_js = check_css_js_placement(paths)
+
+    lines = ["== Duplicados =="]
+    for h, ps in duplicates.items():
+        lines.append(f"Hash {h[:7]}: {', '.join(str(p) for p in ps)}")
+
+    lines.append("\n== Cabeceras repetidas ==")
+    for p in repeated_headers:
+        lines.append(str(p))
+
+    lines.append("\n== Pies repetidos ==")
+    for p in repeated_footers:
+        lines.append(str(p))
+
+    lines.append("\n== CSS/JS mal ubicados ==")
+    for p, msgs in css_js.items():
+        for m in msgs:
+            lines.append(f"{p}: {m}")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    print(generate_report())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `structure_analyzer.py` to scan repo structure
- report duplicate files, repeated headers/footers, and misplaced tags
- document new tool in README

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py`
- `python -m unittest tests/test_graph_db_interface.py`
- `python scripts/structure_analyzer.py | head`

------
https://chatgpt.com/codex/tasks/task_e_6855ca76fdb48329add27420e6e1ade2