### PR TITLE
Switch to npm-managed frontend libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,31 +198,22 @@ Asegúrate primero de tener instalado **PHP CLI** y **Composer**. En sistemas ba
 sudo apt-get install php-cli composer
 ```
 
-Una vez clonado el repositorio instala todas las dependencias de PHP y descarga las
-bibliotecas de JavaScript necesarias ejecutando:
+Una vez clonado el repositorio instala todas las dependencias de PHP, Python y Node ejecutando:
 
 ```bash
 composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xmlwriter --ignore-platform-req=ext-xml
 pip install -r requirements.txt
+npm install
 ./scripts/setup_frontend_libs.sh
 ```
 
 `composer install` descargará todas las librerías de PHP necesarias, incluido **PHPUnit**, que quedará disponible en `vendor/bin/phpunit`.
-pip install -r requirements.txt
 
 Este proyecto utiliza la librería **league/commonmark** para transformar a HTML los archivos Markdown del blog. La dependencia se instala automáticamente con el comando anterior.
 
-El script descarga las bibliotecas **jQuery**, **Bootstrap** y **Tailwind CSS 4.1.10**
-en `assets/vendor`. **Cuando aparezcan nuevas versiones estables** de estas
-dos primeras librerías, actualiza las variables `JQUERY_VERSION` y
-`BOOTSTRAP_VERSION` en `scripts/setup_frontend_libs.sh` antes de volver a
-ejecutar el script. Tras la descarga se genera la hoja
-`assets/vendor/css/tailwind.min.css`.
+El script copia **Bootstrap** y **jQuery** desde `node_modules` a `assets/vendor` y, tras `npm run build`, se genera `assets/vendor/css/tailwind.min.css` mediante Vite.
 
-Ejecuta `npm run build` al instalar el proyecto y cada vez que modifiques
-`tailwind.config.js` o `assets/css/tailwind_base.css`. El script compila
-automáticamente Tailwind y los estilos SCSS para que los cambios se reflejen en
-las hojas finales.
+Ejecuta `npm run build` al instalar el proyecto y cada vez que modifiques `tailwind.config.js` o `assets/css/tailwind_base.css`. El comando usa Vite para compilar Tailwind y los estilos SCSS, dejando los resultados listos en la carpeta `assets/vendor`.
 
 ### Dependencias de npm
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "dependencies": {
-    "sass": "^1.89.2"
+    "sass": "^1.89.2",
+    "bootstrap": "^5.3.7",
+    "jquery": "^3.7.1"
   },
   "devDependencies": {
     "puppeteer": "^24.10.2",
     "svgo": "^3.3.2",
     "tailwindcss": "^4.1.10",
+    "vite": "^6.3.5",
     "@playwright/test": "^1.42.1"
   },
   "scripts": {
@@ -14,6 +17,6 @@
     "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuKeyboardNavigationTest.js",
     "test:playwright": "playwright test tests/phpRoutes.spec.js",
     "test": "npm run start:php && npm run test:puppeteer && npm run test:playwright; npm run stop:php",
-    "build": "npx tailwindcss -i assets/css/tailwind_base.css -o assets/vendor/css/tailwind.min.css --minify && npx sass assets/scss/custom.scss assets/css/custom.css --no-source-map"
+    "build": "vite build && npx sass assets/scss/custom.scss assets/css/custom.css --no-source-map"
   }
 }

--- a/scripts/setup_frontend_libs.sh
+++ b/scripts/setup_frontend_libs.sh
@@ -6,28 +6,16 @@ CSS_DIR="assets/vendor/css"
 
 mkdir -p "$JS_DIR" "$CSS_DIR"
 
-# jQuery
-JQUERY_VERSION="3.7.1"
-JQUERY_URL="https://code.jquery.com/jquery-${JQUERY_VERSION}.min.js"
+npm install bootstrap jquery tailwindcss
 
-curl -L "$JQUERY_URL" -o "$JS_DIR/jquery.min.js"
-
-# Bootstrap
-BOOTSTRAP_VERSION="5.3.7"
-BOOTSTRAP_BASE="https://cdn.jsdelivr.net/npm/bootstrap@${BOOTSTRAP_VERSION}/dist"
-
-curl -L "$BOOTSTRAP_BASE/js/bootstrap.bundle.min.js" -o "$JS_DIR/bootstrap.bundle.min.js"
-curl -L "$BOOTSTRAP_BASE/css/bootstrap.min.css" -o "$CSS_DIR/bootstrap.min.css"
-
-# Tailwind CSS
-TAILWIND_VERSION="4.1.10"
-TAILWIND_URL="https://cdn.jsdelivr.net/npm/tailwindcss@${TAILWIND_VERSION}/tailwind.min.css"
-curl -L "$TAILWIND_URL" -o "$CSS_DIR/tailwind.min.css"
+cp node_modules/jquery/dist/jquery.min.js "$JS_DIR/"
+cp node_modules/bootstrap/dist/js/bootstrap.bundle.min.js "$JS_DIR/"
+cp node_modules/bootstrap/dist/css/bootstrap.min.css "$CSS_DIR/"
 
 cat <<MSG
-Librerías descargadas en:
+Bibliotecas instaladas vía npm y copiadas a:
   - $JS_DIR/jquery.min.js
   - $JS_DIR/bootstrap.bundle.min.js
   - $CSS_DIR/bootstrap.min.css
-  - $CSS_DIR/tailwind.min.css
+Ejecuta 'npm run build' para generar tailwind.min.css
 MSG

--- a/tailwind_entry.js
+++ b/tailwind_entry.js
@@ -1,0 +1,1 @@
+import './assets/css/tailwind_base.css';

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite';
+import tailwindcss from '@tailwindcss/postcss';
+import autoprefixer from 'autoprefixer';
+
+export default defineConfig({
+  css: {
+    postcss: {
+      plugins: [tailwindcss('./tailwind.config.js'), autoprefixer()]
+    }
+  },
+  build: {
+    cssCodeSplit: false,
+    rollupOptions: {
+      input: 'tailwind_entry.js',
+      output: {
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name === 'style.css') return 'css/tailwind.min.css';
+          return assetInfo.name;
+        }
+      }
+    },
+    outDir: 'assets/vendor',
+    emptyOutDir: false
+  }
+});


### PR DESCRIPTION
## Summary
- fetch Bootstrap, jQuery and Tailwind via `npm` in `setup_frontend_libs.sh`
- use Vite to build frontend assets
- document the new build workflow

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6855ca7fa65c8329bf8476e17cd14ea0