### PR TITLE
Add shared theme for React and Svelte demos

### DIFF
--- a/docs/frontend-structure.md
+++ b/docs/frontend-structure.md
@@ -1,0 +1,7 @@
+# Frontend Structure
+
+This directory hosts small demo projects using React and Svelte. All projects import
+`frontend/styles/theme.css` to share the main CSS variables extracted from
+`assets/css/epic_theme.css`.
+
+For colour references see the [style guide](style-guide.md).

--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -1,0 +1,9 @@
+import '../styles/theme.css';
+
+export default function App() {
+  return (
+    <div className="app">
+      <h1 style={{ color: 'var(--epic-gold-main)' }}>React Example</h1>
+    </div>
+  );
+}

--- a/frontend/styles/theme.css
+++ b/frontend/styles/theme.css
@@ -1,0 +1,110 @@
+/* Shared Epic theme variables */
+:root {
+    --epic-error-red: #D9534F; /* Default error red */
+    --epic-purple-emperor: #4A0D67;
+    --epic-purple-emperor-rgb: 74, 13, 103;
+    --epic-gold-main: #CFB53B; /* Old gold tone */
+    --epic-gold-main-rgb: 207, 181, 59;
+    --epic-gold-secondary: #9A6700;
+    --epic-gold-secondary-rgb: 154, 103, 0;
+    --epic-alabaster-bg: #fdfaf6; /* Alabaster white page background */
+    --epic-alabaster-bg-rgb: 253, 250, 246;
+    --epic-alabaster-medium: var(--epic-purple-emperor); /* Maintain purple tone */
+    --epic-alabaster-medium-rgb: var(--epic-purple-emperor-rgb);
+    --epic-text-color: #2c1d12;
+    --epic-text-color-rgb: 44, 29, 18;
+    --epic-text-light: #EAE0C8;
+    --epic-text-light-rgb: 234, 224, 208;
+    /* Legacy color palette names */
+    --color-primario-purpura: var(--epic-purple-emperor);
+    --color-primario-purpura-rgb: var(--epic-purple-emperor-rgb);
+    --color-secundario-dorado: #B8860B;
+    --color-secundario-dorado-rgb: 184, 134, 11;
+    --color-acento-amarillo: var(--epic-gold-main);
+    --color-acento-amarillo-rgb: var(--epic-gold-main-rgb);
+    --color-piedra-clara: var(--epic-text-light);
+    --color-piedra-clara-rgb: var(--epic-text-light-rgb);
+    --color-piedra-media: #D2B48C;
+    --color-piedra-media-rgb: 210, 180, 140;
+    --color-texto-principal: var(--epic-text-color);
+    --color-texto-principal-rgb: var(--epic-text-color-rgb);
+    --color-fondo-pagina: var(--epic-alabaster-bg);
+    --color-fondo-pagina-rgb: var(--epic-alabaster-bg-rgb);
+    --color-negro-contraste: #1A1A1A;
+    --color-negro-contraste-rgb: 26, 26, 26;
+
+    /* Use alabaster tones for all overlay backgrounds */
+    --epic-transparent-overlay-dark: rgba(var(--epic-alabaster-bg-rgb), 0.95);
+    /* Unified 5% transparency across overlays */
+    --epic-transparent-overlay-medium: rgba(var(--epic-alabaster-bg-rgb), 0.95);
+    --epic-transparent-overlay-light: rgba(var(--epic-alabaster-bg-rgb), 0.95);
+    --epic-transparent-black-overlay: rgba(10, 10, 10, 0.75);
+
+    --font-primary: 'Lora', serif;
+    --font-headings: 'Cinzel', serif;
+
+    --global-border-radius: 8px;
+    --global-transition-speed: 0.3s;
+    --global-box-shadow-light: 0 2px 8px rgba(var(--epic-text-color-rgb), 0.1);
+    --global-box-shadow-medium: 0 5px 15px rgba(var(--epic-text-color-rgb), 0.15);
+    --global-box-shadow-dark: 0 8px 25px rgba(var(--epic-text-color-rgb), 0.2);
+    --alabaster-background-image: url('/assets/img/alabastro.jpg');
+    --menu-extra-offset: 60px;
+    --header-footer-height: 60px;
+    /* Altura reservada para la barra de idiomas superior (no usada en el panel lateral) */
+    --language-bar-height: 40px;
+    /* Espacio superior aplicado al menú, ajustado dinámicamente */
+    --menu-top-offset: 0px;
+    /* Additional theme variables for admin dashboard */
+    --epic-purple-hover: #663399;
+    --epic-gray: #6c757d;
+    --epic-gray-dark: #5a6268;
+    --epic-alabaster-light: var(--epic-purple-emperor);
+    --epic-success-bg: #d4edda;
+    --epic-success-text: #155724;
+    --epic-success-border: #c3e6cb;
+    --epic-danger-bg: #f8d7da;
+    --epic-danger-text: #721c24;
+    --epic-danger-border: #f5c6cb;
+    --epic-info-bg: #e2e3e5;
+    --epic-info-text: #383d41;
+    --epic-info-border: #d6d8db;
+    --epic-neutral-border: #ddd;
+    --epic-neutral-bg: #f9f9f9;
+    --epic-highlight-bg: #e7f3ff;
+    --epic-highlight-text: #0056b3;
+    --epic-error-bg: #f2dede;
+    --epic-action-hover: #1e7e34;
+    --epic-input-border: #ccc;
+    --epic-text-muted: #666;
+    --epic-action-bg: #f0fff0;
+    /* Time-based palette variables */
+    --epic-alabaster-dawn: #e5e5e5; /* Soft morning light */
+    --epic-gold-soft: #f3e5ab;      /* Gentle dawn gold */
+    --epic-purple-vibrant: #6b46c1; /* Bright daytime purple */
+    --epic-alabaster-dusk: #efe2d2; /* Warm dusk background */
+    --epic-gold-dusk: #f0b429;      /* Intense dusk gold */
+    --epic-orange-sunset: #f97316;  /* Sunset orange accent */
+    --epic-text-night: #e0e0e0;     /* Light text for night mode */
+    /* Alert variables */
+    --alert-bg: #ffdddd;
+    --alert-border: #ff0000;
+    --alert-text: #d8000c;
+}
+
+body.lang-bar-visible {
+    --menu-top-offset: var(--language-bar-height);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:not(.light-mode) {
+        --epic-alabaster-bg: #252B38;
+        --epic-alabaster-bg-rgb: 37, 43, 56;
+        --epic-alabaster-medium: #2a2f39;
+        --epic-alabaster-medium-rgb: 42, 47, 57;
+        --epic-text-color: #F0F0F0;
+        --epic-text-color-rgb: 240, 240, 240;
+        --epic-text-light: #D8D8D8;
+        --epic-text-light-rgb: 245, 245, 245;
+    }
+}

--- a/frontend/svelte-app/src/App.svelte
+++ b/frontend/svelte-app/src/App.svelte
@@ -1,0 +1,7 @@
+<style global>
+@import '../styles/theme.css';
+</style>
+
+<main>
+  <h1 style="color: var(--epic-gold-main)">Svelte Example</h1>
+</main>


### PR DESCRIPTION
## Summary
- export Epic theme variables to `frontend/styles/theme.css`
- add basic React and Svelte demo apps that import the shared theme
- document the new frontend structure and reference the style guide

## Testing
- `npm test` *(fails: Error: net::ERR_CONNECTION_REFUSED at http://localhost:8080/tests/manual/test_lang.html)*

------
https://chatgpt.com/codex/tasks/task_e_6855ca81241883299ed21433c211797b