### PR TITLE
Add Dockerfile for local dev servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Frontend stage for Astro
+FROM node:20-slim AS frontend
+WORKDIR /app/frontend
+RUN corepack enable
+COPY package.json pnpm-lock.yaml* ./
+RUN pnpm install
+COPY . ./
+EXPOSE 4321
+CMD ["pnpm", "run", "dev", "--host", "0.0.0.0"]
+
+# Backend stage for FastAPI
+FROM python:3.11-slim AS backend
+WORKDIR /app/backend
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend ./
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]
+
+# Development stage
+FROM python:3.11-slim AS development
+WORKDIR /workspace
+# Copy Python environment
+COPY --from=backend /usr/local /usr/local
+# Copy Node environment
+COPY --from=frontend /usr/local /usr/local
+# Copy app sources
+COPY --from=frontend /app/frontend ./frontend
+COPY --from=backend /app/backend ./backend
+EXPOSE 4321 8000
+CMD sh -c "cd frontend && pnpm run dev --host 0.0.0.0 & cd ../backend && uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 && wait"

--- a/README.md
+++ b/README.md
@@ -179,6 +179,22 @@ python flask_app.py
 ```
 
 Si no defines la variable, `flask_app.py` ejecutará `app.run(debug=False)` por defecto.
+### Entorno de desarrollo con Docker
+
+Se proporciona un `Dockerfile` para lanzar de manera conjunta el frontend en Astro y la API desarrollada con FastAPI. Construye la imagen con:
+
+```bash
+docker build -t condado-dev .
+```
+
+Después ejecuta la imagen exponiendo los puertos de cada servicio:
+
+```bash
+docker run --rm -p 4321:4321 -p 8000:8000 condado-dev
+```
+
+El frontend quedará disponible en `http://localhost:4321` y la API en `http://localhost:8000`.
+
 
 ## Instalación de dependencias
 


### PR DESCRIPTION
## Summary
- create Dockerfile with Astro and FastAPI stages
- document Docker development setup in README

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6855ca4244bc8329abd862349f4b3265