### PR TITLE
Add help panel widget

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -67,3 +67,54 @@ body {
 .text-epic-light { color: var(--epic-text-light); }
 .text-epic-gold { color: var(--epic-gold-main); }
 .border-epic-purple { border-color: var(--epic-purple-emperor); }
+
+/* help toggle and panel */
+#help-toggle {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.8);
+    color: var(--epic-gold-main);
+    font-size: 1.5rem;
+    border-radius: 50%;
+    cursor: pointer;
+    z-index: 1100;
+}
+
+#help-panel {
+    position: fixed;
+    bottom: 80px;
+    right: 20px;
+    max-width: 300px;
+    background-color: rgba(var(--epic-alabaster-bg-rgb), 0.95);
+    border: 2px solid var(--epic-gold-main);
+    box-shadow: var(--global-box-shadow-dark);
+    padding: 1em;
+    border-radius: var(--global-border-radius);
+    color: var(--epic-text-color);
+    z-index: 1100;
+}
+
+#help-panel.hidden {
+    display: none;
+}
+
+#help-panel h2 {
+    margin-top: 0;
+    color: var(--epic-purple-emperor);
+    font-size: 1.2rem;
+}
+
+#help-close {
+    float: right;
+    background: none;
+    border: none;
+    color: var(--epic-purple-emperor);
+    font-size: 1.2rem;
+    cursor: pointer;
+}

--- a/assets/js/help.js
+++ b/assets/js/help.js
@@ -1,0 +1,30 @@
+// assets/js/help.js - simple help panel toggle
+
+document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('help-toggle');
+    const panel = document.getElementById('help-panel');
+
+    if (!toggle || !panel) return;
+
+    const applyState = () => {
+        const closed = sessionStorage.getItem('helpClosed') === 'true';
+        panel.classList.toggle('hidden', closed);
+        toggle.setAttribute('aria-expanded', (!closed).toString());
+        panel.setAttribute('aria-hidden', closed.toString());
+    };
+
+    applyState();
+
+    const togglePanel = () => {
+        const currentlyHidden = panel.classList.contains('hidden');
+        panel.classList.toggle('hidden');
+        const hidden = !currentlyHidden;
+        sessionStorage.setItem('helpClosed', hidden.toString());
+        toggle.setAttribute('aria-expanded', (!hidden).toString());
+        panel.setAttribute('aria-hidden', hidden.toString());
+    };
+
+    toggle.addEventListener('click', togglePanel);
+    const closeBtn = document.getElementById('help-close');
+    if (closeBtn) closeBtn.addEventListener('click', togglePanel);
+});

--- a/fragments/footer.php
+++ b/fragments/footer.php
@@ -19,6 +19,16 @@
         <p class="ai-notice">Este sitio incluye contenido generado con ayuda de IA. <a href="/docs/responsible-ai.md">Más información</a>.</p>
 </div>
 </footer>
+<div id="help-toggle" aria-expanded="false" aria-controls="help-panel" title="Ayuda">?</div>
+<div id="help-panel" class="hidden" aria-hidden="true">
+    <button id="help-close" aria-label="Cerrar ayuda">&times;</button>
+    <h2>Consejos rápidos</h2>
+    <ul>
+        <li>Explora las secciones desde el menú principal.</li>
+        <li>Visita el foro para compartir con la comunidad.</li>
+        <li>Consulta la agenda de eventos culturales.</li>
+    </ul>
+</div>
 <script src="/assets/js/main.js"></script>
 <script src="/assets/js/cave_mask.js"></script>
 <script src="/assets/js/hero.js"></script>
@@ -31,3 +41,4 @@
 <script defer src="/assets/js/custom-pointer.js"></script>
 <script src="/assets/js/homonexus-toggle.js"></script>
 <script src="/js/layout.js"></script>
+<script src="/assets/js/help.js"></script>


### PR DESCRIPTION
## Summary
- show a '?' button and help panel in the footer fragment
- persist help panel state in sessionStorage via new `help.js`
- style help widget using alabaster, purple and gold

## Testing
- `python -m unittest tests/test_flask_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856b6b097648329aa18a7dd3716c0a0