### PR TITLE
Add dynamic table of contents support

### DIFF
--- a/assets/js/toc-generator.js
+++ b/assets/js/toc-generator.js
@@ -1,0 +1,42 @@
+(function(){
+  function slugify(text){
+    return text.toString().toLowerCase()
+      .trim()
+      .replace(/\s+/g,'-')
+      .replace(/[^\w\-]+/g,'')
+      .replace(/\-\-+/g,'-');
+  }
+
+  window.generateTOC = function(options={}){
+    const content = document.querySelector(options.contentSelector || 'main');
+    if(!content) return;
+    const headings = content.querySelectorAll(options.headingSelector || 'h2, h3, h4');
+    if(!headings.length) return;
+
+    const toc = document.createElement('nav');
+    toc.className = options.containerClass || 'bg-white/80 backdrop-blur-md p-4 rounded shadow-md text-sm';
+    const list = document.createElement('ul');
+    list.className = 'space-y-2';
+
+    headings.forEach(h => {
+      if(!h.id) h.id = slugify(h.textContent);
+      const depth = parseInt(h.tagName.substring(1)) - 2;
+      const item = document.createElement('li');
+      item.className = depth>0 ? `ml-${depth*2}` : '';
+      const link = document.createElement('a');
+      link.href = '#'+h.id;
+      link.textContent = h.textContent;
+      link.className = 'text-purple hover:text-old-gold';
+      item.appendChild(link);
+      list.appendChild(item);
+    });
+
+    toc.appendChild(list);
+    const target = document.querySelector(options.targetSelector || '#toc');
+    if(target){
+      target.appendChild(toc);
+    } else {
+      content.prepend(toc);
+    }
+  };
+})();

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -18,6 +18,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `js/museo-2d-gallery.js` | Logic for the collaborative museum 2D gallery including uploads and modals. |
 | `js/museo-3d-main.js` | Initializes the 3D museum viewer built on Three.js. |
 | `js/museum-3d/` | Additional modules used by the 3D viewer. |
+| `assets/js/toc-generator.js` | Builds a table of contents from headings inside `<main>` and injects a list of links styled with Tailwind. |
 
 Deprecated or merged scripts such as `js/menu-controller.js` and `js/sliding-menu.js` have been removed in favour of `assets/js/main.js`. The old header loading helper was also dropped as noted in the project README.
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -122,3 +122,10 @@ Cuando un botón está expandido (`aria-expanded="true"`) o un panel visible
     border: 2px solid var(--epic-gold-main);
 }
 ```
+
+## Desplazamiento Suave
+
+Todas las páginas emplean la regla `scroll-behavior: smooth;` definida en
+`assets/css/epic_theme.css`. Basta con incluir una lista de enlaces internos,
+como el índice generado por `toc-generator.js`, para que los saltos entre
+secciones realicen una animación de desplazamiento fluida.

--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -31,6 +31,7 @@ require_once __DIR__ . '/../includes/ai_utils.php';
         </div>
     </header>
     <main>
+        <div id="toc" class="container-epic my-8"></div>
         <section class="section alternate-bg">
             <div class="container-epic">
                 <h2 class="section-title"><?php editableText('atapuerca_titulo_seccion', $pdo, 'Un Tesoro de la Prehistoria'); ?></h2>
@@ -99,6 +100,8 @@ require_once __DIR__ . '/../includes/ai_utils.php';
         </section>
     </main>
 <?php require_once __DIR__ . '/../fragments/footer.php'; ?>
+<script src="/assets/js/toc-generator.js"></script>
+<script>document.addEventListener('DOMContentLoaded', () => generateTOC());</script>
     
         <script>
         document.addEventListener('DOMContentLoaded', function() {

--- a/historia/historia.php
+++ b/historia/historia.php
@@ -15,6 +15,7 @@
     </header>
 
     <main>
+        <div id="toc" class="container-epic my-8"></div>
         <section class="section timeline-section alternate-bg">
             <div class="container-epic">
                 <h2 class="section-title gradient-text">Un Viaje Milenario</h2>
@@ -139,6 +140,8 @@
     </main>
 
     <?php require_once __DIR__ . '/../fragments/footer.php'; ?>
+    <script src="/assets/js/toc-generator.js"></script>
+    <script>document.addEventListener('DOMContentLoaded', () => generateTOC());</script>
     
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create `toc-generator.js` module to build an index from page headings
- use the new TOC on Historia and Atapuerca pages
- document smooth scrolling behavior
- list the new module in the JS overview

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856b68e0134832992588140effc33fa