### PR TITLE
Add Astro museum page

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,15 @@ docker-compose up --build
 ```
 
 Consulta el archivo [docker-compose.yml](docker-compose.yml) para conocer los servicios disponibles.
+
+## Museo en Astro
+
+Se añadió una página experimental en `frontend/astro-app` que usa **Astro** y **TailwindCSS** para mostrar las piezas del museo definidas en `museo/piezas.json`.
+Para ejecutarla:
+
+```bash
+npm install
+npm run dev:astro
+```
+
+La página principal se genera en `/piezas` y presenta las piezas en una cuadrícula adaptable.

--- a/frontend/astro-app/astro.config.mjs
+++ b/frontend/astro-app/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import tailwind from '@astrojs/tailwind';
+
+export default defineConfig({
+  integrations: [tailwind()],
+  outDir: '../../dist/astro'
+});

--- a/frontend/astro-app/package.json
+++ b/frontend/astro-app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "astro-app",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  }
+}

--- a/frontend/astro-app/src/pages/piezas.astro
+++ b/frontend/astro-app/src/pages/piezas.astro
@@ -1,0 +1,23 @@
+---
+import piezas from '../../../museo/piezas.json';
+---
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Piezas del Museo</title>
+  </head>
+  <body class="min-h-screen bg-white font-sans p-4">
+    <h1 class="text-2xl font-bold mb-4 text-purple">Piezas del Museo</h1>
+    <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+      {piezas.map((pieza) => (
+        <div class="border rounded shadow p-2 bg-white/80" key={pieza.id}>
+          <img src={pieza.imagen} alt={pieza.titulo} class="w-full h-48 object-cover mb-2" />
+          <h2 class="text-lg font-semibold text-purple mb-1">{pieza.titulo}</h2>
+          <p class="text-sm mb-2">{pieza.descripcion}</p>
+          <a class="text-old-gold underline" href={pieza.enlace}>Más info</a>
+        </div>
+      ))}
+    </div>
+  </body>
+</html>

--- a/frontend/astro-app/tailwind.config.mjs
+++ b/frontend/astro-app/tailwind.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'tailwindcss';
+import preset from '../../tailwind.config.js';
+export default defineConfig({
+  presets: [preset],
+  content: ['src/**/*.{astro,html,js}'],
+});

--- a/museo/piezas.json
+++ b/museo/piezas.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": 1,
+    "imagen": "/assets/img/105296723_3444421175570910_9131546571639445898_n.jpg",
+    "titulo": "Vasija Romana",
+    "descripcion": "Una pieza de cerámica hallada en excavaciones locales.",
+    "enlace": "#"
+  },
+  {
+    "id": 2,
+    "imagen": "/assets/img/143348269_4069420249737663_313454645275625753_n.jpg",
+    "titulo": "Moneda Antígua",
+    "descripcion": "Ejemplo de moneda utilizada en el comercio medieval.",
+    "enlace": "#"
+  },
+  {
+    "id": 3,
+    "imagen": "/assets/img/30832168158_2671f1b853_c.jpg",
+    "titulo": "Herramienta Prehistórica",
+    "descripcion": "Instrumento utilizado por los primeros asentamientos.",
+    "enlace": "#"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "svgo": "^3.3.2",
     "tailwindcss": "^4.1.10",
     "vite": "^6.3.5",
-    "@playwright/test": "^1.42.1"
+    "@playwright/test": "^1.42.1",
+    "astro": "^5.10.0",
+    "@astrojs/tailwind": "^6.0.2"
   },
   "scripts": {
     "start:php": "sh -c 'php -S localhost:8080 >/dev/null 2>&1 & echo $! > .php_server.pid'",
@@ -17,6 +19,8 @@
     "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuKeyboardNavigationTest.js",
     "test:playwright": "playwright test tests/phpRoutes.spec.js",
     "test": "npm run start:php && npm run test:puppeteer && npm run test:playwright; npm run stop:php",
-    "build": "vite build && npx sass assets/scss/custom.scss assets/css/custom.css --no-source-map"
+    "build": "vite build && npx sass assets/scss/custom.scss assets/css/custom.css --no-source-map",
+    "dev:astro": "astro dev",
+    "build:astro": "astro build"
   }
 }


### PR DESCRIPTION
## Summary
- add minimal Astro setup under `frontend/astro-app`
- show museum pieces from new `museo/piezas.json` in responsive grid
- update package.json with Astro and Tailwind plugins
- document Astro usage in README

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856b69cd0648329868ea5fb3e2e6098