### PR TITLE
Add Astro timeline component

### DIFF
--- a/frontend/astro-app/events.json
+++ b/frontend/astro-app/events.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": 1,
+    "title": "Fundación de Auca Patricia",
+    "date": "74",
+    "epoch": "Antigüedad",
+    "description": "Orígenes romanos de la actual Cerezo de Río Tirón."
+  },
+  {
+    "id": 2,
+    "title": "Construcción del Alcázar de Cerasio",
+    "date": "720",
+    "epoch": "Medievo",
+    "description": "La fortaleza de alabastro que dominó el valle."
+  },
+  {
+    "id": 3,
+    "title": "Unión con el Condado de Lantarón",
+    "date": "860",
+    "epoch": "Medievo",
+    "description": "Cerezo se convierte en núcleo de poder castellano."
+  }
+]

--- a/frontend/astro-app/src/components/Timeline.svelte
+++ b/frontend/astro-app/src/components/Timeline.svelte
@@ -1,0 +1,57 @@
+<script>
+  import events from '../../events.json';
+  let epochs = Array.from(new Set(events.map(e => e.epoch)));
+  let activeEpoch = epochs[0];
+  function scrollToId(id) {
+    const el = document.getElementById(id);
+    if (el) el.scrollIntoView({ behavior: 'smooth' });
+  }
+</script>
+
+<style>
+  .timeline-container {
+    background: var(--epic-alabaster-bg);
+    color: var(--color-piedra-clara, #EAE0C8);
+    padding: 1rem;
+  }
+  .epoch-button {
+    background: var(--epic-purple-emperor);
+    color: var(--epic-gold-main);
+    margin-right: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.3s ease;
+  }
+  .epoch-button.active {
+    transform: scale(1.1);
+  }
+  .event-title {
+    font-weight: bold;
+    background: linear-gradient(90deg, var(--epic-gold-main), var(--epic-purple-emperor));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+  .event-item {
+    margin-bottom: 1rem;
+  }
+</style>
+
+<div class="timeline-container">
+  <div>
+    {#each epochs as epoch}
+      <button
+        class="epoch-button {activeEpoch === epoch ? 'active' : ''}"
+        on:click={() => { activeEpoch = epoch; scrollToId(epoch); }}>
+        {epoch}
+      </button>
+    {/each}
+  </div>
+
+  {#each events.filter(e => e.epoch === activeEpoch) as event}
+    <div id={event.id} class="event-item">
+      <h2 class="event-title">{event.date} – {event.title}</h2>
+      <p>{event.description}</p>
+    </div>
+  {/each}
+</div>

--- a/frontend/astro-app/src/pages/index.astro
+++ b/frontend/astro-app/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+import Timeline from '../components/Timeline.svelte';
+---
+<html>
+  <head>
+    <link rel="stylesheet" href="../../styles/theme.css" />
+  </head>
+  <body>
+    <Timeline />
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "start:php": "sh -c 'php -S localhost:8080 >/dev/null 2>&1 & echo $! > .php_server.pid'",
     "stop:php": "sh -c 'if [ -f .php_server.pid ]; then kill $(cat .php_server.pid); rm .php_server.pid; fi'",
-    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuKeyboardNavigationTest.js",
+    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuKeyboardNavigationTest.js && node tests/timelineDataTest.js",
     "test:playwright": "playwright test tests/phpRoutes.spec.js",
     "test": "npm run start:php && npm run test:puppeteer && npm run test:playwright; npm run stop:php",
     "build": "vite build && npx sass assets/scss/custom.scss assets/css/custom.css --no-source-map"

--- a/tests/timelineDataTest.js
+++ b/tests/timelineDataTest.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const dataPath = path.join(__dirname, '../frontend/astro-app/events.json');
+try {
+  const raw = fs.readFileSync(dataPath, 'utf8');
+  const events = JSON.parse(raw);
+  if (!Array.isArray(events) || events.length === 0) {
+    throw new Error('Event array is empty');
+  }
+  for (const event of events) {
+    if (!event.title || !event.date || !event.epoch) {
+      throw new Error('Missing required event fields');
+    }
+  }
+  console.log('Timeline events loaded correctly');
+} catch (err) {
+  console.error('Timeline data error:', err.message);
+  process.exit(1);
+}
+


### PR DESCRIPTION
## Summary
- implement `Timeline.svelte` for Astro demo
- load event data from `events.json`
- wire up Astro page to display timeline
- verify timeline data via new Node test
- extend npm script to run the new test

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:8080/tests/manual/test_lang.html)*

------
https://chatgpt.com/codex/tasks/task_e_6856b69dfa2483299055d0a2846eb0e4