### PR TITLE
Add localized Astro app

### DIFF
--- a/frontend/astro-app/README.md
+++ b/frontend/astro-app/README.md
@@ -1,0 +1,14 @@
+# Astro App
+
+Este proyecto es una aplicación básica creada manualmente con Astro, TypeScript y TailwindCSS. Proporciona páginas localizadas en español (`/`), inglés (`/en/`) y gallego (`/gl/`).
+
+## Scripts
+
+- `npm install` – instala las dependencias.
+- `npm run dev` – inicia el servidor de desarrollo.
+- `npm run build` – genera la versión estática en `dist/`.
+- `npm run preview` – sirve los archivos generados.
+
+## Notas
+
+El proyecto usa TailwindCSS con una paleta que incluye tonos morado y oro viejo, y aplica un fondo alabastro en `body`. Los textos principales usan un degradado definido con la clase `text-gradient`.

--- a/frontend/astro-app/astro.config.mjs
+++ b/frontend/astro-app/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import tailwind from '@astrojs/tailwind';
+
+export default defineConfig({
+  integrations: [tailwind()],
+  outDir: '../dist/astro-app'
+});

--- a/frontend/astro-app/package.json
+++ b/frontend/astro-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "astro-app",
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.12",
+    "postcss": "^8.4.16"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/frontend/astro-app/postcss.config.cjs
+++ b/frontend/astro-app/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/astro-app/src/env.d.ts
+++ b/frontend/astro-app/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/frontend/astro-app/src/layouts/BaseLayout.astro
+++ b/frontend/astro-app/src/layouts/BaseLayout.astro
@@ -1,0 +1,19 @@
+---
+export interface Props { title: string }
+const { title } = Astro.props;
+import '../styles/global.css';
+---
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+  </head>
+  <body class="min-h-screen bg-white text-gray-900">
+    <slot name="nav" />
+    <main class="p-4">
+      <slot />
+    </main>
+  </body>
+</html>

--- a/frontend/astro-app/src/pages/en/index.astro
+++ b/frontend/astro-app/src/pages/en/index.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+<BaseLayout title="Welcome">
+  <h1 class="text-gradient text-4xl mb-4">Welcome to Cerezo de Río Tirón</h1>
+  <p>Discover its heritage.</p>
+  <ul class="mt-4 space-x-4">
+    <li><a href="/">Español</a></li>
+    <li><a href="/gl/">Galego</a></li>
+  </ul>
+</BaseLayout>

--- a/frontend/astro-app/src/pages/gl/index.astro
+++ b/frontend/astro-app/src/pages/gl/index.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+<BaseLayout title="Benvido">
+  <h1 class="text-gradient text-4xl mb-4">Benvido a Cerezo de Río Tirón</h1>
+  <p>Descobre o seu patrimonio.</p>
+  <ul class="mt-4 space-x-4">
+    <li><a href="/">Español</a></li>
+    <li><a href="/en/">English</a></li>
+  </ul>
+</BaseLayout>

--- a/frontend/astro-app/src/pages/index.astro
+++ b/frontend/astro-app/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+<BaseLayout title="Condado de Castilla">
+  <h1 class="text-gradient text-4xl mb-4">Bienvenido a Cerezo de Río Tirón</h1>
+  <p>Descubre su historia y patrimonio.</p>
+  <ul class="mt-4 space-x-4">
+    <li><a href="/en/">English</a></li>
+    <li><a href="/gl/">Galego</a></li>
+  </ul>
+</BaseLayout>

--- a/frontend/astro-app/src/styles/global.css
+++ b/frontend/astro-app/src/styles/global.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-[#faf7f4];
+}
+
+.text-gradient {
+  @apply bg-gradient-to-r from-purple to-oldgold text-transparent bg-clip-text font-bold;
+}

--- a/frontend/astro-app/tailwind.config.cjs
+++ b/frontend/astro-app/tailwind.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  content: ['./src/**/*.{astro,html,js,jsx,ts,tsx,vue}'],
+  theme: {
+    extend: {
+      colors: {
+        purple: '#6b21a8',
+        oldgold: '#cfb53b'
+      }
+    }
+  },
+  plugins: []
+};

--- a/frontend/astro-app/tsconfig.json
+++ b/frontend/astro-app/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Astro app manually with TypeScript and Tailwind
- add localized pages for `/`, `/en/`, and `/gl/`
- document build and run instructions

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856b6a40dcc8329bf44e93603bfa9e4