### PR TITLE
Improve theme toggle accessibility

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -2536,6 +2536,16 @@ body.dark-mode #overlay-content {
     background-color: var(--epic-alabaster-medium); /* Uses the dark mode version of --epic-alabaster-medium, e.g., #2a2f39 */
 }
 
+/* Smooth theme toggle transitions */
+#theme-toggle {
+    transition: color var(--global-transition-speed) ease-in-out,
+                background-color var(--global-transition-speed) ease-in-out;
+}
+
+#theme-toggle i {
+    transition: color var(--global-transition-speed) ease-in-out;
+}
+
 body.dark-mode #theme-toggle i {
     color: var(--epic-icon-color);
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -218,26 +218,33 @@ document.addEventListener('DOMContentLoaded', () => {
     if (themeToggle) {
         const icon = themeToggle.querySelector('i');
         const storedTheme = localStorage.getItem('theme');
-        if (storedTheme === 'dark' || !storedTheme) {
+        let activeTheme = storedTheme;
+        if (!activeTheme) {
+            activeTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+
+        if (activeTheme === 'dark') {
             document.body.classList.add('dark-mode');
             if (icon) {
                 icon.classList.remove('fa-moon');
                 icon.classList.add('fa-sun');
             }
-            if (!storedTheme) {
-                localStorage.setItem('theme', 'dark');
-            }
         }
+        themeToggle.setAttribute('aria-pressed', activeTheme === 'dark' ? 'true' : 'false');
+        if (!storedTheme) {
+            localStorage.setItem('theme', activeTheme);
+        }
+
         themeToggle.addEventListener('click', () => {
-            document.body.classList.toggle('dark-mode');
-            const isDark = document.body.classList.contains('dark-mode');
+            const isDark = document.body.classList.toggle('dark-mode');
             if (icon) {
                 icon.classList.toggle('fa-moon', !isDark);
                 icon.classList.toggle('fa-sun', isDark);
             }
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    });
-}
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            themeToggle.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+        });
+    }
 
     const moonToggle = document.getElementById('moon-toggle');
     if (moonToggle) {


### PR DESCRIPTION
## Summary
- add smooth transition styles for theme switch button
- respect prefers-color-scheme when no stored theme
- toggle `aria-pressed` state on theme button

## Testing
- `npm test --silent` *(fails: Error: net::ERR_CONNECTION_REFUSED at http://localhost:8080/tests/manual/test_lang.html)*

------
https://chatgpt.com/codex/tasks/task_e_6856b6b4e738832981cbc73b8c33a232