### PR TITLE
Add translation fallback

### DIFF
--- a/historia/atapuerca.php
+++ b/historia/atapuerca.php
@@ -8,6 +8,7 @@ if (session_status() == PHP_SESSION_NONE) {
 }
 // Asumimos que db_connect.php establece $pdo
 require_once __DIR__ . '/../includes/db_connect.php';
+require_once __DIR__ . '/../includes/i18n.php';
 /** @var PDO $pdo */
 if (!$pdo) {
     echo "<p class='db-warning'>Contenido en modo lectura: base de datos no disponible.</p>";
@@ -169,17 +170,11 @@ require_once __DIR__ . '/../includes/ai_utils.php';
         // Preparar los textos de placeholder para cada idioma usando PHP
         // Esto se hace una vez al cargar la página para tenerlos listos en JS
         <?php
-            // Asegurarse de que la función existe antes de llamarla
             $translation_placeholders = [];
-            if (function_exists('translate_with_gemini')) {
-                // Para la demostración, no necesitamos pasar el texto original completo aquí,
-                // la función translate_with_gemini ya tiene una lógica de snippet.
-                // Usaremos un content_id genérico para Atapuerca.
-                $original_text_snippet_for_demo = "Contenido original de la página de Atapuerca..."; // Un snippet muy corto o incluso vacío
-                $translation_placeholders['en-ai'] = translate_with_gemini('atapuerca_main_content', 'en-ai', $original_text_snippet_for_demo);
-                $translation_placeholders['fr-ai'] = translate_with_gemini('atapuerca_main_content', 'fr-ai', $original_text_snippet_for_demo);
-                $translation_placeholders['de-ai'] = translate_with_gemini('atapuerca_main_content', 'de-ai', $original_text_snippet_for_demo);
-            }
+            $sample = "Contenido original de la página de Atapuerca...";
+            $translation_placeholders['en-ai'] = translate_or_lookup('atapuerca_main_content', $sample, 'en-ai');
+            $translation_placeholders['fr-ai'] = translate_or_lookup('atapuerca_main_content', $sample, 'fr-ai');
+            $translation_placeholders['de-ai'] = translate_or_lookup('atapuerca_main_content', $sample, 'de-ai');
         ?>
         const translations = <?php echo json_encode($translation_placeholders); ?>;
 

--- a/includes/i18n.php
+++ b/includes/i18n.php
@@ -1,14 +1,76 @@
 <?php
-function t(string $key): string {
-    static $catalog = null;
-    if ($catalog === null) {
-        $lang = $_GET['lang'] ?? 'es';
+/**
+ * Retrieve a translation for the given key and language.
+ * Falls back to the key itself when missing and records
+ * untranslated keys for later processing.
+ */
+function t(string $key, ?string $lang = null): string {
+    static $catalogs = [];
+
+    $lang = $lang ?? ($_GET['lang'] ?? 'es');
+    if (!isset($catalogs[$lang])) {
         $path = __DIR__ . '/../i18n/' . $lang . '.json';
         if (!file_exists($path)) {
             $path = __DIR__ . '/../i18n/es.json';
         }
         $json = file_get_contents($path);
-        $catalog = json_decode($json, true) ?: [];
+        $catalogs[$lang] = json_decode($json, true) ?: [];
     }
-    return $catalog[$key] ?? $key;
+
+    if (array_key_exists($key, $catalogs[$lang])) {
+        return $catalogs[$lang][$key];
+    }
+
+    mark_untranslated($key, $lang);
+    return $key;
+}
+
+/** @var array<string,array<string,bool>> */
+$untranslated_keys = [];
+
+function mark_untranslated(string $key, string $lang): void {
+    global $untranslated_keys;
+    if (!isset($untranslated_keys[$lang])) {
+        $untranslated_keys[$lang] = [];
+    }
+    $untranslated_keys[$lang][$key] = true;
+}
+
+function _save_untranslated_keys(): void {
+    global $untranslated_keys;
+    if (empty($untranslated_keys)) {
+        return;
+    }
+
+    $path = __DIR__ . '/../i18n/untranslated_keys.json';
+    $existing = [];
+    if (file_exists($path)) {
+        $existing = json_decode(file_get_contents($path), true) ?: [];
+    }
+
+    foreach ($untranslated_keys as $lang => $keys) {
+        if (!isset($existing[$lang])) {
+            $existing[$lang] = [];
+        }
+        foreach ($keys as $k => $_) {
+            $existing[$lang][$k] = true;
+        }
+    }
+
+    file_put_contents($path, json_encode($existing, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+}
+
+register_shutdown_function('_save_untranslated_keys');
+
+function translate_or_lookup(string $key, string $es_text, string $target_lang): string {
+    $lang = preg_replace('/-ai$/', '', $target_lang);
+    $translation = t($key, $lang);
+    if ($translation !== $key) {
+        return $translation;
+    }
+
+    if (!function_exists('get_ai_translation')) {
+        require_once __DIR__ . '/ai_utils.php';
+    }
+    return get_ai_translation($es_text, $lang);
 }


### PR DESCRIPTION
## Summary
- hook i18n helper into Atapuerca page
- support missing-translation tracking and AI fallback

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856b7b9d87883298849d20784ffb69a