### PR TITLE
Add translation helper usage and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ docker-compose up --build
 ```
 
 Consulta el archivo [docker-compose.yml](docker-compose.yml) para conocer los servicios disponibles.
+
+## Cambio de idioma
+
+Para ver el contenido traducido basta con añadir el parámetro `lang` en la URL. Por ejemplo:
+
+```
+https://ejemplo.com/index.php?lang=en
+```
+
+Actualmente se incluyen archivos de traducción para español, inglés y gallego en el directorio `translations/`.

--- a/cultura/cultura.php
+++ b/cultura/cultura.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <title>Cultura y Legado - Condado de Castilla</title>
+    <title><?php echo t('Cultura y Legado - Condado de Castilla'); ?></title>
     <link rel="icon" href="/assets/img/escudo.jpg" type="image/jpeg">
 
 
@@ -30,7 +30,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
 
     <header class="page-header hero bg-[url('/assets/img/hero_cultura_background.jpg')] bg-cover bg-center md:bg-center">
         <div class="hero-content">
-            <img src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header">
+            <img src="/assets/img/estrella.png" alt="<?php echo t('Estrella de Venus decorativa'); ?>" class="decorative-star-header">
             <?php editableText('cultura_hero_titulo', $pdo, 'Cultura Viva y Legado Perenne', 'h1'); ?>
             <?php editableText('cultura_hero_subtitulo', $pdo, 'Las tradiciones, el idioma y el espíritu de una tierra forjada en la historia.', 'p'); ?>
         </div>
@@ -54,7 +54,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
                         que, con el tiempo, se convertiría en el idioma oficial de un vasto imperio y en un vehículo de 
                         expresión literaria de primer orden.', 'p'); ?>
                     <div class="image-container-internal">
-                        <img src="/assets/img/placeholder.jpg" alt="Detalle de un manuscrito medieval antiguo, representando los primeros escritos en castellano">
+                        <img src="/assets/img/placeholder.jpg" alt="<?php echo t('Detalle de un manuscrito medieval antiguo, representando los primeros escritos en castellano'); ?>">
                         <?php editableText('cultura_idioma_caption_texto', $pdo, '<i class="fas fa-scroll"></i> Fragmentos de historia: los primeros vestigios del castellano.', 'p', 'image-caption'); ?>
                     </div>
                 </article>
@@ -66,7 +66,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
                         con celebraciones cristianas, fruto de siglos de sincretismo cultural.', 'p'); ?>
                     
                     <div class="featured-item">
-                        <img src="/assets/img/placeholder.jpg" alt="Imagen de una romería o fiesta popular en la región de Castilla">
+                        <img src="/assets/img/placeholder.jpg" alt="<?php echo t('Imagen de una romería o fiesta popular en la región de Castilla'); ?>">
                         <div class="featured-item-content">
                             <?php editableText('cultura_tradiciones_featured_titulo', $pdo, 'Romerías y Celebraciones Patronales', 'h3'); ?>
                             <?php editableText('cultura_tradiciones_featured_p1', $pdo, 'Las romerías a ermitas cercanas, las fiestas en honor a los santos patronos (como San Vitores en agosto), y las celebraciones
@@ -89,7 +89,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
                         que trabajan la madera, el cuero, la forja o la cerámica con técnicas heredadas. Estos objetos, 
                         más allá de su utilidad, son portadores de una identidad y una historia.', 'p'); ?>
                     <div class="image-container-internal">
-                         <img src="/assets/img/placeholder.jpg" alt="Piezas de artesanía tradicional castellana, como cerámica o tallas de madera">
+                         <img src="/assets/img/placeholder.jpg" alt="<?php echo t('Piezas de artesanía tradicional castellana, como cerámica o tallas de madera'); ?>">
                         <?php editableText('cultura_artesania_manos_caption_texto', $pdo, '<i class="fas fa-tools"></i> La habilidad de las manos que conservan la tradición.', 'p', 'image-caption'); ?>
                     </div>
 
@@ -98,7 +98,7 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
                         Platos como el cordero asado, la morcilla de Burgos, las sopas de ajo, las alubias rojas de Ibeas, y los quesos 
                         artesanales son imprescindibles en cualquier mesa. Los vinos de la Rioja Alta y de la Ribera del Duero, denominaciones cercanas, acompañan a la perfección estos manjares.', 'p'); ?>
                      <div class="featured-item">
-                         <img src="/assets/img/placeholder.jpg" alt="Plato de cordero asado, típico de la gastronomía castellana">
+                         <img src="/assets/img/placeholder.jpg" alt="<?php echo t('Plato de cordero asado, típico de la gastronomía castellana'); ?>">
                         <div class="featured-item-content">
                             <?php editableText('cultura_artesania_featured_titulo', $pdo, 'El Sabor de la Tradición', 'h3'); ?>
                             <?php editableText('cultura_artesania_featured_p1', $pdo, 'En Cerezo y sus alrededores, podrás degustar recetas transmitidas de abuelas a nietas,
@@ -118,11 +118,11 @@ require_once __DIR__ . '/../includes/text_manager.php';// For editableText()
                         estos esfuerzos y visitar los centros de interpretación o museos locales es una forma de conectar 
                         directamente con este legado y contribuir a su preservación.', 'p'); ?>
                     <div class="image-container-internal">
-                        <img src="/assets/img/placeholder.jpg" alt="Fotografía de una excavación arqueológica en curso en el yacimiento de Auca Patricia">
+                        <img src="/assets/img/placeholder.jpg" alt="<?php echo t('Fotografía de una excavación arqueológica en curso en el yacimiento de Auca Patricia'); ?>">
                         <?php editableText('cultura_arqueologia_caption_texto', $pdo, '<i class="fas fa-search-location"></i> Arqueólogos desenterrando los secretos del pasado.', 'p', 'image-caption'); ?>
                     </div>
                     <p class="text-center mt-20">
-                        <?php editableText('cultura_link_explora_lugares_texto', $pdo, 'Explora los Lugares Emblemáticos', 'a', 'cta-button cta-button-small', 'href="/lugares/lugares.php"'); ?>
+                        <?php editableText('cultura_link_explora_lugares_texto', $pdo, t('Explora los Lugares Emblemáticos'), 'a', 'cta-button cta-button-small', 'href="/lugares/lugares.php"'); ?>
                     </p>
                 </article>
             </div>

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ require_once 'includes/ai_utils.php';
 require_once __DIR__ . '/includes/homonexus.php';?><!DOCTYPE html>
 <html lang="es">
 <head>
-    <title>Condado de Castilla - Cuna de tu Cultura y Lengua</title>
+    <title><?php echo t('Condado de Castilla - Cuna de tu Cultura y Lengua'); ?></title>
     <?php include __DIR__ . '/includes/head_common.php'; ?>
     <?php
     require_once __DIR__ . '/includes/load_page_css.php';
@@ -34,8 +34,8 @@ require_once __DIR__ . '/fragments/header.php';
 
     <header id="hero-video" class="relative h-screen w-full overflow-hidden">
         <div id="hero-content" class="relative z-10 flex flex-col items-center justify-center h-full text-center opacity-0 transition-opacity duration-1000 ease-out">
-            <h1 class="gradient-text blend-overlay text-4xl font-headings sm:text-4xl md:text-5xl lg:text-6xl drop-shadow-lg">Condado de Castilla: Cuna de Emperadores</h1>
-            <p class="mission-tagline text-lg font-body mt-4 bg-black bg-opacity-50 text-white p-4 sm:p-6 md:p-8">Promocionamos el turismo en Cerezo de Río Tirón y cuidamos su patrimonio arqueológico y cultural.</p>
+            <h1 class="gradient-text blend-overlay text-4xl font-headings sm:text-4xl md:text-5xl lg:text-6xl drop-shadow-lg"><?php echo t('Condado de Castilla: Cuna de Emperadores'); ?></h1>
+            <p class="mission-tagline text-lg font-body mt-4 bg-black bg-opacity-50 text-white p-4 sm:p-6 md:p-8"><?php echo t('Promocionamos el turismo en Cerezo de Río Tirón y cuidamos su patrimonio arqueológico y cultural.'); ?></p>
         </div>
         <div class="absolute bottom-8 left-1/2 transform -translate-x-1/2 text-yellow-300">
             <svg class="w-8 h-8 animate-bounce" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -45,21 +45,21 @@ require_once __DIR__ . '/fragments/header.php';
     </header>
 
     <nav id="page-nav" class="section-nav cta-group">
-        <a href="#video" class="cta-button-small">Video</a>
-        <a href="#memoria" class="cta-button-small">Memoria</a>
-        <a href="#legado" class="cta-button-small">Legado</a>
-        <a href="#personajes" class="cta-button-small">Personajes</a>
-        <a href="#timeline" class="cta-button-small">Historia</a>
-        <a href="#inmersion" class="cta-button-small">Cultura Viva</a>
+        <a href="#video" class="cta-button-small"><?php echo t('Video'); ?></a>
+        <a href="#memoria" class="cta-button-small"><?php echo t('Memoria'); ?></a>
+        <a href="#legado" class="cta-button-small"><?php echo t('Legado'); ?></a>
+        <a href="#personajes" class="cta-button-small"><?php echo t('Personajes'); ?></a>
+        <a href="#timeline" class="cta-button-small"><?php echo t('Historia'); ?></a>
+        <a href="#inmersion" class="cta-button-small"><?php echo t('Cultura Viva'); ?></a>
     </nav>
 
     <section id="video" class="video-section section spotlight-active py-12 sm:py-16 lg:py-20" data-aos="fade-up">
         <div class="container-epic px-4 sm:px-6 lg:px-8">
-            <h2 class="section-title text-2xl font-headings">Un Vistazo a Nuestra Tierra</h2>
+            <h2 class="section-title text-2xl font-headings"><?php echo t('Un Vistazo a Nuestra Tierra'); ?></h2>
             <div class="video-container mx-auto">
                 <iframe class="w-full h-full"
                     src="https://drive.google.com/file/d/1wm74VmKH21Nz7zFUkY8a8Z9672D4cyHN/preview"
-                    title="Video promocional del Condado de Castilla y Cerezo de Río Tirón"
+                    title="<?php echo t('Video promocional del Condado de Castilla y Cerezo de Río Tirón'); ?>"
                     width="560" height="315"
                     frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
@@ -87,27 +87,27 @@ require_once __DIR__ . '/fragments/header.php';
                 <h2 class="section-title text-2xl font-headings">Explora Nuestro Legado</h2>
                 <div class="card-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
                     <div class="card">
-                        <img class="w-full h-auto" src="/assets/img/PrimerEscritoCastellano.jpg" alt="Página de un manuscrito medieval iluminado, simbolizando la rica historia de Castilla">
+                        <img class="w-full h-auto" src="/assets/img/PrimerEscritoCastellano.jpg" alt="<?php echo t('Página de un manuscrito medieval iluminado, simbolizando la rica historia de Castilla'); ?>">
                         <div class="card-content">
-                            <h3 class="font-headings">Nuestra Historia</h3>
-                            <p class="text-lg font-body">Desde los Concanos y la Civitate Auca Patricia hasta la formación del Condado. Sumérgete en los relatos que definieron Castilla.</p>
-                            <a href="/historia/historia.php" class="read-more">Leer Más</a>
+                            <h3 class="font-headings"><?php echo t('Nuestra Historia'); ?></h3>
+                            <p class="text-lg font-body"><?php echo t('Desde los Concanos y la Civitate Auca Patricia hasta la formación del Condado. Sumérgete en los relatos que definieron Castilla.'); ?></p>
+                            <a href="/historia/historia.php" class="read-more"><?php echo t('Leer Más'); ?></a>
                         </div>
                     </div>
                     <div class="card">
-                        <img class="w-full h-auto" src="/assets/img/RodrigoTabliegaCastillo.jpg" alt="Imponentes ruinas del Alcázar de Casio recortadas contra un cielo dramático">
+                        <img class="w-full h-auto" src="/assets/img/RodrigoTabliegaCastillo.jpg" alt="<?php echo t('Imponentes ruinas del Alcázar de Casio recortadas contra un cielo dramático'); ?>">
                         <div class="card-content">
-                            <h3 class="font-headings">Lugares Emblemáticos</h3>
-                            <p class="text-lg font-body">Descubre el imponente Alcázar de Casio, los secretos de la Civitate Auca y otros tesoros arqueológicos que esperan ser explorados.</p>
-                            <a href="/lugares/lugares.php" class="read-more">Explorar Sitios</a>
+                            <h3 class="font-headings"><?php echo t('Lugares Emblemáticos'); ?></h3>
+                            <p class="text-lg font-body"><?php echo t('Descubre el imponente Alcázar de Casio, los secretos de la Civitate Auca y otros tesoros arqueológicos que esperan ser explorados.'); ?></p>
+                            <a href="/lugares/lugares.php" class="read-more"><?php echo t('Explorar Sitios'); ?></a>
                         </div>
                     </div>
                     <div class="card">
-                        <img class="w-full h-auto" src="/assets/img/Yanna.jpg" alt="Iglesia de Santa María de la Llana, ejemplo del patrimonio arquitectónico de Cerezo">
+                        <img class="w-full h-auto" src="/assets/img/Yanna.jpg" alt="<?php echo t('Iglesia de Santa María de la Llana, ejemplo del patrimonio arquitectónico de Cerezo'); ?>">
                         <div class="card-content">
-                            <h3 class="font-headings">Planifica Tu Visita</h3>
-                            <p class="text-lg font-body">Encuentra toda la información que necesitas para tu aventura en Cerezo de Río Tirón: cómo llegar, dónde alojarte y qué no te puedes perder.</p>
-                            <a href="/visitas/visitas.php" class="read-more">Organizar Viaje</a>
+                            <h3 class="font-headings"><?php echo t('Planifica Tu Visita'); ?></h3>
+                            <p class="text-lg font-body"><?php echo t('Encuentra toda la información que necesitas para tu aventura en Cerezo de Río Tirón: cómo llegar, dónde alojarte y qué no te puedes perder.'); ?></p>
+                            <a href="/visitas/visitas.php" class="read-more"><?php echo t('Organizar Viaje'); ?></a>
                         </div>
                     </div>
                 </div>
@@ -116,57 +116,57 @@ require_once __DIR__ . '/fragments/header.php';
 
         <section id="personajes" class="section py-12 sm:py-16 lg:py-20" data-aos="fade-up">
             <div class="container-epic px-4 sm:px-6 lg:px-8">
-                <h2 class="section-title text-2xl font-headings">Personajes de la Historia</h2>
+                <h2 class="section-title text-2xl font-headings"><?php echo t('Personajes de la Historia'); ?></h2>
                 <div class="card-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
                     <div class="card">
-                        <img class="w-full h-auto" src="/assets/img/Casio.png" alt="Retrato idealizado o ilustración del Conde Casio, figura histórica del siglo VIII">
+                        <img class="w-full h-auto" src="/assets/img/Casio.png" alt="<?php echo t('Retrato idealizado o ilustración del Conde Casio, figura histórica del siglo VIII'); ?>">
                         <div class="card-content">
-                            <h3 class="font-headings">Conde Casio</h3>
-                            <p class="text-lg font-body">Figura fundamental del siglo VIII, se le atribuye la construcción o refuerzo del Alcázar de Cerezo.</p>
-                            <a href="/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html" class="read-more">Saber Más</a>
+                            <h3 class="font-headings"><?php echo t('Conde Casio'); ?></h3>
+                            <p class="text-lg font-body"><?php echo t('Figura fundamental del siglo VIII, se le atribuye la construcción o refuerzo del Alcázar de Cerezo.'); ?></p>
+                            <a href="/personajes/Militares_y_Gobernantes/conde_casio_cerasio.html" class="read-more"><?php echo t('Saber Más'); ?></a>
                         </div>
                     </div>
                     <div class="card">
-                        <img class="w-full h-auto" src="/assets/img/GonzaloTellez.png" alt="Ilustración representando a Gonzalo Téllez, Conde de Lantarón y Cerezo">
+                        <img class="w-full h-auto" src="/assets/img/GonzaloTellez.png" alt="<?php echo t('Ilustración representando a Gonzalo Téllez, Conde de Lantarón y Cerezo'); ?>">
                         <div class="card-content">
-                            <h3 class="font-headings">Gonzalo Téllez</h3>
-                            <p class="text-lg font-body">Conde de Lantarón y Cerezo (c. 897 - c. 913), personaje clave en la consolidación de los territorios.</p>
-                            <a href="/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html" class="read-more">Saber Más</a>
+                            <h3 class="font-headings"><?php echo t('Gonzalo Téllez'); ?></h3>
+                            <p class="text-lg font-body"><?php echo t('Conde de Lantarón y Cerezo (c. 897 - c. 913), personaje clave en la consolidación de los territorios.'); ?></p>
+                            <a href="/personajes/Condes_de_Castilla_Alava_y_Lantaron/gonzalo_tellez.html" class="read-more"><?php echo t('Saber Más'); ?></a>
                         </div>
                     </div>
                     <div class="card">
-                        <img class="w-full h-auto" src="/assets/img/FernandoDiaz.png" alt="Representación artística de Fernando Díaz, conde castellano">
+                        <img class="w-full h-auto" src="/assets/img/FernandoDiaz.png" alt="<?php echo t('Representación artística de Fernando Díaz, conde castellano'); ?>">
                         <div class="card-content">
-                            <h3 class="font-headings">Fernando Díaz</h3>
-                            <p class="text-lg font-body">Sucesor de Gonzalo Téllez, continuó la labor de defensa y organización en la primitiva Castilla.</p>
-                            <a href="/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html" class="read-more">Saber Más</a>
+                            <h3 class="font-headings"><?php echo t('Fernando Díaz'); ?></h3>
+                            <p class="text-lg font-body"><?php echo t('Sucesor de Gonzalo Téllez, continuó la labor de defensa y organización en la primitiva Castilla.'); ?></p>
+                            <a href="/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html" class="read-more"><?php echo t('Saber Más'); ?></a>
                         </div>
                     </div>
                 </div>
                  <p class="cta-group">
-                    <a href="/personajes/indice_personajes.html" class="cta-button">Personajes</a>
+                    <a href="/personajes/indice_personajes.html" class="cta-button"><?php echo t('Personajes'); ?></a>
                 </p>
             </div>
         </section>
         
         <section id="timeline" class="section timeline-section-summary alternate-bg py-12 sm:py-16 lg:py-20" data-aos="fade-up">
             <div class="container-epic px-4 sm:px-6 lg:px-8">
-                <h2 class="section-title text-2xl font-headings">Nuestra Historia en el Tiempo</h2>
-                <p class="timeline-intro text-lg font-body">Un recorrido conciso por los momentos más determinantes de nuestra región, desde la prehistoria hasta la consolidación del Condado. Cada época ha dejado una huella imborrable.</p>
+                <h2 class="section-title text-2xl font-headings"><?php echo t('Nuestra Historia en el Tiempo'); ?></h2>
+                <p class="timeline-intro text-lg font-body"><?php echo t('Un recorrido conciso por los momentos más determinantes de nuestra región, desde la prehistoria hasta la consolidación del Condado. Cada época ha dejado una huella imborrable.'); ?></p>
                 <p class="cta-group">
-                    <a href="/secciones_index/historia_tiempo_resumen.html" class="cta-button">Explorar Resumen de la Historia</a>
+                    <a href="/secciones_index/historia_tiempo_resumen.html" class="cta-button"><?php echo t('Explorar Resumen de la Historia'); ?></a>
                 </p>
             </div>
         </section>
 
         <section id="inmersion" class="section immersion-section py-12 sm:py-16 lg:py-20" data-aos="fade-up">
             <div class="container-epic px-4 sm:px-6 lg:px-8">
-                <h2 class="text-2xl font-headings">Sumérgete en la Historia Viva de Tu Cultura</h2>
+                <h2 class="text-2xl font-headings"><?php echo t('Sumérgete en la Historia Viva de Tu Cultura'); ?></h2>
                 <p class="text-lg font-body">
-                    Esta web es más que información; es una puerta a tus raíces. Un viaje al origen del castellano y la identidad hispana te espera.
-                    Siente la llamada de la historia y conecta con el legado que nos une.
+                    <?php echo t('Esta web es más que información; es una puerta a tus raíces. Un viaje al origen del castellano y la identidad hispana te espera.'); ?>
+                    <?php echo t('Siente la llamada de la historia y conecta con el legado que nos une.'); ?>
                 </p>
-                <a href="/cultura/cultura.php" class="cta-button">Cultura</a>
+                <a href="/cultura/cultura.php" class="cta-button"><?php echo t('Cultura'); ?></a>
             </div>
         </section>
     </main>

--- a/translations/en.json
+++ b/translations/en.json
@@ -2566,5 +2566,20 @@
   "← Volver al listado": "",
   "☰ Expertos": "",
   "🌙 Modo luna": "",
-  "🌿 Alfoz de Cerezo y Lantarón": ""
+  "🌿 Alfoz de Cerezo y Lantarón": "",
+  "Video promocional del Condado de Castilla y Cerezo de Río Tirón": "",
+  "Página de un manuscrito medieval iluminado, simbolizando la rica historia de Castilla": "",
+  "Imponentes ruinas del Alcázar de Casio recortadas contra un cielo dramático": "",
+  "Iglesia de Santa María de la Llana, ejemplo del patrimonio arquitectónico de Cerezo": "",
+  "Retrato idealizado o ilustración del Conde Casio, figura histórica del siglo VIII": "",
+  "Ilustración representando a Gonzalo Téllez, Conde de Lantarón y Cerezo": "",
+  "Representación artística de Fernando Díaz, conde castellano": "",
+  "Esta web es más que información; es una puerta a tus raíces. Un viaje al origen del castellano y la identidad hispana te espera.": "",
+  "Siente la llamada de la historia y conecta con el legado que nos une.": "",
+  "Estrella de Venus decorativa": "",
+  "Detalle de un manuscrito medieval antiguo, representando los primeros escritos en castellano": "",
+  "Imagen de una romería o fiesta popular en la región de Castilla": "",
+  "Piezas de artesanía tradicional castellana, como cerámica o tallas de madera": "",
+  "Plato de cordero asado, típico de la gastronomía castellana": "",
+  "Fotografía de una excavación arqueológica en curso en el yacimiento de Auca Patricia": ""
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -2566,5 +2566,20 @@
   "← Volver al listado": "← Volver al listado",
   "☰ Expertos": "☰ Expertos",
   "🌙 Modo luna": "🌙 Modo luna",
-  "🌿 Alfoz de Cerezo y Lantarón": "🌿 Alfoz de Cerezo y Lantarón"
+  "🌿 Alfoz de Cerezo y Lantarón": "🌿 Alfoz de Cerezo y Lantarón",
+  "Video promocional del Condado de Castilla y Cerezo de Río Tirón": "Video promocional del Condado de Castilla y Cerezo de Río Tirón",
+  "Página de un manuscrito medieval iluminado, simbolizando la rica historia de Castilla": "Página de un manuscrito medieval iluminado, simbolizando la rica historia de Castilla",
+  "Imponentes ruinas del Alcázar de Casio recortadas contra un cielo dramático": "Imponentes ruinas del Alcázar de Casio recortadas contra un cielo dramático",
+  "Iglesia de Santa María de la Llana, ejemplo del patrimonio arquitectónico de Cerezo": "Iglesia de Santa María de la Llana, ejemplo del patrimonio arquitectónico de Cerezo",
+  "Retrato idealizado o ilustración del Conde Casio, figura histórica del siglo VIII": "Retrato idealizado o ilustración del Conde Casio, figura histórica del siglo VIII",
+  "Ilustración representando a Gonzalo Téllez, Conde de Lantarón y Cerezo": "Ilustración representando a Gonzalo Téllez, Conde de Lantarón y Cerezo",
+  "Representación artística de Fernando Díaz, conde castellano": "Representación artística de Fernando Díaz, conde castellano",
+  "Esta web es más que información; es una puerta a tus raíces. Un viaje al origen del castellano y la identidad hispana te espera.": "Esta web es más que información; es una puerta a tus raíces. Un viaje al origen del castellano y la identidad hispana te espera.",
+  "Siente la llamada de la historia y conecta con el legado que nos une.": "Siente la llamada de la historia y conecta con el legado que nos une.",
+  "Estrella de Venus decorativa": "Estrella de Venus decorativa",
+  "Detalle de un manuscrito medieval antiguo, representando los primeros escritos en castellano": "Detalle de un manuscrito medieval antiguo, representando los primeros escritos en castellano",
+  "Imagen de una romería o fiesta popular en la región de Castilla": "Imagen de una romería o fiesta popular en la región de Castilla",
+  "Piezas de artesanía tradicional castellana, como cerámica o tallas de madera": "Piezas de artesanía tradicional castellana, como cerámica o tallas de madera",
+  "Plato de cordero asado, típico de la gastronomía castellana": "Plato de cordero asado, típico de la gastronomía castellana",
+  "Fotografía de una excavación arqueológica en curso en el yacimiento de Auca Patricia": "Fotografía de una excavación arqueológica en curso en el yacimiento de Auca Patricia"
 }

--- a/translations/gl.json
+++ b/translations/gl.json
@@ -2566,5 +2566,20 @@
   "← Volver al listado": "",
   "☰ Expertos": "",
   "🌙 Modo luna": "",
-  "🌿 Alfoz de Cerezo y Lantarón": ""
+  "🌿 Alfoz de Cerezo y Lantarón": "",
+  "Video promocional del Condado de Castilla y Cerezo de Río Tirón": "",
+  "Página de un manuscrito medieval iluminado, simbolizando la rica historia de Castilla": "",
+  "Imponentes ruinas del Alcázar de Casio recortadas contra un cielo dramático": "",
+  "Iglesia de Santa María de la Llana, ejemplo del patrimonio arquitectónico de Cerezo": "",
+  "Retrato idealizado o ilustración del Conde Casio, figura histórica del siglo VIII": "",
+  "Ilustración representando a Gonzalo Téllez, Conde de Lantarón y Cerezo": "",
+  "Representación artística de Fernando Díaz, conde castellano": "",
+  "Esta web es más que información; es una puerta a tus raíces. Un viaje al origen del castellano y la identidad hispana te espera.": "",
+  "Siente la llamada de la historia y conecta con el legado que nos une.": "",
+  "Estrella de Venus decorativa": "",
+  "Detalle de un manuscrito medieval antiguo, representando los primeros escritos en castellano": "",
+  "Imagen de una romería o fiesta popular en la región de Castilla": "",
+  "Piezas de artesanía tradicional castellana, como cerámica o tallas de madera": "",
+  "Plato de cordero asado, típico de la gastronomía castellana": "",
+  "Fotografía de una excavación arqueológica en curso en el yacimiento de Auca Patricia": ""
 }


### PR DESCRIPTION
## Summary
- wrap interface strings in `index.php` and `cultura.php` with `t()`
- add translation keys in `translations/*.json`
- document `?lang=` usage in README

## Testing
- `./scripts/setup_environment.sh` *(fails: PHP 8.1 or higher is required but not found)*
- `vendor/bin/phpunit` *(failed: command not found)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py` *(failed: command not found)*
- `npm run test:puppeteer` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b7bbef608329b744b0fea3a34d1f