### PR TITLE
Configure Tailwind JIT build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "puppeteer": "^24.10.2",
     "svgo": "^3.3.2",
     "tailwindcss": "^4.1.10",
+    "@tailwindcss/postcss": "^4.1.10",
+    "autoprefixer": "^10.4.21",
     "vite": "^6.3.5",
     "@playwright/test": "^1.42.1"
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,8 +2,9 @@
 const plugin = require('tailwindcss/plugin')
 
 module.exports = {
+  mode: 'jit',
   // Include tailwind_base.css so @layer directives inside it are processed
-  content: [
+  purge: [
     './**/*.{php,html}',
     './assets/js/**/*.js',
     './assets/css/tailwind_base.css',

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
     }
   },
   build: {
+    minify: true,
     cssCodeSplit: false,
     rollupOptions: {
       input: 'tailwind_entry.js',


### PR DESCRIPTION
## Summary
- enable JIT mode and purge templates in `tailwind.config.js`
- minify Tailwind output via Vite
- add PostCSS dependencies for Tailwind

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856b83e07988329ae845242d17bf851