### PR TITLE
Add JS bundling via Vite

### DIFF
--- a/assets/js/bundle-entry.js
+++ b/assets/js/bundle-entry.js
@@ -1,0 +1,15 @@
+import './main.js';
+import './cave_mask.js';
+import './hero.js';
+import './scroll-fade.js';
+import './parallax.js';
+import './audio-controller.js';
+import './escudo-reveal.js';
+import './escudo-drag.js';
+import './custom-pointer.js';
+import './homonexus-toggle.js';
+import './help.js';
+import './foro.js';
+import './influencia_romana.js';
+import './polyfills.js';
+import './torch_cursor.js';

--- a/fragments/footer.php
+++ b/fragments/footer.php
@@ -29,16 +29,23 @@
         <li>Consulta la agenda de eventos culturales.</li>
     </ul>
 </div>
+<?php
+$app_debug = filter_var($_ENV['APP_DEBUG'] ?? false, FILTER_VALIDATE_BOOLEAN);
+if ($app_debug) {
+?>
 <script src="/assets/js/main.js"></script>
 <script src="/assets/js/cave_mask.js"></script>
 <script src="/assets/js/hero.js"></script>
 <script src="/assets/js/scroll-fade.js"></script>
 <script src="/assets/js/parallax.js"></script>
-<script src="/js/lang-bar.js"></script>
 <script src="/assets/js/audio-controller.js"></script>
 <script src="/assets/js/escudo-reveal.js"></script>
 <script src="/assets/js/escudo-drag.js"></script>
 <script defer src="/assets/js/custom-pointer.js"></script>
 <script src="/assets/js/homonexus-toggle.js"></script>
-<script src="/js/layout.js"></script>
 <script src="/assets/js/help.js"></script>
+<?php } else { ?>
+<script src="/assets/vendor/js/main.min.js"></script>
+<?php } ?>
+<script src="/js/lang-bar.js"></script>
+<script src="/js/layout.js"></script>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/postcss';
 import autoprefixer from 'autoprefixer';
+import { resolve } from 'path';
 
 export default defineConfig({
   css: {
@@ -11,11 +12,18 @@ export default defineConfig({
   build: {
     cssCodeSplit: false,
     rollupOptions: {
-      input: 'tailwind_entry.js',
+      input: {
+        tailwind: resolve(__dirname, 'tailwind_entry.js'),
+        main: resolve(__dirname, 'assets/js/bundle-entry.js')
+      },
       output: {
         assetFileNames: (assetInfo) => {
           if (assetInfo.name === 'style.css') return 'css/tailwind.min.css';
           return assetInfo.name;
+        },
+        entryFileNames: (chunkInfo) => {
+          if (chunkInfo.name === 'main') return 'js/main.min.js';
+          return 'assets/[name].js';
         }
       }
     },


### PR DESCRIPTION
## Summary
- create entry file to bundle all JS
- extend `vite.config.js` to output `main.min.js`
- load bundled script in production

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:8080)*

------
https://chatgpt.com/codex/tasks/task_e_6856b83e5b7483299d8dda34dd997676