### PR TITLE
Introduce dataclasses in GraphDBInterface

### DIFF
--- a/graph_db_interface.py
+++ b/graph_db_interface.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import dataclass, asdict, field
 from datetime import datetime
 import json
 import logging
@@ -15,6 +16,26 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
+@dataclass
+class Resource:
+    url: str
+    content: str = "N/A (placeholder)"
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    last_crawled_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class Link:
+    source_url: str
+    target_url: str
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    source_resource_id: str | None = None
+    target_resource_id: str | None = None
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    anchor_text: str | None = None
+
 class GraphDBInterface:
     def __init__(self, config=None, db_filepath: str | None = None):
         """
@@ -22,8 +43,8 @@ class GraphDBInterface:
         _nodes stores resources keyed by their URL for quick lookup.
         _edges is a list of link dictionaries.
         """
-        self._nodes = {}  # Key: URL, Value: resource_data dictionary
-        self._edges = []  # List of link_data dictionaries
+        self._nodes: dict[str, Resource] = {}  # Key: URL, Value: Resource
+        self._edges: list[Link] = []  # List of Link objects
         self.db_filepath = (
             db_filepath
             or os.environ.get("GRAPH_DB_PATH", "knowledge_graph_db.json")
@@ -38,7 +59,9 @@ class GraphDBInterface:
         try:
             with self._lock:
                 with open(self.db_filepath, 'w') as f:
-                    json.dump({"nodes": self._nodes, "edges": self._edges}, f, indent=2)
+                    nodes_dict = {url: asdict(res) for url, res in self._nodes.items()}
+                    edges_list = [asdict(edge) for edge in self._edges]
+                    json.dump({"nodes": nodes_dict, "edges": edges_list}, f, indent=2)
             logger.info("Database state saved to %s", self.db_filepath)
         except IOError as e:
             logger.error("Error saving database state to %s: %s", self.db_filepath, e)
@@ -49,8 +72,10 @@ class GraphDBInterface:
             with self._lock:
                 with open(self.db_filepath, 'r') as f:
                     data = json.load(f)
-                    self._nodes = data.get("nodes", {})
-                    self._edges = data.get("edges", [])
+                    nodes = data.get("nodes", {})
+                    edges = data.get("edges", [])
+                    self._nodes = {url: Resource(**res) for url, res in nodes.items()}
+                    self._edges = [Link(**edge) for edge in edges]
             logger.info("Database state loaded from %s", self.db_filepath)
         except FileNotFoundError:
             logger.warning("Database file %s not found. Starting with an empty database.", self.db_filepath)
@@ -60,43 +85,31 @@ class GraphDBInterface:
             logger.error("Error loading database state from %s: %s. Starting with an empty database.", self.db_filepath, e)
 
 
-    def _create_placeholder_resource(self, url: str) -> dict:
+    def _create_placeholder_resource(self, url: str) -> Resource:
         """Helper to create a basic resource if it doesn't exist."""
         logger.info("Creating placeholder resource for URL: %s", url)
-        return {
-            "id": str(uuid.uuid4()),
-            "url": url,
-            "content": "N/A (placeholder)",
-            "last_crawled_at": datetime.utcnow().isoformat(),
-            "metadata": {"status": "placeholder"}
-        }
+        return Resource(url=url, metadata={"status": "placeholder"})
 
-    def add_or_update_resource(self, resource_data: dict) -> None:
-        """Adds or updates a resource in ``self._nodes`` and persists changes.
+    def add_or_update_resource(self, resource: Resource) -> None:
+        """Adds or updates a resource in ``self._nodes`` and persists changes."""
 
-        ``resource_data`` must contain a ``url`` key.
-        """
-        url = resource_data.get("url")
+        url = resource.url
         if not url:
             logger.error("'url' is required to add or update a resource.")
             return
 
         if url in self._nodes:
-            self._nodes[url].update(resource_data)
+            existing = self._nodes[url]
+            for field_name, value in asdict(resource).items():
+                setattr(existing, field_name, value)
             logger.info("Updated resource: %s", url)
-            self._save_to_file()
         else:
-            # Ensure essential fields like 'id' are present if new
-            if "id" not in resource_data:
-                resource_data["id"] = str(uuid.uuid4())
-            if "last_crawled_at" not in resource_data:
-                resource_data["last_crawled_at"] = datetime.utcnow().isoformat()
-            self._nodes[url] = resource_data
+            self._nodes[url] = resource
             logger.info("Added new resource: %s", url)
-            # Persist changes for newly added resources
-            self._save_to_file()
 
-    def get_resource(self, url: str) -> dict | None:
+        self._save_to_file()
+
+    def get_resource(self, url: str) -> Resource | None:
         """Retrieves a resource from self._nodes by URL."""
         resource = self._nodes.get(url)
         if resource:
@@ -111,15 +124,15 @@ class GraphDBInterface:
         logger.info("Resource exists check for %s: %s", url, exists)
         return exists
 
-    def add_link(self, link_data: dict) -> None:
+    def add_link(self, link: Link) -> None:
         """
         Adds a link to self._edges.
         Requires 'source_url' and 'target_url' in link_data.
         Creates placeholder resources if source_url or target_url don't exist.
         Prevents duplicate links based on (source_url, target_url) pair.
         """
-        source_url = link_data.get("source_url")
-        target_url = link_data.get("target_url")
+        source_url = link.source_url
+        target_url = link.target_url
 
         if not source_url or not target_url:
             logger.error("'source_url' and 'target_url' are required to add a link.")
@@ -127,7 +140,7 @@ class GraphDBInterface:
 
         # Check for duplicate links
         for edge in self._edges:
-            if edge.get("source_url") == source_url and edge.get("target_url") == target_url:
+            if edge.source_url == source_url and edge.target_url == target_url:
                 logger.info("Link from %s to %s already exists. Skipping.", source_url, target_url)
                 return
 
@@ -136,8 +149,7 @@ class GraphDBInterface:
             logger.info("Source resource %s not found. Creating placeholder.", source_url)
             placeholder_source = self._create_placeholder_resource(source_url)
             self.add_or_update_resource(placeholder_source)
-        # Update link_data with the actual source resource ID
-        link_data["source_resource_id"] = self._nodes[source_url]["id"]
+        link.source_resource_id = self._nodes[source_url].id
 
 
         # Ensure target resource exists or create a placeholder
@@ -145,42 +157,34 @@ class GraphDBInterface:
             logger.info("Target resource %s not found. Creating placeholder.", target_url)
             placeholder_target = self._create_placeholder_resource(target_url)
             self.add_or_update_resource(placeholder_target)
-        # Update link_data with the actual target resource ID (if it was a placeholder)
-        # In a real system, this might be just the URL, and ID resolution happens later.
-        # For now, we'll assume we might want to store the target's ID if known.
-        link_data["target_resource_id"] = self._nodes[target_url]["id"]
+        link.target_resource_id = self._nodes[target_url].id
 
 
         # Ensure essential fields for the link itself
-        if "id" not in link_data:
-            link_data["id"] = str(uuid.uuid4())
-        if "created_at" not in link_data:
-            link_data["created_at"] = datetime.utcnow().isoformat()
-
-        self._edges.append(link_data)
+        self._edges.append(link)
         logger.info("Added link: %s -> %s", source_url, target_url)
         self._save_to_file() # Save after adding a link
 
-    def get_links_from_resource(self, url: str) -> list[dict]:
+    def get_links_from_resource(self, url: str) -> list[Link]:
         """Returns a list of links where source_url matches the given URL."""
-        links = [edge for edge in self._edges if edge.get("source_url") == url]
+        links = [edge for edge in self._edges if edge.source_url == url]
         logger.info("Found %d links from resource: %s", len(links), url)
         return links
 
-    def get_links_to_resource(self, url: str) -> list[dict]:
+    def get_links_to_resource(self, url: str) -> list[Link]:
         """Returns a list of links where target_url matches the given URL."""
-        links = [edge for edge in self._edges if edge.get("target_url") == url]
+        links = [edge for edge in self._edges if edge.target_url == url]
         logger.info("Found %d links to resource: %s", len(links), url)
         return links
 
-    def get_all_resources(self) -> list[dict]:
-        """Returns a list of all resource dictionaries."""
+    def get_all_resources(self) -> list[Resource]:
+        """Returns a list of all resources."""
         all_nodes = list(self._nodes.values())
         logger.info("Retrieved %d resources.", len(all_nodes))
         return all_nodes
 
-    def get_all_links(self) -> list[dict]:
-        """Returns a list of all link dictionaries."""
+    def get_all_links(self) -> list[Link]:
+        """Returns a list of all links."""
         logger.info("Retrieved %d links.", len(self._edges))
         return list(self._edges)
 

--- a/tests/test_graph_db_interface.py
+++ b/tests/test_graph_db_interface.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest
 
-from graph_db_interface import GraphDBInterface
+from graph_db_interface import GraphDBInterface, Resource, Link
 
 
 class GraphDBInterfaceTestCase(unittest.TestCase):
@@ -17,18 +17,18 @@ class GraphDBInterfaceTestCase(unittest.TestCase):
 
     def test_add_or_update_resource_and_resource_exists(self):
         url = "http://example.com/page1"
-        data = {"url": url, "content": "contenido"}
+        data = Resource(url=url, content="contenido")
         self.db.add_or_update_resource(data)
         # verify the resource was added
         self.assertTrue(self.db.resource_exists(url))
-        self.assertEqual(self.db.get_resource(url)["content"], "contenido")
+        self.assertEqual(self.db.get_resource(url).content, "contenido")
         # update existing resource
-        updated = {"url": url, "content": "actualizado"}
+        updated = Resource(url=url, content="actualizado")
         self.db.add_or_update_resource(updated)
-        self.assertEqual(self.db.get_resource(url)["content"], "actualizado")
+        self.assertEqual(self.db.get_resource(url).content, "actualizado")
 
     def test_add_link_creates_placeholders_and_prevents_duplicates(self):
-        link = {"source_url": "http://src.com", "target_url": "http://dst.com"}
+        link = Link(source_url="http://src.com", target_url="http://dst.com")
         self.db.add_link(link)
         # file should exist after save
         self.assertTrue(os.path.exists(self.db.db_filepath))
@@ -41,29 +41,29 @@ class GraphDBInterfaceTestCase(unittest.TestCase):
         self.assertEqual(len(self.db.get_all_links()), 1)
 
     def test_get_all_resources(self):
-        res1 = {"url": "http://a.com", "content": "A"}
-        res2 = {"url": "http://b.com", "content": "B"}
+        res1 = Resource(url="http://a.com", content="A")
+        res2 = Resource(url="http://b.com", content="B")
         self.db.add_or_update_resource(res1)
         self.db.add_or_update_resource(res2)
-        urls = {r["url"] for r in self.db.get_all_resources()}
+        urls = {r.url for r in self.db.get_all_resources()}
         self.assertEqual(urls, {"http://a.com", "http://b.com"})
 
     def test_get_links_from_resource(self):
-        self.db.add_link({"source_url": "http://src.com", "target_url": "http://a.com"})
-        self.db.add_link({"source_url": "http://src.com", "target_url": "http://b.com"})
-        self.db.add_link({"source_url": "http://other.com", "target_url": "http://a.com"})
+        self.db.add_link(Link(source_url="http://src.com", target_url="http://a.com"))
+        self.db.add_link(Link(source_url="http://src.com", target_url="http://b.com"))
+        self.db.add_link(Link(source_url="http://other.com", target_url="http://a.com"))
 
         links = self.db.get_links_from_resource("http://src.com")
-        targets = {l["target_url"] for l in links}
+        targets = {l.target_url for l in links}
         self.assertEqual(targets, {"http://a.com", "http://b.com"})
 
     def test_get_links_to_resource(self):
-        self.db.add_link({"source_url": "http://src.com", "target_url": "http://dst.com"})
-        self.db.add_link({"source_url": "http://other.com", "target_url": "http://dst.com"})
-        self.db.add_link({"source_url": "http://src.com", "target_url": "http://else.com"})
+        self.db.add_link(Link(source_url="http://src.com", target_url="http://dst.com"))
+        self.db.add_link(Link(source_url="http://other.com", target_url="http://dst.com"))
+        self.db.add_link(Link(source_url="http://src.com", target_url="http://else.com"))
 
         links = self.db.get_links_to_resource("http://dst.com")
-        sources = {l["source_url"] for l in links}
+        sources = {l.source_url for l in links}
         self.assertEqual(sources, {"http://src.com", "http://other.com"})
 
 


### PR DESCRIPTION
## Summary
- define `Resource` and `Link` dataclasses
- update `GraphDBInterface` to use these dataclasses
- adapt unit tests to create and verify `Resource` and `Link` objects

## Testing
- `python3 -m unittest tests/test_graph_db_interface.py`

------
https://chatgpt.com/codex/tasks/task_e_6856b8566308832986ee5c3cb71ef277