### PR TITLE
Add accessibility audit script with docs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,6 +44,18 @@ npm ci
 
 Esto descargará `puppeteer` y los binarios de Chrome.
 
+### Auditorías de accesibilidad
+
+El script `scripts/run_accessibility_audit.sh` permite generar informes de
+accesibilidad de las páginas principales mediante **Lighthouse**.
+
+```bash
+./scripts/run_accessibility_audit.sh
+```
+
+Los resultados se guardan en `reports/accessibility/`. Ábrelos con el navegador
+para revisar posibles problemas.
+
 
 
 ## Solucion de problemas

--- a/scripts/run_accessibility_audit.sh
+++ b/scripts/run_accessibility_audit.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+# Pages to audit. Update this list to cover the most important routes.
+PAGES=(
+    "http://localhost:8080/index.php"
+    "http://localhost:8080/museo/museo.php"
+    "http://localhost:8080/blog.php"
+    "http://localhost:8080/contacto/contacto.php"
+)
+
+OUTPUT_DIR="reports/accessibility"
+mkdir -p "$OUTPUT_DIR"
+
+# Launch a local PHP server if none is running
+php -S localhost:8080 >/dev/null 2>&1 &
+PHP_PID=$!
+trap 'kill $PHP_PID' EXIT
+sleep 2
+
+for page in "${PAGES[@]}"; do
+    fname=$(echo "$page" | sed 's|https*://||;s|/|_|g')
+    echo "Auditing $page..."
+    npx --yes lighthouse "$page" \
+        --quiet --output html \
+        --output-path "$OUTPUT_DIR/${fname}.html" >/dev/null
+    echo "Saved report to $OUTPUT_DIR/${fname}.html"
+done
+
+echo "All accessibility reports generated in $OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- add `run_accessibility_audit.sh` for Lighthouse-based accessibility testing
- store audit results in `reports/accessibility`
- document how to run accessibility audits in `docs/testing.md`

## Testing
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py` *(fails: ModuleNotFoundError: No module named 'filelock')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856b864dc8483298dcbb9efea82778c