### PR TITLE
Improve contrast for gold theme colors

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -3,8 +3,8 @@
     --epic-error-red: #D9534F; /* Default error red */
     --epic-purple-emperor: #4A0D67;
     --epic-purple-emperor-rgb: 74, 13, 103;
-    --epic-gold-main: #CFB53B; /* Old gold tone */
-    --epic-gold-main-rgb: 207, 181, 59;
+    --epic-gold-main: #a03c00; /* Accessible gold tone */
+    --epic-gold-main-rgb: 160, 60, 0;
     --epic-gold-secondary: #9A6700;
     --epic-gold-secondary-rgb: 154, 103, 0;
     --epic-alabaster-bg: #fdfaf6; /* Alabaster white page background */
@@ -83,7 +83,7 @@
     --epic-gold-soft: #f3e5ab;      /* Gentle dawn gold */
     --epic-purple-vibrant: #6b46c1; /* Bright daytime purple */
     --epic-alabaster-dusk: #efe2d2; /* Warm dusk background */
-    --epic-gold-dusk: #f0b429;      /* Intense dusk gold */
+    --epic-gold-dusk: #a04600;      /* Accessible dusk gold */
     --epic-orange-sunset: #f97316;  /* Sunset orange accent */
     --epic-text-night: #e0e0e0;     /* Light text for night mode */
     /* Alert variables */

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -16,7 +16,7 @@ Esta guía resume la paleta de colores usada de forma consistente en todo el pro
 | `--epic-gold-soft` | Oro pálido de las primeras horas | `#f3e5ab` |
 | `--epic-purple-vibrant` | Morado intenso para el día | `#6b46c1` |
 | `--epic-alabaster-dusk` | Fondo cálido del atardecer | `#efe2d2` |
-| `--epic-gold-dusk` | Dorado profundo del atardecer | `#f0b429` |
+| `--epic-gold-dusk` | Dorado profundo del atardecer | `#a04600` |
 | `--epic-orange-sunset` | Naranja brillante del ocaso | `#f97316` |
 | `--epic-text-night` | Texto claro para el modo nocturno | `#e0e0e0` |
 | `--color-negro-contraste` | Negro de alto contraste | `#1A1A1A` |
@@ -122,3 +122,15 @@ Cuando un botón está expandido (`aria-expanded="true"`) o un panel visible
     border: 2px solid var(--epic-gold-main);
 }
 ```
+
+## Resultados de contraste
+
+Las combinaciones principales de color se revisaron con una herramienta de contraste.
+Todas superan la relación 4.5:1 tras los ajustes realizados:
+
+| Texto | Fondo | Ratio |
+|-------|-------|------|
+| `--epic-purple-emperor` (`#4A0D67`) | `--epic-alabaster-bg` (`#fdfaf6`) | **13.06** |
+| `--epic-purple-vibrant` (`#6b46c1`) | `--epic-alabaster-dawn` (`#e5e5e5`) | **5.10** |
+| `--epic-gold-main` (`#a03c00`) | `--epic-alabaster-bg` (`#fdfaf6`) | **6.43** |
+| `--epic-gold-dusk` (`#a04600`) | `--epic-alabaster-dusk` (`#efe2d2`) | **4.89** |

--- a/frontend/styles/theme.css
+++ b/frontend/styles/theme.css
@@ -3,8 +3,8 @@
     --epic-error-red: #D9534F; /* Default error red */
     --epic-purple-emperor: #4A0D67;
     --epic-purple-emperor-rgb: 74, 13, 103;
-    --epic-gold-main: #CFB53B; /* Old gold tone */
-    --epic-gold-main-rgb: 207, 181, 59;
+    --epic-gold-main: #a03c00; /* Accessible gold tone */
+    --epic-gold-main-rgb: 160, 60, 0;
     --epic-gold-secondary: #9A6700;
     --epic-gold-secondary-rgb: 154, 103, 0;
     --epic-alabaster-bg: #fdfaf6; /* Alabaster white page background */
@@ -83,7 +83,7 @@
     --epic-gold-soft: #f3e5ab;      /* Gentle dawn gold */
     --epic-purple-vibrant: #6b46c1; /* Bright daytime purple */
     --epic-alabaster-dusk: #efe2d2; /* Warm dusk background */
-    --epic-gold-dusk: #f0b429;      /* Intense dusk gold */
+    --epic-gold-dusk: #a04600;      /* Accessible dusk gold */
     --epic-orange-sunset: #f97316;  /* Sunset orange accent */
     --epic-text-night: #e0e0e0;     /* Light text for night mode */
     /* Alert variables */


### PR DESCRIPTION
## Summary
- use accessible gold colors in theme CSS
- update contrast ratios in style guide

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856b86a19848329a218bc769aed2d2b