### PR TITLE
Add reusable breadcrumbs fragment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,22 @@ Para insertar estas partes en una página basta con:
 Los fragmentos del directorio `fragments/` pueden copiarse o modificarse para
 crear nuevas secciones del menú.
 
+### Breadcrumbs
+
+El fragmento `fragments/breadcrumbs.php` genera automáticamente una lista de enlaces según la URL actual. Se usa así:
+
+```php
+<?php
+require_once __DIR__ . '/fragments/breadcrumbs.php';
+render_breadcrumbs([
+    'historia' => 'Nuestra Historia',
+    'subpaginas' => 'Índice Detallado',
+]);
+?>
+```
+
+Los estilos coinciden con `assets/css/pages/historia_subpaginas_auca_patricia_ubicacion.css`.
+
 ## Añadir nuevas páginas
 
 1. Crea el archivo dentro de la carpeta adecuada (`historia/`, `lugares/`, etc.).

--- a/fragments/breadcrumbs.php
+++ b/fragments/breadcrumbs.php
@@ -1,0 +1,49 @@
+<?php
+function render_breadcrumbs(array $labelMap = []): void
+{
+    $defaults = [
+        '' => 'Inicio',
+        'index.php' => 'Inicio',
+        'historia' => 'Nuestra Historia',
+        'historia.php' => 'Nuestra Historia',
+        'subpaginas' => 'Índice Detallado',
+        'subpaginas_indice.php' => 'Índice Detallado',
+        'lugares' => 'Lugares',
+        'lugares.php' => 'Lugares',
+    ];
+    $labels = array_merge($defaults, $labelMap);
+
+    $uri = $_SERVER['REQUEST_URI'] ?? '/';
+    $path = parse_url($uri, PHP_URL_PATH);
+    $segments = array_values(array_filter(explode('/', trim($path, '/'))));
+
+    $crumbs = [];
+    $accum = '';
+
+    // Root breadcrumb
+    $crumbs[] = [
+        'url' => '/',
+        'label' => $labels[''] ?? 'Inicio'
+    ];
+
+    foreach ($segments as $seg) {
+        $accum .= '/' . $seg;
+        $label = $labels[$seg] ?? $labels[$accum] ?? ucwords(str_replace(['_', '-'], [' ', ' '], pathinfo($seg, PATHINFO_FILENAME)));
+        $crumbs[] = [
+            'url' => $accum,
+            'label' => $label
+        ];
+    }
+
+    echo '<div class="breadcrumb-container"><nav aria-label="breadcrumb"><ol class="breadcrumb">';
+    $total = count($crumbs);
+    foreach ($crumbs as $idx => $crumb) {
+        if ($idx === $total - 1) {
+            echo '<li class="active" aria-current="page">' . htmlspecialchars($crumb['label']) . '</li>';
+        } else {
+            echo '<li><a href="' . htmlspecialchars($crumb['url']) . '">' . htmlspecialchars($crumb['label']) . '</a></li>';
+        }
+    }
+    echo '</ol></nav></div>';
+}
+?>

--- a/historia/subpaginas/alcazar_de_cerasio.php
+++ b/historia/subpaginas/alcazar_de_cerasio.php
@@ -18,6 +18,12 @@
     </header>
     <main>
         <section class="section">
+            <div class="container">
+                <?php
+                require_once __DIR__ . "/../../fragments/breadcrumbs.php";
+                render_breadcrumbs(["historia" => "Nuestra Historia", "subpaginas" => "Índice Detallado"]);
+                ?>
+            </div>
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
                 <h3>Construcción y Materiales</h3>

--- a/historia/subpaginas/alfoz_cerezo_lantaron.php
+++ b/historia/subpaginas/alfoz_cerezo_lantaron.php
@@ -18,6 +18,12 @@
     </header>
     <main>
         <section class="section">
+            <div class="container">
+                <?php
+                require_once __DIR__ . "/../../fragments/breadcrumbs.php";
+                render_breadcrumbs(["historia" => "Nuestra Historia", "subpaginas" => "Índice Detallado"]);
+                ?>
+            </div>
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
                 <h3>Definición y Extensión del Alfoz</h3>

--- a/historia/subpaginas/auca_patricia_ubicacion.php
+++ b/historia/subpaginas/auca_patricia_ubicacion.php
@@ -12,53 +12,8 @@
     <?php require_once __DIR__ . "/../../fragments/header.php"; ?>
 
 <?php
+$titulo_pagina_actual = "Auca Patricia: Ubicación";
 $id_tema_actual = "auca_patricia_ubicacion"; // ID de esta página específica
-
-// Variables para los breadcrumbs
-$breadcrumb_inicio_url = "/index.php"; // O la URL correcta de tu página de inicio
-$breadcrumb_inicio_texto = "Inicio";
-$breadcrumb_historia_url = "/historia/historia.html"; // Enlace a la página principal de historia
-$breadcrumb_historia_texto = "Nuestra Historia"; // Texto por defecto
-$breadcrumb_indice_url = "/historia/subpaginas_indice.php";
-$breadcrumb_indice_texto = "Índice Detallado"; // Texto por defecto
-$breadcrumb_tema_actual_texto = "Tema Actual"; // Texto por defecto
-// Cargar JSON de índice detallado
-$json_indice_detallado_path = __DIR__ . '/../../../data/historia/indice_detallado.json';
-$indice_detallado_data = null;
-$error_message_breadcrumb = '';
-if (file_exists($json_indice_detallado_path)) {
-    $json_content = file_get_contents($json_indice_detallado_path);
-    $decoded_data = json_decode($json_content, true);
-    if (json_last_error() === JSON_ERROR_NONE) {
-        $indice_detallado_data = $decoded_data;
-        $breadcrumb_indice_texto = $indice_detallado_data['titulo_pagina'] ?? $breadcrumb_indice_texto;
-        // Encontrar el título del tema actual
-        if (isset($indice_detallado_data['temas_detallados']) && is_array($indice_detallado_data['temas_detallados'])) {
-            foreach ($indice_detallado_data['temas_detallados'] as $tema) {
-                if (isset($tema['id_tema']) && $tema['id_tema'] === $id_tema_actual) {
-                    $breadcrumb_tema_actual_texto = $tema['titulo_tema'] ?? $breadcrumb_tema_actual_texto;
-                    break;
-                }
-            }
-        }
-    } else {
-        $error_message_breadcrumb .= 'Error al decodificar indice_detallado.json. ';
-    }
-} else {
-    $error_message_breadcrumb .= 'No se pudo encontrar indice_detallado.json. ';
-}
-// Cargar JSON de historia_indice (para el título de "Nuestra Historia", si aplica)
-$json_historia_indice_path = __DIR__ . '/../../../data/historia/historia_indice.json';
-if (file_exists($json_historia_indice_path)) {
-    $json_content_hist = file_get_contents($json_historia_indice_path);
-    $decoded_data_hist = json_decode($json_content_hist, true);
-    if (json_last_error() === JSON_ERROR_NONE && isset($decoded_data_hist['titulo_general'])) {
-        // Podrías buscar una sección específica si la estructura lo permitiera mejor.
-        // Por ahora, si queremos ser más específicos, podríamos tomar el título de una sección si coincide con "historia.html"
-        // o simplemente usar el $breadcrumb_historia_texto = $decoded_data_hist['titulo_general']; si es apropiado.
-        // Para este ejemplo, mantendré el "Nuestra Historia" fijo ya que la estructura de historia_indice.json no está diseñada para esto.
-        $error_message_breadcrumb .= 'Error al decodificar historia_indice.json o título no encontrado. ';
-    $error_message_breadcrumb .= 'No se pudo encontrar historia_indice.json. ';
 // Título de la página actual (podría venir del JSON si esta página también fuera generada por el script)
 // Asumiendo que $pdo no está disponible aún, o para asegurar que sí lo esté.
 require_once __DIR__ . '/../../../includes/db_connect.php'; // Ajustar ruta si es necesario
@@ -77,19 +32,10 @@ require_once __DIR__ . '/../../../includes/text_manager.php';
     <main>
         <section class="section">
             <div class="container-epic">
-                <div class="breadcrumb-container">
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb">
-                            <li><a href="<?php echo htmlspecialchars($breadcrumb_inicio_url); ?>"><?php echo htmlspecialchars($breadcrumb_inicio_texto); ?></a></li>
-                            <li><a href="<?php echo htmlspecialchars($breadcrumb_historia_url); ?>"><?php echo htmlspecialchars($breadcrumb_historia_texto); ?></a></li>
-                            <li><a href="<?php echo htmlspecialchars($breadcrumb_indice_url); ?>"><?php echo htmlspecialchars($breadcrumb_indice_texto); ?></a></li>
-                            <li class="active" aria-current="page"><?php echo htmlspecialchars($breadcrumb_tema_actual_texto); ?></li>
-                        </ol>
-                    </nav>
-                    <?php if (!empty($error_message_breadcrumb)): ?>
-                        <p class="breadcrumb-error">Error en datos para breadcrumbs: <?php echo htmlspecialchars(trim($error_message_breadcrumb)); ?></p>
-                    <?php endif; ?>
-                </div>
+                <?php
+                require_once __DIR__ . "/../../fragments/breadcrumbs.php";
+                render_breadcrumbs(["historia" => "Nuestra Historia", "subpaginas" => "Índice Detallado"]);
+                ?>
                 <div class="article-content">
                     <p><a href="/historia/subpaginas_indice.php" class="back-link">&laquo; Volver al Índice Detallado</a></p>
                     <h3>La Identificación de Auca Patricia</h3>

--- a/historia/subpaginas/becerro_galicano_origen_castilla.php
+++ b/historia/subpaginas/becerro_galicano_origen_castilla.php
@@ -18,6 +18,12 @@
     </header>
     <main>
         <section class="section">
+            <div class="container">
+                <?php
+                require_once __DIR__ . "/../../fragments/breadcrumbs.php";
+                render_breadcrumbs(["historia" => "Nuestra Historia", "subpaginas" => "Índice Detallado"]);
+                ?>
+            </div>
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
                 <h3>Interpretación del Becerro Galicano</h3>

--- a/historia/subpaginas/condes_castilla_alava_cerasio.php
+++ b/historia/subpaginas/condes_castilla_alava_cerasio.php
@@ -18,6 +18,12 @@
     </header>
     <main>
         <section class="section">
+            <div class="container">
+                <?php
+                require_once __DIR__ . "/../../fragments/breadcrumbs.php";
+                render_breadcrumbs(["historia" => "Nuestra Historia", "subpaginas" => "Índice Detallado"]);
+                ?>
+            </div>
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
                 <h3>El Gobierno desde Cerasio</h3>

--- a/historia/subpaginas/evidencia_arqueologica_cerezo.php
+++ b/historia/subpaginas/evidencia_arqueologica_cerezo.php
@@ -18,6 +18,12 @@
     </header>
     <main>
         <section class="section">
+            <div class="container">
+                <?php
+                require_once __DIR__ . "/../../fragments/breadcrumbs.php";
+                render_breadcrumbs(["historia" => "Nuestra Historia", "subpaginas" => "Índice Detallado"]);
+                ?>
+            </div>
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
                 <h3>Murallas y Estructuras Urbanas</h3>

--- a/historia/subpaginas/legado_romano_emperadores_estructuras.php
+++ b/historia/subpaginas/legado_romano_emperadores_estructuras.php
@@ -18,6 +18,12 @@
     </header>
     <main>
         <section class="section">
+            <div class="container">
+                <?php
+                require_once __DIR__ . "/../../fragments/breadcrumbs.php";
+                render_breadcrumbs(["historia" => "Nuestra Historia", "subpaginas" => "Índice Detallado"]);
+                ?>
+            </div>
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
                 <h3>Emperadores Romanos y Auca Patricia</h3>

--- a/historia/subpaginas/obispado_auca_cerezo.php
+++ b/historia/subpaginas/obispado_auca_cerezo.php
@@ -18,6 +18,12 @@
     </header>
     <main>
         <section class="section">
+            <div class="container">
+                <?php
+                require_once __DIR__ . "/../../fragments/breadcrumbs.php";
+                render_breadcrumbs(["historia" => "Nuestra Historia", "subpaginas" => "Índice Detallado"]);
+                ?>
+            </div>
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
                 <h3 class="gradient-text">Auca Patricia y la Diócesis de Oca</h3>

--- a/historia/subpaginas/obispado_oca_auca.php
+++ b/historia/subpaginas/obispado_oca_auca.php
@@ -18,6 +18,12 @@
     </header>
     <main>
         <section class="section">
+            <div class="container">
+                <?php
+                require_once __DIR__ . "/../../fragments/breadcrumbs.php";
+                render_breadcrumbs(["historia" => "Nuestra Historia", "subpaginas" => "Índice Detallado"]);
+                ?>
+            </div>
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
                 <h3>La Sede Episcopal de Auca</h3>

--- a/historia/subpaginas/origenes_castellano_vulgar.php
+++ b/historia/subpaginas/origenes_castellano_vulgar.php
@@ -18,6 +18,12 @@
     </header>
     <main>
         <section class="section">
+            <div class="container">
+                <?php
+                require_once __DIR__ . "/../../fragments/breadcrumbs.php";
+                render_breadcrumbs(["historia" => "Nuestra Historia", "subpaginas" => "Índice Detallado"]);
+                ?>
+            </div>
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
                 <h3>El Alfoz de Cerezo y la Lengua Castellana</h3>

--- a/historia/subpaginas/san_vitores_san_formerio.php
+++ b/historia/subpaginas/san_vitores_san_formerio.php
@@ -18,6 +18,12 @@
     </header>
     <main>
         <section class="section">
+            <div class="container">
+                <?php
+                require_once __DIR__ . "/../../fragments/breadcrumbs.php";
+                render_breadcrumbs(["historia" => "Nuestra Historia", "subpaginas" => "Índice Detallado"]);
+                ?>
+            </div>
             <div class="container article-content">
                 <p><a href="/historia/historia.php" class="back-link">&laquo; Volver a Nuestra Historia</a></p>
                 <h3>San Formerio y el Circo Romano</h3>


### PR DESCRIPTION
## Summary
- add PHP fragment to build breadcrumbs from URL
- display breadcrumbs on historia subpages
- document breadcrumb usage

## Testing
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6856b690d9088329955ea5b911e9d034