### PR TITLE
Refactor JS into modules

### DIFF
--- a/assets/js/modules/forum.js
+++ b/assets/js/modules/forum.js
@@ -8,3 +8,4 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 });
+\nexport {};

--- a/assets/js/modules/gallery.js
+++ b/assets/js/modules/gallery.js
@@ -326,3 +326,4 @@ document.addEventListener('DOMContentLoaded', () => {
 
     fetchPieces(); // Initial fetch of pieces for the gallery
 });
+\nexport {};

--- a/assets/js/modules/iaTools.js
+++ b/assets/js/modules/iaTools.js
@@ -301,3 +301,4 @@ function showChatDialog(text) {
         dialog.style.display = 'block';
     }
 }
+\nexport {};

--- a/assets/js/modules/menu.js
+++ b/assets/js/modules/menu.js
@@ -330,3 +330,4 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     populateSidebarContents(); // Call it on initial load to populate the sidebar
 });
+\nexport {};

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -31,13 +31,13 @@ El panel también incluye `admin-menu.php` y `social-menu.html` dentro de bloque
 
 ## Personalización del menú deslizante y nuevas páginas
 * **Estilos**: modifica `assets/css/menus/consolidated-menu.css` para cambiar colores morado y oro viejo, anchura u otros efectos del panel `.menu-panel`.
-* **Comportamiento**: `assets/js/main.js` gestiona la apertura y cierre con el atributo `data-menu-target`.
+* **Comportamiento**: `assets/js/modules/menu.js` gestiona la apertura y cierre con el atributo `data-menu-target`.
 * **Añadir páginas**: edita `fragments/menus/main-menu.php` para crear nuevos enlaces y añade el archivo correspondiente en el directorio del proyecto.
 
 ### Clase `menu-compressed` y transformación de la página
 
 Al pulsar un botón con el atributo `data-menu-target="id-del-panel"`,
-`assets/js/main.js` abre el panel de menú indicado y añade la clase
+`assets/js/modules/menu.js` abre el panel de menú indicado y añade la clase
 `menu-compressed` al elemento `<body>`. También se aplica
 `menu-open-left` o `menu-open-right` según el lado del que se despliegue
 el panel. Estas clases están definidas en
@@ -154,18 +154,18 @@ Su estructura principal es la siguiente:
 - `<dialog id="ai-dialog">` y el área `#ai-response-box` sirven para
   mostrar la respuesta completa.
 
-`assets/js/main.js` controla la apertura y cierre de este panel utilizando
+`assets/js/modules/menu.js` controla la apertura y cierre de este panel utilizando
 el atributo `data-menu-target="ai-chat-panel"`. Cuando el panel se abre,
 el script enfoca `#gemini-chat-area` y permite cerrarlo al pulsar
 `#close-ai-drawer`. Las funciones concretas de cada botón se encuentran en
-`js/ia-tools.js`.
+`assets/js/modules/iaTools.js`.
 
 ### Modificar etiquetas o añadir nuevas acciones
 
 1. Abre `fragments/header/ai-drawer.html` y cambia el texto de los botones
    que necesites dentro de `#ia-tools-menu`.
 2. Si deseas una acción adicional, duplica un botón con un nuevo `id` y
-   escribe su manejador en `js/ia-tools.js` siguiendo el estilo de
+   escribe su manejador en `assets/js/modules/iaTools.js` siguiendo el estilo de
    `handleSummary()` o `handleResearch()`.
 3. Recarga los archivos JavaScript y CSS tras realizar los cambios para que
    tengan efecto en la web.

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -4,22 +4,22 @@ This document summarizes the purpose of the main JavaScript files present in the
 
 | File | Description |
 |------|-------------|
-| `assets/js/main.js` | Handles sliding menu interactions, closing behavior, and the light/dark theme toggle used across all pages. |
+| `assets/js/modules/menu.js` | Handles sliding menu interactions and the light/dark theme toggle. |
 | `assets/js/homonexus-toggle.js` | Toggles Homonexus mode, storing the preference in a cookie. |
-| `assets/js/foro.js` | Simple toggling for the forum agents menu. |
-| `/assets/js/audio-controller.js` | Lowers audio/video volume when sliding menus open. Other scripts, such as `assets/js/main.js`, invoke its `handleMenuToggle` function directly. |
+| `assets/js/modules/forum.js` | Simple toggling for the forum agents menu. |
+| `/assets/js/audio-controller.js` | Lowers audio/video volume when sliding menus open. The menu module dispatches events for it. |
 | `js/config.js` | Defines `API_BASE_URL` and `DEBUG_MODE` globals for other scripts. |
 | `js/layout.js` | Loads external CSS/JS libraries on demand, initializes the flashlight effect and other page-level utilities. If CDN requests fail, it falls back to bundled copies of GSAP and AOS located in `assets/vendor/`. |
 | ~~Header loader script~~ | **Deprecated.** The header is now loaded directly without this helper. See the README note on its removal. |
-| `js/ia-tools.js` | Implements AI assistant utilities such as summaries, translations and chat. |
+| `assets/js/modules/iaTools.js` | Implements AI assistant utilities such as summaries, translations and chat. |
 | `js/lang-bar.js` | Loads Google Translate when a `?lang=` URL parameter is present. |
 | `js/lugares-data.js` | Provides static data used by `lugares-dynamic-list.js`. |
 | `js/lugares-dynamic-list.js` | Generates the list of places dynamically from `lugares-data.js`. |
-| `js/museo-2d-gallery.js` | Logic for the collaborative museum 2D gallery including uploads and modals. |
+| `assets/js/modules/gallery.js` | Logic for the collaborative museum 2D gallery including uploads and modals. |
 | `js/museo-3d-main.js` | Initializes the 3D museum viewer built on Three.js. |
 | `js/museum-3d/` | Additional modules used by the 3D viewer. |
 
-Deprecated or merged scripts such as `js/menu-controller.js` and `js/sliding-menu.js` have been removed in favour of `assets/js/main.js`. The old header loading helper was also dropped as noted in the project README.
+Deprecated or merged scripts such as `js/menu-controller.js` and `js/sliding-menu.js` have been removed in favour of the module `assets/js/modules/menu.js`. The old header loading helper was also dropped as noted in the project README.
 
 ## Simplified Translation
 

--- a/foro/index.php
+++ b/foro/index.php
@@ -102,7 +102,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo) {
     <?php endforeach; ?>
 </main>
 <?php require_once __DIR__ . '/../fragments/footer.php'; ?>
-<script src="/assets/js/foro.js"></script>
+<script type="module" src="/assets/js/modules/forum.js"></script>
 
 </body>
 </html>

--- a/fragments/footer.php
+++ b/fragments/footer.php
@@ -19,7 +19,7 @@
         <p class="ai-notice">Este sitio incluye contenido generado con ayuda de IA. <a href="/docs/responsible-ai.md">Más información</a>.</p>
 </div>
 </footer>
-<script src="/assets/js/main.js"></script>
+<script type="module" src="/assets/js/modules/menu.js"></script>
 <script src="/assets/js/cave_mask.js"></script>
 <script src="/assets/js/hero.js"></script>
 <script src="/assets/js/scroll-fade.js"></script>

--- a/js/layout.js
+++ b/js/layout.js
@@ -169,9 +169,10 @@ function loadAos() {
 
 
 function loadIAToolsScript() {
-    if (!document.querySelector('script[src="/js/ia-tools.js"]')) {
+    if (!document.querySelector('script[src="/assets/js/modules/iaTools.js"]')) {
         const script = document.createElement('script');
-        script.src = '/js/ia-tools.js';
+        script.type = 'module';
+        script.src = '/assets/js/modules/iaTools.js';
         document.head.appendChild(script);
     }
 }

--- a/museo/galeria.php
+++ b/museo/galeria.php
@@ -32,6 +32,6 @@
     <?php require_once __DIR__ . '/../fragments/footer.php'; ?>
     <script src="/js/config.js"></script>
     
-    <script src="/js/museo-2d-gallery.js"></script>
+    <script type="module" src="/assets/js/modules/gallery.js"></script>
 </body>
 </html>

--- a/museo/museo.php
+++ b/museo/museo.php
@@ -144,7 +144,7 @@
 
     <script src="/js/config.js"></script>
     
-    <script src="/js/museo-2d-gallery.js"></script>
+    <script type="module" src="/assets/js/modules/gallery.js"></script>
     <!-- Museo 3D Modules -->
     <script src="/js/museum-3d/utils.js"></script>
     <script src="/js/museum-3d/config.js"></script>

--- a/museo/subir_pieza.php
+++ b/museo/subir_pieza.php
@@ -97,6 +97,6 @@
     <?php require_once __DIR__ . '/../fragments/footer.php'; ?>
     <script src="/js/config.js"></script>
     
-    <script src="/js/museo-2d-gallery.js"></script>
+    <script type="module" src="/assets/js/modules/gallery.js"></script>
 </body>
 </html>

--- a/tests/moonToggleTest.js
+++ b/tests/moonToggleTest.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const {JSDOM} = require('jsdom');
 
 const headerHtml = fs.readFileSync('fragments/header.php', 'utf8');
-const scriptJs = fs.readFileSync('assets/js/main.js', 'utf8');
+const scriptJs = fs.readFileSync('assets/js/modules/menu.js', 'utf8');
 
 const dom = new JSDOM(`<body>${headerHtml}</body>`, {
   runScripts: "dangerously",
@@ -14,6 +14,7 @@ const {window} = dom;
 window.localStorage.setItem('theme', 'dark');
 
 const scriptEl = window.document.createElement('script');
+scriptEl.type = 'module';
 scriptEl.textContent = scriptJs;
 window.document.body.appendChild(scriptEl);
 

--- a/tests/themeToggleTest.js
+++ b/tests/themeToggleTest.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const {JSDOM} = require('jsdom');
 
 const headerHtml = fs.readFileSync('fragments/header.php', 'utf8');
-const scriptJs = fs.readFileSync('assets/js/main.js', 'utf8');
+const scriptJs = fs.readFileSync('assets/js/modules/menu.js', 'utf8');
 
 const dom = new JSDOM(`<body>${headerHtml}</body>`, {
   runScripts: "dangerously",
@@ -14,6 +14,7 @@ const {window} = dom;
 window.localStorage.setItem('theme', 'dark');
 
 const scriptEl = window.document.createElement('script');
+scriptEl.type = 'module';
 scriptEl.textContent = scriptJs;
 window.document.body.appendChild(scriptEl);
 


### PR DESCRIPTION
## Summary
- migrate core scripts to ES modules under `assets/js/modules`
- update pages to use the new module scripts
- document updated module structure

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856b6ae801483298308b85d11dccf2c