### PR TITLE
Add scripts admin page

### DIFF
--- a/fragments/menus/admin-menu.php
+++ b/fragments/menus/admin-menu.php
@@ -4,6 +4,7 @@ echo '<ul id="admin-menu" class="nav-links">';
 if (is_admin_logged_in()) {
     echo '<li><a href="/dashboard/logout.php">Cerrar sesión</a></li>';
     echo '<li><a href="/dashboard/index.php">Panel</a></li>';
+    echo '<li><a href="/scripts_admin.php">Scripts</a></li>';
 } else {
     echo '<li><a href="/dashboard/login.php">Admin</a></li>';
 }

--- a/scripts_admin.php
+++ b/scripts_admin.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/includes/session.php';
+ensure_session_started();
+require_once __DIR__ . '/includes/auth.php';
+require_admin_login();
+
+// Gather list of scripts in scripts/ directory
+$scriptsDir = __DIR__ . '/scripts';
+$scripts = [];
+if (is_dir($scriptsDir)) {
+    $entries = scandir($scriptsDir);
+    foreach ($entries as $entry) {
+        if ($entry === '.' || $entry === '..') continue;
+        $path = $scriptsDir . '/' . $entry;
+        if (is_file($path)) {
+            $scripts[] = $entry;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <?php require_once __DIR__ . '/includes/head_common.php'; ?>
+    <title>Administrar Scripts</title>
+</head>
+<body class="alabaster-bg">
+    <?php require_once __DIR__ . '/fragments/header.php'; ?>
+    <main class="container-epic">
+        <h1 class="gradient-text">Gestión de Scripts</h1>
+        <p style="color: var(--epic-purple-emperor);">Lista de scripts disponibles en el sistema.</p>
+        <?php if ($scripts): ?>
+            <ul>
+                <?php foreach ($scripts as $script): ?>
+                    <li>
+                        <a class="cta-button" href="scripts/<?php echo urlencode($script); ?>" download><?php echo htmlspecialchars($script); ?></a>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php else: ?>
+            <p>No se encontraron scripts.</p>
+        <?php endif; ?>
+        <p><a href="/dashboard/index.php" class="cta-button">Volver al Panel</a></p>
+    </main>
+    <?php require_once __DIR__ . '/fragments/footer.php'; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Scripts admin management page that lists available scripts
- include header and footer fragments
- add link in admin menu

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856c6059e8c832986b2036acb0cd7f9