### PR TITLE
Add script catalog

### DIFF
--- a/docs/script_catalog.md
+++ b/docs/script_catalog.md
@@ -1,0 +1,30 @@
+# Catálogo de scripts
+
+Este documento recopila los scripts disponibles en el directorio `scripts/` y su propósito.
+
+| Script | Descripción |
+|-------|-------------|
+| `ai_whisper_generator.py` | Genera "whispers" o frases breves a partir de datos de personajes. |
+| `character_parser.py` | Extrae información de archivos HTML con biografías. |
+| `chat_cli.php` | Cliente en línea de comandos para el asistente IA. |
+| `check_alt_texts.sh` | Busca imágenes sin atributo `alt` en el proyecto. |
+| `check_db.sh` | Comprueba la conectividad con la base de datos PostgreSQL. |
+| `compress_images.sh` | Crea versiones optimizadas y miniaturas de imágenes. |
+| `daily_agent.py` | Ejecuta tareas periódicas como generar el sitemap o revisar enlaces. |
+| `export_menu_links.php` | Lista las URL del menú principal para revisarlas rápidamente. |
+| `extract_parent_child.py` | Genera `docs/parent_child_pairs.md` con relaciones de parentesco. |
+| `extract_translations.py` | Reúne cadenas de texto y produce archivos JSON de traducción. |
+| `gemini_request.sh` | Ejemplo de petición a la API Gemini. |
+| `generar_json_historia.php` | Convierte el contenido de `historia/` a archivos JSON estructurados. |
+| `generate_sitemap.py` | Crea `sitemap.xml` a partir de las páginas del sitio. |
+| `install_dev_deps.sh` | Instala dependencias de PHP y Python para desarrollo. |
+| `link_checker.py` | Escanea el HTML del repositorio y detecta enlaces rotos. |
+| `process_characters.py` | Combina el parser y el generador de whispers para producir datos enriquecidos. |
+| `run_accessibility_audit.sh` | Ejecuta Lighthouse para auditar la accesibilidad de varias páginas. |
+| `setup_environment.sh` | Verifica e instala runtimes y dependencias básicas. |
+| `setup_frontend_libs.sh` | Descarga bibliotecas JS/CSS y las copia a `assets/vendor`. |
+| `setup_project.sh` | Configura el proyecto completo y crea archivos iniciales. |
+| `structure_analyzer.py` | Informa de duplicados y de etiquetas mal ubicadas en las plantillas. |
+| `test_gemini_error.php` | Demostración de manejo de errores al llamar a Gemini. |
+
+Para ejemplos de uso y opciones adicionales, revisa cada archivo directamente en el directorio `scripts/`.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -102,7 +102,7 @@ Para agilizar la carga se recomienda emplear formatos modernos y limitar las dim
 - Formato **WebP** para fotos y capturas; **PNG** solo cuando se necesite transparencia.
 - Anchura máxima de **1920&nbsp;px** en imágenes de cabecera y **800&nbsp;px** para el resto.
 - El peso ideal está por debajo de **300&nbsp;KB**. Cualquier imagen que supere **1&nbsp;MB** debería revisarse.
-- Utiliza el script [`scripts/compress_images.sh`](../scripts/compress_images.sh) para generar versiones optimizadas o miniaturas.
+- Para generar versiones optimizadas o miniaturas se dispone de un script descrito en [script_catalog.md](script_catalog.md).
 
 Actualmente existen archivos superiores a 2&nbsp;MB en `assets/img/` (por ejemplo `GonzaloTellez.png`), conviene reconvertirlos a WebP o aplicar compresión.
 

--- a/docs/tareas.md
+++ b/docs/tareas.md
@@ -19,6 +19,6 @@
 La auditoría de accesibilidad se centró en los roles ARIA de los botones y paneles de navegación.
 Se confirmó que el encabezado y los menús deslizantes usan puntos de corte de **480 px**, **768 px** y **992 px**,
 garantizando que su posición fija no obstaculice la navegación en móviles.
-Tras ejecutar `./scripts/setup_environment.sh` y servir la web con `php -S`, se
+Tras preparar el entorno con `setup_environment.sh` (ver [script_catalog.md](script_catalog.md)) y servir la web con `php -S`, se
 verificó que el botón `#consolidated-menu-button` permanece visible al hacer
 scroll en pantallas de 768 px o menos.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,7 +2,7 @@
 
 Esta guía explica cómo preparar el entorno y ejecutar las pruebas automatizadas del proyecto.
 ## Paso a paso
-1. Prepara el entorno y sus dependencias:
+1. Prepara el entorno y sus dependencias ejecutando `setup_environment.sh` (ver [script_catalog.md](script_catalog.md)):
 ```bash
 ./scripts/setup_environment.sh
 ```
@@ -46,15 +46,12 @@ Esto descargará `puppeteer` y los binarios de Chrome.
 
 ### Auditorías de accesibilidad
 
-El script `scripts/run_accessibility_audit.sh` permite generar informes de
-accesibilidad de las páginas principales mediante **Lighthouse**.
+Consulta las opciones del script en [script_catalog.md](script_catalog.md).
 
 ```bash
 ./scripts/run_accessibility_audit.sh
 ```
 
-Los resultados se guardan en `reports/accessibility/`. Ábrelos con el navegador
-para revisar posibles problemas.
 
 
 
@@ -64,7 +61,7 @@ para revisar posibles problemas.
 ```bash
 php -S localhost:8080
 ```
-- Si las dependencias fallaron al instalarse, vuelve a lanzar `./scripts/setup_environment.sh`.
+- Si las dependencias fallaron al instalarse, consulta [script_catalog.md](script_catalog.md) para volver a ejecutar el script de preparación.
 - Si Puppeteer informa que no se encuentra Chromium, ejecuta `npm ci` para reinstalar las dependencias.
 ## Resultados del 20/06/2025
 


### PR DESCRIPTION
## Summary
- document scripts in `docs/script_catalog.md`
- reference catalog from existing docs

## Testing
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py` *(fails: ModuleNotFoundError)*
- `vendor/bin/phpunit` *(fails: PHPUnit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c608d97c832982d79a0a0c39f589