### PR TITLE
Add graph DB interface tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,8 +15,13 @@ php -S localhost:8080
 vendor/bin/phpunit
 ```
 4. Ejecuta las pruebas de Python:
+   - Solo la suite de la interfaz de grafo:
 ```bash
-python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py
+python -m unittest tests/test_graph_db_interface.py
+```
+   - Toda la batería de pruebas de Python:
+```bash
+python -m unittest discover -s tests
 ```
 5. Ejecuta las pruebas de interfaz con Puppeteer:
 ```bash

--- a/tests/test_graph_db_interface.py
+++ b/tests/test_graph_db_interface.py
@@ -27,6 +27,15 @@ class GraphDBInterfaceTestCase(unittest.TestCase):
         self.db.add_or_update_resource(updated)
         self.assertEqual(self.db.get_resource(url).content, "actualizado")
 
+    def test_resource_persistence_across_instances(self):
+        url = "http://example.com/persist"
+        data = Resource(url=url, content="first")
+        self.db.add_or_update_resource(data)
+        # Reload DB from the same file path to verify persistence
+        new_db = GraphDBInterface(db_filepath=self.db.db_filepath)
+        self.assertTrue(new_db.resource_exists(url))
+        self.assertEqual(new_db.get_resource(url).content, "first")
+
     def test_add_link_creates_placeholders_and_prevents_duplicates(self):
         link = Link(source_url="http://src.com", target_url="http://dst.com")
         self.db.add_link(link)


### PR DESCRIPTION
## Summary
- test graph DB persistence across instances
- update testing guide with python usage

## Testing
- `pip install -q -r requirements.txt`
- `python -m unittest tests/test_graph_db_interface.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6856cb6b9944832991c2b4a09f5dd83b