### PR TITLE
Add forum comments API

### DIFF
--- a/ajax_actions/save_comment.php
+++ b/ajax_actions/save_comment.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/../includes/db_connect.php';
+
+$agent = $argv[1] ?? '';
+$comment = $argv[2] ?? '';
+$agent = is_string($agent) ? trim($agent) : '';
+$comment = is_string($comment) ? trim($comment) : '';
+
+if ($agent === '' || $comment === '') {
+    fwrite(STDERR, "Missing agent or comment\n");
+    exit(1);
+}
+
+if (!$pdo) {
+    fwrite(STDERR, "Database connection not available\n");
+    exit(1);
+}
+
+try {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS forum_comments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        agent VARCHAR(50) NOT NULL,
+        comment TEXT NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )");
+    $stmt = $pdo->prepare('INSERT INTO forum_comments (agent, comment) VALUES (:agent, :comment)');
+    $stmt->execute([':agent' => $agent, ':comment' => $comment]);
+    echo "success";
+} catch (Throwable $e) {
+    fwrite(STDERR, $e->getMessage());
+    exit(1);
+}
+?>

--- a/flask_app.py
+++ b/flask_app.py
@@ -3,6 +3,7 @@ from flask_caching import Cache
 from graph_db_interface import GraphDBInterface
 import os
 import subprocess
+import sqlite3
 
 app = Flask(__name__)
 cache = Cache(app, config={
@@ -11,6 +12,22 @@ cache = Cache(app, config={
 })
 
 db = GraphDBInterface()
+
+
+def get_forum_comments_from_db():
+    """Return forum comments grouped by agent as a dict."""
+    db_path = os.getenv('TEST_SQLITE_PATH') or os.path.join(os.path.dirname(__file__), 'forum.db')
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS forum_comments (id INTEGER PRIMARY KEY AUTOINCREMENT, agent TEXT NOT NULL, comment TEXT NOT NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+    )
+    rows = conn.execute('SELECT agent, comment, created_at FROM forum_comments ORDER BY created_at DESC').fetchall()
+    comments = {}
+    for row in rows:
+        comments.setdefault(row['agent'], []).append({'comment': row['comment'], 'created_at': row['created_at']})
+    conn.close()
+    return comments
 
 @app.route('/api/resource', methods=['GET', 'POST'])
 def resource_collection():
@@ -50,6 +67,36 @@ def chat_handler():
         return jsonify({'response': result.stdout.strip()})
     except Exception as exc:
         return jsonify({'error': str(exc)}), 500
+
+
+@app.route('/api/forum/comments', methods=['GET', 'POST'])
+def forum_comments_handler():
+    if request.method == 'POST':
+        data = request.get_json(silent=True) or {}
+        agent = str(data.get('agent', '')).strip()
+        comment = str(data.get('comment', '')).strip()
+        if not agent or not comment:
+            return jsonify({'error': "'agent' and 'comment' are required"}), 400
+        script_path = os.path.join(os.path.dirname(__file__), 'ajax_actions', 'save_comment.php')
+        try:
+            result = subprocess.run(
+                ['php', script_path, agent, comment],
+                capture_output=True,
+                text=True,
+                check=False
+            )
+            if result.returncode != 0:
+                error_msg = result.stderr.strip() or result.stdout.strip() or 'Unknown error'
+                return jsonify({'error': f'PHP error: {error_msg}'}), 500
+            return jsonify({'success': True})
+        except Exception as exc:
+            return jsonify({'error': str(exc)}), 500
+    else:
+        try:
+            comments = get_forum_comments_from_db()
+            return jsonify(comments)
+        except Exception as exc:
+            return jsonify({'error': str(exc)}), 500
 
 if __name__ == '__main__':
     debug_env = os.getenv('FLASK_DEBUG')

--- a/js/config.js
+++ b/js/config.js
@@ -2,3 +2,5 @@ const API_BASE_URL = '';
 window.API_BASE_URL = API_BASE_URL;
 const DEBUG_MODE = false;
 window.DEBUG_MODE = DEBUG_MODE;
+const FORUM_COMMENTS_ENDPOINT = `${API_BASE_URL}/api/forum/comments`;
+window.FORUM_COMMENTS_ENDPOINT = FORUM_COMMENTS_ENDPOINT;


### PR DESCRIPTION
## Summary
- implement forum comments API endpoint
- create CLI PHP handler for saving comments
- expose new endpoint in `config.js`
- test new API route

## Testing
- `python -m pytest -q tests/test_flask_api.py`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856cb6e04ec83299ceecad4d8d6c151