### PR TITLE
Enhance sliding menu scaling

### DIFF
--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -60,7 +60,7 @@
 /* Slightly scale down the page when any slide menu is active */
 body.menu-compressed {
     transition: transform 0.3s ease;
-    transform: scaleX(0.92);
+    transform: scale(0.96);
     transform-origin: center;
 }
 
@@ -69,11 +69,11 @@ body.menu-open-right {
     transition: transform 0.3s ease;
 }
 body.menu-open-left {
-    transform: translateX(260px) scaleX(0.92);
+    transform: translateX(260px) scale(0.96);
     transform-origin: left center;
 }
 body.menu-open-right {
-    transform: translateX(-260px) scaleX(0.92);
+    transform: translateX(-260px) scale(0.96);
     transform-origin: right center;
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -49,6 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const open = !menu.classList.contains('sidebar-visible');
         menu.classList.toggle('sidebar-visible', open);
         document.body.classList.toggle('sidebar-active', open);
+        document.body.classList.toggle('menu-compressed', open);
         updateAria(btn, menu, open);
 
         if (open) {
@@ -93,6 +94,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     : (menu.classList.contains('right-panel') ? 'right' : '');
         const open = !menu.classList.contains('active');
         menu.classList.toggle('active', open);
+        document.body.classList.toggle('menu-compressed', open);
         updateAria(btn, menu, open);
         if (side) document.body.classList.toggle(`menu-open-${side}`, open);
 
@@ -119,7 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const sidebarOpen = document.getElementById(sidebarMenuId)?.classList.contains('sidebar-visible');
         const anyOpen = anyPanelOpen || sidebarOpen;
 
-        document.body.classList.toggle('menu-compressed', anyOpen && !sidebarOpen); // menu-compressed might only apply to panels
+        document.body.classList.toggle('menu-compressed', anyOpen);
 
         if (window.audioController && typeof window.audioController.handleMenuToggle === 'function') {
             window.audioController.handleMenuToggle(anyOpen);

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -38,7 +38,7 @@ El panel también incluye `admin-menu.php` y `social-menu.html` dentro de bloque
 
 Al pulsar un botón con el atributo `data-menu-target="id-del-panel"`,
 `assets/js/main.js` abre el panel de menú indicado y añade la clase
-`menu-compressed` al elemento `<body>`. También se aplica
+`menu-compressed` al elemento `<body>` para escalar la página. También se aplica
 `menu-open-left` o `menu-open-right` según el lado del que se despliegue
 el panel. Estas clases están definidas en
 `assets/css/sliding_menu.css`:
@@ -46,15 +46,20 @@ el panel. Estas clases están definidas en
 ```css
 body.menu-compressed {
     transition: transform 0.3s ease;
-    transform: scaleX(0.95);
+    transform: scale(0.96);
 }
 body.menu-open-left {
-    transform: translateX(260px) scaleX(0.95);
+    transform: translateX(260px) scale(0.96);
 }
 body.menu-open-right {
-    transform: translateX(-260px) scaleX(0.95);
+    transform: translateX(-260px) scale(0.96);
 }
 ```
+
+`assets/js/main.js` actualiza los atributos `aria-expanded` y `aria-hidden`
+de los botones y paneles cada vez que se abre o cierra un menú, y
+añade o quita la clase `menu-compressed` para aplicar la animación de
+escala.
 
 El contenido de la página se desplaza y se escala horizontalmente,
 comprimiéndose hacia el lado opuesto al menú abierto. Al cerrar todos


### PR DESCRIPTION
## Summary
- compress page using scale when slide menu is open
- toggle `menu-compressed` class via JavaScript and update ARIA
- document new animation behaviour

## Testing
- `./scripts/setup_environment.sh` *(failed: PHP 8.1 or higher is required but not found)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py`
- `vendor/bin/phpunit --testsuite unit` *(failed: command not found)*
- `npm run test:puppeteer` *(failed: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856cb70aeb88329a7a9cacb31f25170