### PR TITLE
Update docs references for graph and map

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,14 @@ npm run dev:astro
 ```
 
 La página principal se genera en `/piezas` y presenta las piezas en una cuadrícula adaptable.
+
+
+## Mapa interactivo
+
+Visita `lugares/mapa_interactivo.php` para explorar los principales monumentos y poblaciones sobre un mapa dinámico.
+
+## Actualización diaria del grafo de conocimiento
+
+El script `scripts/daily_agent.py` se ejecuta cada noche mediante GitHub Actions para revisar y actualizar `knowledge_graph_db.json`.
+
+Para detalles sobre la paleta de colores y la tipografía consulta [docs/style-guide.md](docs/style-guide.md), en especial las líneas 1‑24 que enumeran todas las variables CSS.

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,9 +145,11 @@ Los estilos coinciden con `assets/css/pages/historia_subpaginas_auca_patricia_ub
 - [Guía de Estilo](style-guide.md)
 - [Documentación del crawler](crawler.md)
 - [Interfaz de la base de datos de grafo](graph_db.md)
+- [API de consulta de grafo](../api/graph)
 - [Guía de Testing](testing.md)
 - [Gráfica de Influencia Romana](roman_influence_graph.md)
 - [Relaciones de Parentesco](parent_child_pairs.md)
+- [Visualizador del Árbol Genealógico](../personajes/genealogia/index.html)
 - [Guía Fullstack 2025](fullstack-tools-2025.md)
 
 La guía de estilo recoge la paleta en tonos morado y oro viejo con fondos de


### PR DESCRIPTION
## Summary
- mention the interactive map in README
- highlight the daily graph update script
- link to the genealogical tree viewer and new /api/graph endpoint in docs
- cite the style guide with the full color palette

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*
- `python -m unittest tests/test_graph_db_interface.py tests/test_flask_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6856cbd9c89883298105dfcbbc46f958