### PR TITLE
Add /api/graph endpoint

### DIFF
--- a/docs/graph_db.md
+++ b/docs/graph_db.md
@@ -64,3 +64,31 @@ all_links = db.get_all_links()
 ```
 
 Esta herramienta sirve de apoyo para organizar la información relacionada con Cerezo de Río Tirón y facilitar su análisis dentro del proyecto de promoción turística y gestión patrimonial.
+
+## Endpoint `/api/graph`
+
+El servicio Flask incluye una ruta para obtener todo el contenido del grafo en formato JSON.
+
+### Uso
+
+```
+GET /api/graph
+```
+
+Parámetros opcionales:
+
+- `start_date` – fecha en formato ISO‑8601 para filtrar los nodos y enlaces creados a partir de ese momento.
+- `limit` – número máximo de nodos a devolver. Los enlaces se limitan a los que conectan nodos presentes en el resultado.
+
+### Respuesta
+
+```json
+{
+  "nodes": [
+    {"url": "http://example.com", "last_crawled_at": "2024-01-01T00:00:00"}
+  ],
+  "links": [
+    {"source_url": "http://example.com", "target_url": "http://example.net"}
+  ]
+}
+```

--- a/tests/test_flask_api.py
+++ b/tests/test_flask_api.py
@@ -6,10 +6,13 @@ import flask_app
 class FakeDB:
     def __init__(self):
         self.resources = []
+        self.links = []
     def add_or_update_resource(self, data):
         self.resources.append(data)
     def get_all_resources(self):
         return self.resources
+    def get_all_links(self):
+        return self.links
 
 class FlaskApiTestCase(unittest.TestCase):
     def setUp(self):
@@ -50,6 +53,45 @@ class FlaskApiTestCase(unittest.TestCase):
         res = self.client.post('/api/chat', json={'prompt': 'hola'})
         self.assertEqual(res.status_code, 500)
         self.assertIn('error', res.get_json())
+
+    def test_graph_endpoint_basic(self):
+        flask_app.db.resources = [
+            {'url': 'http://a.com', 'last_crawled_at': '2020-01-01T00:00:00'}
+        ]
+        flask_app.db.links = [
+            {
+                'source_url': 'http://a.com',
+                'target_url': 'http://b.com',
+                'created_at': '2020-01-01T00:00:00'
+            }
+        ]
+
+        res = self.client.get('/api/graph')
+        self.assertEqual(res.status_code, 200)
+        data = res.get_json()
+        self.assertIn('nodes', data)
+        self.assertIn('links', data)
+        self.assertEqual(len(data['nodes']), 1)
+
+    def test_graph_endpoint_limit_and_start_date(self):
+        flask_app.db.resources = [
+            {'url': 'http://a.com', 'last_crawled_at': '2021-01-01T00:00:00'},
+            {'url': 'http://b.com', 'last_crawled_at': '2022-01-01T00:00:00'}
+        ]
+        flask_app.db.links = [
+            {
+                'source_url': 'http://a.com',
+                'target_url': 'http://b.com',
+                'created_at': '2022-01-01T00:00:00'
+            }
+        ]
+
+        res = self.client.get('/api/graph?limit=1&start_date=2022-01-01T00:00:00')
+        self.assertEqual(res.status_code, 200)
+        data = res.get_json()
+        self.assertEqual(len(data['nodes']), 1)
+        # after filtering, no links should remain because b.com node removed
+        self.assertEqual(len(data['links']), 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- provide a `/api/graph` route to return graph data
- document the new API in `docs/graph_db.md`
- extend Flask API tests for the new route

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856cbda1f5c8329b61141ae88dcea9d