### PR TITLE
Improve mobile text contrast

### DIFF
--- a/assets/css/mobile_contrast.css
+++ b/assets/css/mobile_contrast.css
@@ -2,11 +2,18 @@
   body {
     color: var(--color-negro-contraste);
   }
+  /* Override heading gradients so text remains readable */
+  h1,
   .gradient-text {
     background-image: none;
     color: var(--epic-purple-emperor);
     -webkit-background-clip: initial;
     background-clip: initial;
-    text-shadow: none;
+    text-shadow: 1px 1px 2px rgba(var(--color-negro-contraste-rgb), 0.6);
+  }
+
+  /* Slightly stronger background for tagline ribbons */
+  .tagline-background {
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.5);
   }
 }

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -66,6 +66,11 @@ diagonal que combina el morado principal (`--epic-purple-emperor`) y el
 oro viejo (`--epic-gold-main`) y aprovecha `background-clip: text` para
 dejar a la vista los colores de la paleta.
 
+Para dispositivos móviles existe una hoja específica,
+`mobile_contrast.css`, que desactiva estos degradados y define
+colores sólidos de alto contraste. Así se garantiza que los encabezados
+se lean con claridad incluso en pantallas pequeñas.
+
 ```html
 <h1 class="gradient-text">Descubre Cerezo</h1>
 ```


### PR DESCRIPTION
## Summary
- mention `mobile_contrast.css` in the style guide
- enhance heading legibility on small screens by disabling gradients and adding subtle text shadow

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856d7391d048329a5cd8460dc3c14d6