### PR TITLE
Add touchstart handler for menu toggles

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -130,7 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     // Use event delegation so dynamically injected buttons still work
-    document.addEventListener('click', (e) => {
+    const handleToggleEvent = (e) => {
         const btn = e.target.closest('[data-menu-target]');
         if (btn) {
             e.preventDefault();
@@ -147,7 +147,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 toggleMenu(btn);
             }
         }
-    });
+    };
+    document.addEventListener('click', handleToggleEvent);
+    document.addEventListener('touchstart', handleToggleEvent);
 
     document.addEventListener('click', (e) => {
         // Close panel menus if click is outside


### PR DESCRIPTION
## Summary
- support instant menu toggling on touch devices

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856d73d91f083298706989bba7a8332