### PR TITLE
Add menu link auto-close behavior

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -150,6 +150,20 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.addEventListener('click', (e) => {
+        const link = e.target.closest('.menu-panel a[href]');
+        if (link) {
+            const menu = link.closest('.menu-panel');
+            if (menu) {
+                if (menu.id === sidebarMenuId) {
+                    const sidebarBtn = document.getElementById('consolidated-menu-button');
+                    closeMobileSidebar(menu, sidebarBtn);
+                } else {
+                    const btn = document.querySelector(`[data-menu-target="${menu.id}"]`);
+                    closeMenu(menu, btn);
+                }
+            }
+        }
+
         // Close panel menus if click is outside
         document.querySelectorAll('.menu-panel.active').forEach(menu => {
             const btn = document.querySelector(`[data-menu-target="${menu.id}"]`);


### PR DESCRIPTION
## Summary
- close menus or sidebar when a menu link is activated

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6856d73c8ff8832995bce4de820285fb