### PR TITLE
Add nuevo4 summary doc and update links

### DIFF
--- a/contexto/nuevo4.md
+++ b/contexto/nuevo4.md
@@ -1,3 +1,7 @@
+## Notas preliminares
+Este archivo contiene apuntes sin filtrar.
+Consulte [docs/historia_ampliada_nuevo4.md](../docs/historia_ampliada_nuevo4.md) para un resumen estructado.
+
 
  
 Y ver cómo Pancorvo del Alfoz de cerezo, Valpuesta del Alfoz de cerezo, y Auca

--- a/docs/historia_ampliada_nuevo4.md
+++ b/docs/historia_ampliada_nuevo4.md
@@ -1,0 +1,21 @@
+# Origen de Castilla: Síntesis de *nuevo4.md*
+
+Este documento recoge las ideas principales halladas en `contexto/nuevo4.md` sobre la importancia de Cerezo de Río Tirón y Auca Patricia en el nacimiento de Castilla. Resume el contenido extenso para facilitar su consulta en la web.
+
+## Cerasio y el Alfoz
+- El **Alcázar de Cerasio**, construido con alabastro, llegó a medir cerca de 1200 metros y albergó la corte condal que administraba Castilla y Álava.
+- La fortaleza presidía un amplio alfoz que incluía enclaves como **Valpuesta** y **Pancorbo**, considerados pilares en la configuración temprana del condado.
+
+## Simbología del escudo
+- El escudo de Cerezo muestra una estrella sobre una puerta. `nuevo4.md` la relaciona con monedas romanas, algunas halladas en la zona, donde aparece una estrella sobre la puerta de un campamento.
+
+## Restos romanos destacados
+- Se mencionan **teatros romanos**, murallas y torres aún visibles en el paraje de la Tejera.
+- En la **Vega de los Tormentos** existirían ruinas de un circo romano de unos 160&nbsp;m × 8&nbsp;m, asociado a los martirios de San Formerio y San Vitores.
+- Se localiza un **puerto fluvial** en el Gurugú, último tramo navegable del Ebro, que abastecía a la ciudad de Auca Patricia.
+
+## Legado cultural
+- Los textos sitúan a Cerezo en el origen del castellano por su cercanía a San Millán de la Cogolla y Valpuesta.
+- Documentos como *De rebus Hispaniae* y tradiciones locales refuerzan la relevancia de Auca Patricia como capital de la Cantábrica.
+
+Para más información histórica y referencias completas, consulte la sección [Nuestra Historia](../historia/historia.php).

--- a/historia/historia.php
+++ b/historia/historia.php
@@ -91,7 +91,7 @@
                         <div class="timeline-content">
                             <h3 class="gradient-text">Explorando Auca Patricia, Cerasio y los Orígenes de Castilla</h3>
                             <p>Un análisis detallado sobre la importancia de Auca Patricia, el Alcázar de Cerasio y su papel fundamental en la historia y origen de Castilla, basado en investigaciones y textos históricos.</p>
-                            <a href="/historia/nuestra_historia_nuevo4.php" class="read-more timeline-read-more">Leer Más Sobre los Orígenes de Castilla</a>
+                            <a href="/docs/historia_ampliada_nuevo4.md" class="read-more timeline-read-more">Resumen de Auca Patricia y Cerasio</a>
                         </div>
                     </li>
                     <li class="timeline-item scroll-fade opacity-0 transition-opacity duration-700" data-aos="fade-up" tabindex="0">

--- a/historia/subpaginas_indice.php
+++ b/historia/subpaginas_indice.php
@@ -48,7 +48,7 @@ load_page_css();
                     </div>
                 <?php else: ?>
                     <p class="intro-centered"><?php echo htmlspecialchars($descripcion_general); ?></p>
-                    <p class="text-center mb-25"><a href="/historia/nuestra_historia_nuevo4.html" class="read-more" style="background-color: var(--color-primario-purpura);">&laquo; Volver a la página principal de Nuestra Historia</a></p>
+                    <p class="text-center mb-25"><a href="/docs/historia_ampliada_nuevo4.md" class="read-more" style="background-color: var(--color-primario-purpura);">&laquo; Resumen de nuevo4</a></p>
                     <?php if (!empty($temas_detallados)): ?>
                         <ul class="subpage-index-list">
                             <?php foreach ($temas_detallados as $tema): ?>

--- a/scripts/generar_json_historia.php
+++ b/scripts/generar_json_historia.php
@@ -525,9 +525,9 @@ if (file_exists($ruta_linea_tiempo_html)) {
     echo "Error: No se encontró el archivo " . $ruta_linea_tiempo_html . "\n";
 }
 
-// Procesar historia/nuestra_historia_nuevo4.html
+// Procesar historia/historia_ampliada_nuevo4.md
 // Este se procesará como una subpágina detallada, pero con un id_tema y ruta_json_salida específicos
-$ruta_nuestra_historia_html = DIR_BASE_HTML . 'nuestra_historia_nuevo4.html';
+$ruta_nuestra_historia_html = DIR_BASE_HTML . 'historia_ampliada_nuevo4.md';
 $id_tema_nuestra_historia = 'origenes_castilla'; // Según el punto 7 del requerimiento
 // $ruta_json_nuestra_historia debe usar la nueva DIR_OUTPUT para la escritura temporal
 $ruta_json_escritura_nuestra_historia = DIR_OUTPUT . $id_tema_nuestra_historia . '.json';
@@ -539,7 +539,7 @@ if (file_exists($ruta_nuestra_historia_html)) {
         // Llamamos a procesar_subpagina_detallada directamente
             echo "Preparando para procesar y guardar origenes_castilla.json (nuestra_historia_nuevo4) en: " . $ruta_json_escritura_nuestra_historia . "\n"; // DEBUG
         procesar_subpagina_detallada(
-            'historia/nuestra_historia_nuevo4.html',
+            'historia/historia_ampliada_nuevo4.md',
             $id_tema_nuestra_historia,
                 $ruta_json_escritura_nuestra_historia,
             $xpath_nh,

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -193,7 +193,7 @@
     <lastmod>2025-06-21</lastmod>
   </url>
   <url>
-    <loc>https://condadodecastilla.com/historia/nuestra_historia_nuevo4.php</loc>
+    <loc>https://condadodecastilla.com/docs/historia_ampliada_nuevo4.md</loc>
     <lastmod>2025-06-21</lastmod>
   </url>
   <url>


### PR DESCRIPTION
## Summary
- add `docs/historia_ampliada_nuevo4.md` summarizing the extensive nuevo4 notes
- link from `contexto/nuevo4.md` to the new summary
- update PHP pages and sitemap to reference the new document
- adjust JSON generation script to use the new path

## Testing
- `./scripts/setup_environment.sh` *(fails: PHP 8.1 not found)*
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py` *(fails: missing Flask and FileLock)*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856cc134428832997453488bcf3bb4a