### PR TITLE
Add ConsistencyAnalyzer tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,9 +14,9 @@ php -S localhost:8080
 ```bash
 vendor/bin/phpunit
 ```
-4. Ejecuta las pruebas de Python:
+4. Ejecuta las pruebas de Python (todas las del directorio `tests`):
 ```bash
-python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py
+python -m unittest discover -s tests -v
 ```
 5. Ejecuta las pruebas de interfaz con Puppeteer:
 ```bash

--- a/tests/test_consistency_analyzer.py
+++ b/tests/test_consistency_analyzer.py
@@ -1,0 +1,90 @@
+import unittest
+
+from consistency_analyzer import ConsistencyAnalyzer
+
+
+class FakeDB:
+    def __init__(self, resources=None):
+        self.resources = resources or {}
+
+    def get_resource(self, url):
+        return self.resources.get(url)
+
+
+class ConsistencyAnalyzerTestCase(unittest.TestCase):
+    def setUp(self):
+        # prepare some resources for link coherence tests
+        self.db = FakeDB(
+            {
+                "http://valid.com": {
+                    "url": "http://valid.com",
+                    "content": "content" * 20,
+                    "metadata": {"title": "Valid"},
+                },
+                "http://short.com": {
+                    "url": "http://short.com",
+                    "content": "short",
+                    "metadata": {"title": "Short"},
+                },
+                "http://placeholder.com": {
+                    "url": "http://placeholder.com",
+                    "content": "N/A (placeholder)",
+                    "metadata": {"title": "Placeholder"},
+                },
+            }
+        )
+        self.analyzer = ConsistencyAnalyzer(self.db)
+
+    def test_resource_completeness_valid(self):
+        data = {
+            "url": "http://example.com",
+            "content": "A" * 60,
+            "metadata": {"title": "Title"},
+        }
+        result = self.analyzer.check_resource_completeness(data)
+        self.assertTrue(result["complete"])
+
+    def test_resource_completeness_missing_title(self):
+        data = {"url": "http://example.com", "content": "A" * 60, "metadata": {}}
+        result = self.analyzer.check_resource_completeness(data)
+        self.assertFalse(result["complete"])
+        self.assertIn("Missing or empty title", result["reason"])
+
+    def test_resource_completeness_short_content(self):
+        data = {
+            "url": "http://example.com",
+            "content": "short",
+            "metadata": {"title": "Title"},
+        }
+        result = self.analyzer.check_resource_completeness(data)
+        self.assertFalse(result["complete"])
+        self.assertIn("too short", result["reason"])
+
+    def test_link_coherence_valid(self):
+        link = {"source_url": "http://valid.com", "target_url": "http://short.com"}
+        result = self.analyzer.check_link_topical_coherence(link)
+        self.assertTrue(result["consistent"])
+
+    def test_link_coherence_missing_source(self):
+        link = {"source_url": "http://missing.com", "target_url": "http://short.com"}
+        result = self.analyzer.check_link_topical_coherence(link)
+        self.assertFalse(result["consistent"])
+        self.assertIn("not found", result["reason"])
+
+    def test_link_coherence_placeholder_target(self):
+        link = {
+            "source_url": "http://valid.com",
+            "target_url": "http://placeholder.com",
+        }
+        result = self.analyzer.check_link_topical_coherence(link)
+        self.assertFalse(result["consistent"])
+        self.assertIn("placeholder", result["reason"])
+
+    def test_link_coherence_missing_urls(self):
+        result = self.analyzer.check_link_topical_coherence({})
+        self.assertFalse(result["consistent"])
+        self.assertIn("Missing source or target URL", result["reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add test file for ConsistencyAnalyzer covering resource completeness and link coherence across cases
- reference new test file in the docs
- update Python testing instructions to run all tests via unittest discover

## Testing
- `python -m unittest tests/test_consistency_analyzer.py -v`
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_6856cbdb99f483299256a2bd89893a61