### PR TITLE
Add documentation page link

### DIFF
--- a/config/main_menu.php
+++ b/config/main_menu.php
@@ -22,5 +22,6 @@ return [
     ['label' => 'menu_gestion_yacimientos', 'url' => 'empresa/index.php'],
     ['label' => 'menu_foro', 'url' => 'foro/index.php'],
     ['label' => 'menu_blog', 'url' => 'blog.php'],
+    ['label' => 'menu_documentacion', 'url' => 'docs/index.php'],
     ['label' => 'menu_contacto', 'url' => 'contacto/contacto.php'],
 ];

--- a/docs/index.php
+++ b/docs/index.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__ . '/../includes/head_common.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+}
+use League\CommonMark\CommonMarkConverter;
+
+function render_markdown_file(string $path): string {
+    static $converter = null;
+    if ($converter === null) {
+        $converter = new CommonMarkConverter();
+    }
+    $markdown = file_get_contents($path);
+    return $converter->convert($markdown)->getContent();
+}
+
+$readme = __DIR__ . '/README.md';
+$docs = array_filter(glob(__DIR__ . '/*.md'), function($f) use ($readme) { return $f !== $readme; });
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <title>Documentación - Condado de Castilla</title>
+    <link rel="stylesheet" href="/assets/css/custom.css">
+</head>
+<body class="alabaster-bg">
+<?php require_once __DIR__ . '/../fragments/header.php'; ?>
+<main class="container page-content-block">
+    <h1 class="gradient-text">Documentación</h1>
+    <section class="section">
+        <?php if (file_exists($readme)): ?>
+            <?php echo render_markdown_file($readme); ?>
+        <?php endif; ?>
+    </section>
+    <section class="section">
+        <h2 class="section-title">Archivos</h2>
+        <ul class="doc-list">
+            <?php foreach ($docs as $doc): $name = basename($doc); ?>
+                <li><a href="<?php echo $name; ?>"><?php echo $name; ?></a></li>
+            <?php endforeach; ?>
+        </ul>
+    </section>
+</main>
+<?php require_once __DIR__ . '/../fragments/footer.php'; ?>
+</body>
+</html>

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -21,5 +21,6 @@
   "menu_foro": "Foro",
   "menu_blog": "Blog",
   "menu_contacto": "Contacto",
-  "menu_mapa_interactivo": "Mapa Interactivo"
+  "menu_mapa_interactivo": "Mapa Interactivo",
+  "menu_documentacion": "Documentación"
 }


### PR DESCRIPTION
## Summary
- add Spanish translation for docs menu
- link new Documentation page in main navigation
- render README and list docs in docs/index.php

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856d9c6a0348329b0913f0e2cd68b1c