### PR TITLE
Add testing instructions and helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,23 @@ Visita `lugares/mapa_interactivo.php` para explorar los principales monumentos y
 El script `scripts/daily_agent.py` se ejecuta cada noche mediante GitHub Actions para revisar y actualizar `knowledge_graph_db.json`.
 
 Para detalles sobre la paleta de colores y la tipografía consulta [docs/style-guide.md](docs/style-guide.md), en especial las líneas 1‑24 que enumeran todas las variables CSS.
+
+## Testing
+
+Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar todas las pruebas. Los pasos básicos son:
+
+1. Instala las dependencias con `./scripts/setup_environment.sh`.
+2. Si la suite incluye pruebas de interfaz, arranca un servidor PHP con:
+   ```bash
+   php -S localhost:8080
+   ```
+3. Ejecuta las pruebas de PHP:
+   ```bash
+   vendor/bin/phpunit
+   ```
+4. Ejecuta la batería completa de pruebas de Python:
+   ```bash
+   python -m unittest discover -s tests
+   ```
+
+También se proporciona `scripts/run_tests.sh` para instalar `requirements.txt` y lanzar la suite de forma directa.

--- a/docs/script_catalog.md
+++ b/docs/script_catalog.md
@@ -21,6 +21,7 @@ Este documento recopila los scripts disponibles en el directorio `scripts/` y su
 | `link_checker.py` | Escanea el HTML del repositorio y detecta enlaces rotos. |
 | `process_characters.py` | Combina el parser y el generador de whispers para producir datos enriquecidos. |
 | `run_accessibility_audit.sh` | Ejecuta Lighthouse para auditar la accesibilidad de varias páginas. |
+| `run_tests.sh` | Instala dependencias de Python y ejecuta la batería completa de pruebas. |
 | `setup_environment.sh` | Verifica e instala runtimes y dependencias básicas. |
 | `setup_frontend_libs.sh` | Descarga bibliotecas JS/CSS y las copia a `assets/vendor`. |
 | `setup_project.sh` | Configura el proyecto completo y crea archivos iniciales. |

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+pip install -r requirements.txt
+python -m unittest discover -s tests


### PR DESCRIPTION
## Summary
- detail testing workflow in README
- document `run_tests.sh` in script catalog
- add `run_tests.sh` helper script

## Testing
- `python -m unittest discover -s tests`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6856da1b2c7483298a5f6b631bc09704