### PR TITLE
Fix touch-click menu toggle issue

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -148,8 +148,19 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     };
-    document.addEventListener('click', handleToggleEvent);
-    document.addEventListener('touchstart', handleToggleEvent);
+
+    let touchHandled = false;
+    document.addEventListener('touchstart', (e) => {
+        touchHandled = true;
+        handleToggleEvent(e);
+    });
+    document.addEventListener('click', (e) => {
+        if (touchHandled) {
+            touchHandled = false;
+            return;
+        }
+        handleToggleEvent(e);
+    });
 
     document.addEventListener('click', (e) => {
         const link = e.target.closest('.menu-panel a[href]');


### PR DESCRIPTION
## Summary
- prevent duplicate clicks when menu buttons are tapped on touchscreens

## Testing
- `npm test` *(fails: cannot find module 'puppeteer')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_app')*

------
https://chatgpt.com/codex/tasks/task_e_6856da1f0ff88329beeea3deaed2a376