### PR TITLE
Fix menu link data provider for tests

### DIFF
--- a/tests/MainMenuLinksTest.php
+++ b/tests/MainMenuLinksTest.php
@@ -21,7 +21,10 @@ class MainMenuLinksTest extends TestCase {
     }
 
     public static function urlProvider(): array {
-        $html = file_get_contents(__DIR__.'/../fragments/menus/main-menu.php');
+        ob_start();
+        include __DIR__ . '/../fragments/menus/main-menu.php';
+        $html = ob_get_clean();
+
         $dom = new DOMDocument();
         libxml_use_internal_errors(true);
         $dom->loadHTML($html);
@@ -29,6 +32,9 @@ class MainMenuLinksTest extends TestCase {
         foreach ($dom->getElementsByTagName('a') as $a) {
             $href = $a->getAttribute('href');
             if ($href !== '') {
+                if ($href[0] !== '/') {
+                    $href = '/' . $href;
+                }
                 $urls[] = [$href];
             }
         }


### PR DESCRIPTION
## Summary
- execute the main menu fragment to capture generated HTML
- normalize URLs in the provider to start with '/'
- parse the output with DOMDocument as before

## Testing
- `vendor/bin/phpunit tests/MainMenuLinksTest.php`
- `vendor/bin/phpunit` *(fails: Errors: 4, Failures: 14)*

------
https://chatgpt.com/codex/tasks/task_e_6856da5bf60c83298efbed527afa7d02