### PR TITLE
Add script execution page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Promocionar el turismo de **Cerezo de Río Tirón** y proteger su patrimonio arq
 - `backend/` – API en Python (Flask) y herramientas de IA.
 - `docs/` – documentación completa.
 - `scripts/` – utilidades de desarrollo y mantenimiento.
+- `scripts_admin.php` – interfaz protegida para ejecutar esos scripts y revisar la salida.
 - `tests/` – pruebas automáticas.
 
 ## Tecnologías recomendadas

--- a/assets/css/admin_theme.css
+++ b/assets/css/admin_theme.css
@@ -166,3 +166,12 @@ body.edit-pieza-page td {
 body.edit-pieza-page th {
     background-color: var(--epic-neutral-bg);
 }
+
+.code-output {
+    background-color: var(--epic-neutral-bg);
+    padding: 10px;
+    border-radius: 4px;
+    white-space: pre-wrap;
+    font-family: monospace;
+    max-width: 100%;
+}

--- a/fragments/admin_header.php
+++ b/fragments/admin_header.php
@@ -28,6 +28,7 @@ if ($geminiNotice) {
             <li><a href="/museo/editar_pieza.php">Piezas Museo</a></li>
             <li><a href="/foro/manage_comments.php">Comentarios</a></li>
             <li><a href="/dashboard/create_user.php">Crear Usuario</a></li>
+            <li><a href="/scripts_admin.php">Scripts</a></li>
             <li><a href="/dashboard/logout.php">Cerrar sesión</a></li>
             <li><a href="/index.php">Inicio Sitio</a></li>
         </ul>

--- a/scripts_admin.php
+++ b/scripts_admin.php
@@ -7,6 +7,16 @@ require_admin_login();
 // Gather list of scripts in scripts/ directory
 $scriptsDir = __DIR__ . '/scripts';
 $scripts = [];
+$output = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['script'])) {
+    $selected = basename($_POST['script']);
+    $pathToRun = $scriptsDir . '/' . $selected;
+    if (is_file($pathToRun)) {
+        $output = shell_exec(escapeshellcmd($pathToRun) . ' 2>&1');
+    } else {
+        $output = 'Script no encontrado.';
+    }
+}
 if (is_dir($scriptsDir)) {
     $entries = scandir($scriptsDir);
     foreach ($entries as $entry) {
@@ -22,10 +32,11 @@ if (is_dir($scriptsDir)) {
 <html lang="es">
 <head>
     <?php require_once __DIR__ . '/includes/head_common.php'; ?>
+    <link rel="stylesheet" href="/assets/css/admin_theme.css">
     <title>Administrar Scripts</title>
 </head>
-<body class="alabaster-bg">
-    <?php require_once __DIR__ . '/fragments/header.php'; ?>
+<body class="alabaster-bg admin-page">
+    <?php require_once __DIR__ . '/fragments/admin_header.php'; ?>
     <main class="container-epic">
         <h1 class="gradient-text">Gestión de Scripts</h1>
         <p style="color: var(--epic-purple-emperor);">Lista de scripts disponibles en el sistema.</p>
@@ -33,12 +44,21 @@ if (is_dir($scriptsDir)) {
             <ul>
                 <?php foreach ($scripts as $script): ?>
                     <li>
-                        <a class="cta-button" href="scripts/<?php echo urlencode($script); ?>" download><?php echo htmlspecialchars($script); ?></a>
+                        <span class="script-name"><?php echo htmlspecialchars($script); ?></span>
+                        <form method="POST" style="display:inline;margin-left:0.5rem;">
+                            <input type="hidden" name="script" value="<?php echo htmlspecialchars($script); ?>">
+                            <button type="submit" class="cta-button">Ejecutar</button>
+                        </form>
+                        <a class="cta-button" href="scripts/<?php echo urlencode($script); ?>" download>Descargar</a>
                     </li>
                 <?php endforeach; ?>
             </ul>
         <?php else: ?>
             <p>No se encontraron scripts.</p>
+        <?php endif; ?>
+        <?php if ($output): ?>
+            <h2 class="gradient-text">Resultado de la Ejecución</h2>
+            <pre class="code-output"><?php echo htmlspecialchars($output); ?></pre>
         <?php endif; ?>
         <p><a href="/dashboard/index.php" class="cta-button">Volver al Panel</a></p>
     </main>


### PR DESCRIPTION
## Summary
- allow admin to execute server scripts and show results
- link script runner from admin header
- style script output area
- document script admin page

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856da0260208329af524d5f0441bc4e