### PR TITLE
Add menu group translations

### DIFF
--- a/i18n/es.json
+++ b/i18n/es.json
@@ -22,5 +22,9 @@
   "menu_blog": "Blog",
   "menu_contacto": "Contacto",
   "menu_mapa_interactivo": "Mapa Interactivo",
-  "menu_documentacion": "Documentación"
+  "menu_documentacion": "Documentación",
+  "group_historia_cultura": "Historia y Cultura",
+  "group_lugares_patrimonio": "Lugares y Patrimonio",
+  "group_servicios_visitante": "Servicios al Visitante",
+  "group_comunidad": "Comunidad"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -2566,5 +2566,9 @@
   "← Volver al listado": "",
   "☰ Expertos": "",
   "🌙 Modo luna": "",
-  "🌿 Alfoz de Cerezo y Lantarón": ""
+  "🌿 Alfoz de Cerezo y Lantarón": "",
+  "group_historia_cultura": "History and Culture",
+  "group_lugares_patrimonio": "Sites and Heritage",
+  "group_servicios_visitante": "Visitor Services",
+  "group_comunidad": "Community"
 }

--- a/translations/gl.json
+++ b/translations/gl.json
@@ -2566,5 +2566,9 @@
   "← Volver al listado": "",
   "☰ Expertos": "",
   "🌙 Modo luna": "",
-  "🌿 Alfoz de Cerezo y Lantarón": ""
+  "🌿 Alfoz de Cerezo y Lantarón": "",
+  "group_historia_cultura": "Historia e Cultura",
+  "group_lugares_patrimonio": "Lugares e Patrimonio",
+  "group_servicios_visitante": "Servizos ao Visitante",
+  "group_comunidad": "Comunidade"
 }


### PR DESCRIPTION
## Summary
- add menu group translations for Spanish
- translate menu groups to English and Galician
- include localization test results

## Testing
- `python3 -m json.tool i18n/es.json`
- `python3 -m json.tool translations/en.json`
- `python3 -m json.tool translations/gl.json`
- `python3 -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6856db9142a48329afae5d595638ab5f