### PR TITLE
Fix Markdown formatting across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ npm run dev:astro
 
 La página principal se genera en `/piezas` y presenta las piezas en una cuadrícula adaptable.
 
-
 ## Mapa interactivo
 
 Visita `lugares/mapa_interactivo.php` para explorar los principales monumentos y poblaciones sobre un mapa dinámico.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # Documentación
 
 Este directorio reúne todas las guías del proyecto **Condado de Castilla**.
-La misión principal es *promocionar el turismo en Cerezo de Río Tirón y*
-*proteger su patrimonio arqueológico y cultural*.
+La misión principal es _promocionar el turismo en Cerezo de Río Tirón y_
+_proteger su patrimonio arqueológico y cultural_.
 
 ## Árbol de directorios
 

--- a/docs/arqueologia.md
+++ b/docs/arqueologia.md
@@ -1,12 +1,15 @@
 # Arqueología de Cerezo de Río Tirón
 
 ## Restos romanos
+
 La antigua Auca Patricia se extiende frente al casco urbano actual. Entre sus ruinas se identifican tramos de muralla, un posible circo y el puerto fluvial que facilitó el transporte de mercancías por el Ebro. Las excavaciones sacan a la luz cerámicas, monedas y estructuras que confirman la importancia de este enclave en época imperial.
 
 ## Fortalezas medievales
+
 El alabastro de la ciudad romana sirvió para erigir el Alcázar de Cerasio y diversas torres defensivas. Estos restos reflejan la evolución del territorio desde la dominación musulmana hasta el surgimiento del condado castellano. A su alrededor se conservan caminos, ermitas y necrópolis que hablan de una ocupación continuada.
 
 ## Conservación y turismo
+
 Los hallazgos arqueológicos forman parte del patrimonio de Cerezo de Río Tirón. Su estudio contribuye a entender la transición de la Antigüedad al medievo y a fomentar el turismo cultural. Las visitas guiadas permiten descubrir la relevancia de este asentamiento en el origen de Castilla.
 
 Para consultar el índice completo de la documentación, visita [nuevo4.md](../nuevo4.md).

--- a/docs/crawler.md
+++ b/docs/crawler.md
@@ -3,6 +3,7 @@
 Esta página describe el pequeño crawler incluido en `crawler.py`. Su objetivo principal es recorrer páginas de manera controlada y extraer enlaces para poblar la base de datos de conocimiento. Actualmente el código ofrece una versión de demostración.
 
 ## ¿Qué hace `crawler.py`?
+
 - Simula la descarga de páginas web mediante `fetch_page`. Por ahora sólo responde con HTML predeterminado para `http://example.com` y `/another-page`.
 - Analiza el contenido con BeautifulSoup a través de `parse_html` para obtener el título y todos los enlaces válidos.
 - Genera un diccionario `web_resource_data` que almacena la URL, un identificador único y la fecha de rastreo.
@@ -11,6 +12,7 @@ Esta página describe el pequeño crawler incluido en `crawler.py`. Su objetivo 
 Este módulo es un punto de partida para construir un rastreador más completo. En el futuro puede integrarse con comprobaciones de `robots.txt`, manejo de errores HTTP o almacenamiento directo en la base de datos de grafo.
 
 ## Uso básico
+
 1. Instala las dependencias necesarias (ver `requirements.txt`).
 2. Ejecuta el script directamente para probar con `example.com`:
 
@@ -21,4 +23,5 @@ python crawler.py
 El resultado mostrará ejemplos de `WebResource` y de enlaces extraídos.
 
 ## Relación con el proyecto
+
 El rastreador sirve para recopilar información de diferentes páginas relacionadas con Cerezo de Río Tirón. Los datos generados pueden almacenarse en la base `knowledge_graph_db.json` mediante `graph_db_interface.py`.

--- a/docs/forum_agents.md
+++ b/docs/forum_agents.md
@@ -2,12 +2,12 @@
 
 El archivo `config/forum_agents.php` define la lista de expertos que participan en las conversaciones. Cada entrada del array contiene varios campos que caracterizan al agente.
 
-| Campo | Descripción |
-|-------|-------------|
-| `name` | Nombre visible del agente. |
-| `bio` | Breve reseña que destaca su trayectoria y su aportación a la comunidad. |
-| `expertise` | Área de especialización desde la que orienta a los usuarios. |
-| `avatar` | Ruta a la imagen representativa del agente en nuestra paleta de morado y oro viejo sobre fondo de alabastro. |
-| `role_icon` | Icono Font Awesome que identifica su rol y acompaña a su nombre en las respuestas. |
+| Campo       | Descripción                                                                                                  |
+| ----------- | ------------------------------------------------------------------------------------------------------------ |
+| `name`      | Nombre visible del agente.                                                                                   |
+| `bio`       | Breve reseña que destaca su trayectoria y su aportación a la comunidad.                                      |
+| `expertise` | Área de especialización desde la que orienta a los usuarios.                                                 |
+| `avatar`    | Ruta a la imagen representativa del agente en nuestra paleta de morado y oro viejo sobre fondo de alabastro. |
+| `role_icon` | Icono Font Awesome que identifica su rol y acompaña a su nombre en las respuestas.                           |
 
 Configurar correctamente estos campos respalda nuestra misión de **promocionar el turismo en Cerezo de Río Tirón y proteger su patrimonio arqueológico y cultural**. Los agentes actúan como guías temáticos que animan la participación y mantienen vivo el legado de Castilla.

--- a/docs/fullstack-tools-2025.md
+++ b/docs/fullstack-tools-2025.md
@@ -5,40 +5,49 @@ Este documento resume los lenguajes y frameworks sugeridos para el desarrollo de
 ## 🧠 Backend Moderno
 
 ### Rust
+
 - Actix
 - Axum
 
 ### Go
+
 - Gin
 - Echo
 - Fiber
 
 ### Elixir
+
 - Phoenix
 
 ### Python
+
 - FastAPI
 - Django
 - Flask
 
 ### Node.js / TypeScript
+
 - Express
 - NestJS
 - Fastify
 
 ### Deno
+
 - Fresh
 - Aleph.js
 
 ### Kotlin
+
 - Ktor
 - Spring Boot
 
 ### Java
+
 - Spring Boot
 - Micronaut
 
 ### Ruby
+
 - Ruby on Rails
 
 ---
@@ -46,9 +55,11 @@ Este documento resume los lenguajes y frameworks sugeridos para el desarrollo de
 ## 🎨 Frontend Moderno
 
 ### Lenguaje base
+
 - TypeScript
 
 ### Frameworks y Librerías
+
 - React
 - Next.js
 - Vue 3
@@ -104,4 +115,3 @@ Fullstack: Next.js + API en Python o Node (NestJS)
 ```
 
 Este proyecto sigue una estética basada en tonos morados y oro viejo sobre fondos de alabastro. Los menús son deslizantes, las letras presentan degradados de alto contraste y se emplea la versión más reciente de las bibliotecas JavaScript y las mejoras de CSS/HTML.
-

--- a/docs/graph_db.md
+++ b/docs/graph_db.md
@@ -3,12 +3,14 @@
 `graph_db_interface.py` implementa una interfaz sencilla para almacenar recursos web y enlaces en formato JSON. El archivo de persistencia predeterminado es `knowledge_graph_db.json`.
 
 ## Características principales
+
 - Guarda nodos (recursos) en un diccionario donde la clave es la URL. Cada nodo incluye un `id`, la fecha de rastreo y campos de contenido o metadatos.
 - Los enlaces se almacenan como una lista de diccionarios con `source_url`, `target_url` y un identificador propio.
 - Al agregar enlaces se crean recursos "placeholder" si la fuente o destino no existen aún.
 - Todos los cambios se guardan automáticamente en `knowledge_graph_db.json` para conservar el estado entre ejecuciones.
 
 ## Estructura de `knowledge_graph_db.json`
+
 El archivo contiene dos claves principales:
 
 ```json
@@ -19,7 +21,7 @@ El archivo contiene dos claves principales:
       "url": "http://example.com",
       "content": "Texto o título",
       "last_crawled_at": "fecha ISO",
-      "metadata": {"title": "Example Domain"}
+      "metadata": { "title": "Example Domain" }
     }
   },
   "edges": [
@@ -37,6 +39,7 @@ El archivo contiene dos claves principales:
 ```
 
 ## Uso básico
+
 1. Instancia la clase en tu aplicación:
 
 ```python
@@ -66,6 +69,7 @@ all_links = db.get_all_links()
 Esta herramienta sirve de apoyo para organizar la información relacionada con Cerezo de Río Tirón y facilitar su análisis dentro del proyecto de promoción turística y gestión patrimonial.
 
 ## Actualización del grafo
+
 El script `scripts/update_graph.py` automatiza el proceso de rastrear páginas y actualizar `knowledge_graph_db.json`. Utiliza `crawler.py` para obtener los enlaces y `GraphDBInterface` para almacenarlos. Al finalizar ejecuta `ConsistencyAnalyzer.analyze_graph_consistency()` para detectar problemas.
 
 ### Ejecución

--- a/docs/historia.md
+++ b/docs/historia.md
@@ -1,15 +1,19 @@
 # Historia de Cerezo de Río Tirón
 
 ## De la Antigüedad al Medievo
+
 Cerezo de Río Tirón hunde sus raíces en la ciudad romana de **Auca Patricia**. Junto al río se conservan vestigios de calzadas, murallas y un antiguo puerto fluvial que conectaba con el valle del Ebro. Tras la caída del Imperio, la zona mantuvo su relevancia como enclave visigodo y, más tarde, como parte de la frontera musulmana.
 
 ## Formación del Alcázar de Cerasio
+
 En el siglo VIII se levantó el Alcázar de Cerasio reutilizando el alabastro de la ciudad romana. Esta fortaleza dominaba el valle y sirvió de sede a los primeros condes que administraron Castilla y Álava. Su alfoz incluía lugares como Valpuesta y Pancorbo, pilares en la configuración del condado.
 
 ## Condado de Cerezo y Lantarón
+
 Desde Cerezo se gobernó un extenso territorio durante la Alta Edad Media. Figuras como Gonzalo Téllez o Álvaro Herraméliz dejaron constancia de la importancia estratégica del enclave. La unión de Cerezo y Lantarón marcó el comienzo de una organización política que daría lugar al posterior Condado de Castilla.
 
 ## Legado cultural
+
 La proximidad de Valpuesta y San Millán de la Cogolla sitúa a la comarca en el origen del castellano. La tradición recuerda a Cerezo como centro de poder y lugar de paso del Camino de Santiago. Hoy su patrimonio histórico invita a descubrir cómo surgió Castilla en torno a estas tierras.
 
 Para consultar el índice completo de la documentación, visita [nuevo4.md](../nuevo4.md).

--- a/docs/historia_ampliada_nuevo4.md
+++ b/docs/historia_ampliada_nuevo4.md
@@ -5,18 +5,21 @@ Su objetivo es apoyar la misión de **promocionar el turismo** y **gestionar el
 patrimonio arqueológico y cultural** de Cerezo de Río Tirón.
 
 ## Auca Patricia y sus vestigios
+
 La ciudad romana de Auca Patricia dominaba el valle. Entre sus restos se
 identifican calzadas, murallas y un puerto fluvial que conectaba con el Ebro.
 La continuidad del poblamiento se aprecia en las necrópolis y caminos
 adyacentes.
 
 ## Del alcázar medieval al condado
+
 Con el material de la ciudad romana se levantó el Alcázar de Cerasio.
 Esta fortaleza articuló el alfoz y consolidó el poder de los primeros condes
 castellanos. El control del territorio impulsó la aparición del condado de
 Castilla y Lantarón.
 
 ## Legado cultural y proyección turística
+
 La zona forma parte de la cuna del castellano junto a Valpuesta y San Millán.
 Hoy se potencian las rutas turísticas y las visitas guiadas para conservar y
 difundir este patrimonio.

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -1,25 +1,29 @@
 # Guía de index.php y el menú deslizante
 
 ## Secciones principales de `index.php`
+
 El archivo `index.php` actúa como portada del sitio y se organiza en varias secciones. Asignarles un identificador facilita enlazarlas desde el menú o desde otras páginas.
 
-| Sección (clase)                         | Contenido                                  | ID sugerido |
-|-----------------------------------------|---------------------------------------------|-------------|
-| `<header class="hero">`                | Escudo, texto editable y botón de historia | `hero`      |
-| `<section class="video-section">`      | Vídeo promocional de la zona                | `video`     |
-| `<section class="detailed-intro-section">` | Introducción a la memoria de la Hispanidad | `memoria`   |
-| `<section class="alternate-bg">`       | Tarjetas "Explora Nuestro Legado"           | `legado`    |
-| `<section>` (Personajes)                | Tarjetas de personajes históricos           | `personajes`|
-| `<section class="timeline-section-summary">` | Resumen cronológico                         | `timeline`  |
-| `<section class="immersion-section">`  | Invitación final a profundizar en la cultura| `cultura`   |
+| Sección (clase)                              | Contenido                                    | ID sugerido  |
+| -------------------------------------------- | -------------------------------------------- | ------------ |
+| `<header class="hero">`                      | Escudo, texto editable y botón de historia   | `hero`       |
+| `<section class="video-section">`            | Vídeo promocional de la zona                 | `video`      |
+| `<section class="detailed-intro-section">`   | Introducción a la memoria de la Hispanidad   | `memoria`    |
+| `<section class="alternate-bg">`             | Tarjetas "Explora Nuestro Legado"            | `legado`     |
+| `<section>` (Personajes)                     | Tarjetas de personajes históricos            | `personajes` |
+| `<section class="timeline-section-summary">` | Resumen cronológico                          | `timeline`   |
+| `<section class="immersion-section">`        | Invitación final a profundizar en la cultura | `cultura`    |
 
 Para usar anclas basta con añadir `id="..."` a cada elemento. Por ejemplo:
+
 ```html
-<section id="video" class="video-section section spotlight-active">...
+<section id="video" class="video-section section spotlight-active">...</section>
 ```
 
 ## Cómo `fragments/header.php` carga los menús
+
 El archivo `fragments/header.php` genera el panel deslizante derecho e inserta las diferentes secciones de menú leyendo los archivos de `fragments/menus/`:
+
 ```php
 <?php
 if (file_exists(__DIR__ . '/fragments/menus/main-menu.php')) {
@@ -27,12 +31,14 @@ if (file_exists(__DIR__ . '/fragments/menus/main-menu.php')) {
 }
 ?>
 ```
+
 El panel también incluye `admin-menu.php` y `social-menu.html` dentro de bloques `<div class="menu-section">`.
 
 ## Personalización del menú deslizante y nuevas páginas
-* **Estilos**: modifica `assets/css/menus/consolidated-menu.css` para cambiar colores morado y oro viejo, anchura u otros efectos del panel `.menu-panel`.
-* **Comportamiento**: `assets/js/main.js` gestiona la apertura y cierre con el atributo `data-menu-target`.
-* **Añadir páginas**: edita `fragments/menus/main-menu.php` para crear nuevos enlaces y añade el archivo correspondiente en el directorio del proyecto.
+
+- **Estilos**: modifica `assets/css/menus/consolidated-menu.css` para cambiar colores morado y oro viejo, anchura u otros efectos del panel `.menu-panel`.
+- **Comportamiento**: `assets/js/main.js` gestiona la apertura y cierre con el atributo `data-menu-target`.
+- **Añadir páginas**: edita `fragments/menus/main-menu.php` para crear nuevos enlaces y añade el archivo correspondiente en el directorio del proyecto.
 
 ### Clase `menu-compressed` y transformación de la página
 
@@ -45,14 +51,14 @@ el panel. Estas clases están definidas en
 
 ```css
 body.menu-compressed {
-    transition: transform 0.3s ease;
-    transform: scale(0.96);
+  transition: transform 0.3s ease;
+  transform: scale(0.96);
 }
 body.menu-open-left {
-    transform: translateX(260px) scale(0.96);
+  transform: translateX(260px) scale(0.96);
 }
 body.menu-open-right {
-    transform: translateX(-260px) scale(0.96);
+  transform: translateX(-260px) scale(0.96);
 }
 ```
 
@@ -69,23 +75,28 @@ posición original.
 Tras cualquier modificacion consulta la [Guia de Testing](testing.md) para ejecutar las pruebas.
 
 ## Contenedor `#fixed-header-elements`
+
 Este bloque fijo aparece al inicio de cada página y mantiene visibles los controles principales.
 
 ### Botones de control rápido
+
 Estos son los accesos que incorpora por defecto:
+
 - `#consolidated-menu-button` abre el panel lateral con toda la navegación.
 - `#ai-chat-trigger` para iniciar el chat desde el menú.
 - `#theme-toggle` alterna entre modo claro y oscuro.
 
 Al añadir más elementos al contenedor puede ser necesario ajustar la posición de los paneles deslizantes. Para ello define la variable `--menu-extra-offset` con la altura del contenedor y úsala junto a `--language-bar-offset` en `assets/css/menus/consolidated-menu.css`:
+
 ```css
 :root {
-    --menu-extra-offset: 48px;
+  --menu-extra-offset: 48px;
 }
 .menu-panel {
-    top: calc(var(--language-bar-offset) + var(--menu-extra-offset));
+  top: calc(var(--language-bar-offset) + var(--menu-extra-offset));
 }
 ```
+
 Esto evitará que los menús se oculten tras los botones fijos.
 
 ### Modificar la altura del contenedor
@@ -98,7 +109,6 @@ El índice incorpora una gráfica interactiva que muestra la huella de Roma en
 la región. Esta visualización se implementa con **D3.js** y cambia de paleta de
 colores automáticamente cuando el usuario activa el modo oscuro mediante el
 botón `#theme-toggle`.
-
 
 ## Configuración de los agentes del foro
 
@@ -121,7 +131,7 @@ return [
 Edita sus valores o añade nuevas claves para ampliar el listado de agentes.
 
 Los agentes deben respaldar la misión descrita en `docs/README.md`:
-*promocionar el turismo en Cerezo de Río Tirón y proteger su patrimonio arqueológico y cultural*. Cada experto contribuye a este objetivo desde su área:
+_promocionar el turismo en Cerezo de Río Tirón y proteger su patrimonio arqueológico y cultural_. Cada experto contribuye a este objetivo desde su área:
 
 - **historian** contextualiza la historia local para turistas y residentes.
 - **archaeologist** vela por la preservación de hallazgos.
@@ -178,7 +188,6 @@ el script enfoca `#gemini-chat-area` y permite cerrarlo al pulsar
 3. Recarga los archivos JavaScript y CSS tras realizar los cambios para que
    tengan efecto en la web.
 
-
 ## Administración de agentes del foro
 
 Existe una página protegida para modificar el archivo `config/forum_agents.php` de forma sencilla. Se encuentra en `backend/php/admin/forum_agents_admin.php` y solo es accesible tras iniciar sesión como administrador.
@@ -186,6 +195,6 @@ Existe una página protegida para modificar el archivo `config/forum_agents.php`
 1. Abre `/backend/php/admin/forum_agents_admin.php` en tu navegador.
 2. El formulario lista cada agente actual con campos para nombre, biografía y experiencia.
 3. Cambia los datos que necesites y pulsa **Guardar** para actualizar el archivo.
-4. Para añadir un nuevo agente rellena los campos del apartado *Añadir Nuevo Agente* indicando un identificador único.
+4. Para añadir un nuevo agente rellena los campos del apartado _Añadir Nuevo Agente_ indicando un identificador único.
 
 Al enviar el formulario se regenerará `config/forum_agents.php` con la nueva información.

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -2,23 +2,23 @@
 
 This document summarizes the purpose of the main JavaScript files present in the repository after consolidation.
 
-| File | Description |
-|------|-------------|
-| `assets/js/main.js` | Handles sliding menu interactions, closing behavior, and the light/dark theme toggle used across all pages. |
-| `assets/js/homonexus-toggle.js` | Toggles Homonexus mode, storing the preference in a cookie. |
-| `assets/js/foro.js` | Simple toggling for the forum agents menu. |
-| `/assets/js/audio-controller.js` | Lowers audio/video volume when sliding menus open. Other scripts, such as `assets/js/main.js`, invoke its `handleMenuToggle` function directly. |
-| `js/config.js` | Defines `API_BASE_URL` and `DEBUG_MODE` globals for other scripts. |
-| `js/layout.js` | Loads external CSS/JS libraries on demand, initializes the flashlight effect and other page-level utilities. If CDN requests fail, it falls back to bundled copies of GSAP and AOS located in `assets/vendor/`. |
-| ~~Header loader script~~ | **Deprecated.** The header is now loaded directly without this helper. See the README note on its removal. |
-| `js/ia-tools.js` | Implements AI assistant utilities such as summaries, translations and chat. |
-| `js/lang-bar.js` | Loads Google Translate when a `?lang=` URL parameter is present. |
-| `js/lugares-data.js` | Provides static data used by `lugares-dynamic-list.js`. |
-| `js/lugares-dynamic-list.js` | Generates the list of places dynamically from `lugares-data.js`. |
-| `js/museo-2d-gallery.js` | Logic for the collaborative museum 2D gallery including uploads and modals. |
-| `js/museo-3d-main.js` | Initializes the 3D museum viewer built on Three.js. |
-| `js/museum-3d/` | Additional modules used by the 3D viewer. |
-| `assets/js/toc-generator.js` | Builds a table of contents from headings inside `<main>` and injects a list of links styled with Tailwind. |
+| File                             | Description                                                                                                                                                                                                     |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `assets/js/main.js`              | Handles sliding menu interactions, closing behavior, and the light/dark theme toggle used across all pages.                                                                                                     |
+| `assets/js/homonexus-toggle.js`  | Toggles Homonexus mode, storing the preference in a cookie.                                                                                                                                                     |
+| `assets/js/foro.js`              | Simple toggling for the forum agents menu.                                                                                                                                                                      |
+| `/assets/js/audio-controller.js` | Lowers audio/video volume when sliding menus open. Other scripts, such as `assets/js/main.js`, invoke its `handleMenuToggle` function directly.                                                                 |
+| `js/config.js`                   | Defines `API_BASE_URL` and `DEBUG_MODE` globals for other scripts.                                                                                                                                              |
+| `js/layout.js`                   | Loads external CSS/JS libraries on demand, initializes the flashlight effect and other page-level utilities. If CDN requests fail, it falls back to bundled copies of GSAP and AOS located in `assets/vendor/`. |
+| ~~Header loader script~~         | **Deprecated.** The header is now loaded directly without this helper. See the README note on its removal.                                                                                                      |
+| `js/ia-tools.js`                 | Implements AI assistant utilities such as summaries, translations and chat.                                                                                                                                     |
+| `js/lang-bar.js`                 | Loads Google Translate when a `?lang=` URL parameter is present.                                                                                                                                                |
+| `js/lugares-data.js`             | Provides static data used by `lugares-dynamic-list.js`.                                                                                                                                                         |
+| `js/lugares-dynamic-list.js`     | Generates the list of places dynamically from `lugares-data.js`.                                                                                                                                                |
+| `js/museo-2d-gallery.js`         | Logic for the collaborative museum 2D gallery including uploads and modals.                                                                                                                                     |
+| `js/museo-3d-main.js`            | Initializes the 3D museum viewer built on Three.js.                                                                                                                                                             |
+| `js/museum-3d/`                  | Additional modules used by the 3D viewer.                                                                                                                                                                       |
+| `assets/js/toc-generator.js`     | Builds a table of contents from headings inside `<main>` and injects a list of links styled with Tailwind.                                                                                                      |
 
 Deprecated or merged scripts such as `js/menu-controller.js` and `js/sliding-menu.js` have been removed in favour of `assets/js/main.js`. The old header loading helper was also dropped as noted in the project README.
 

--- a/docs/menu-structure.md
+++ b/docs/menu-structure.md
@@ -2,30 +2,30 @@
 
 La siguiente tabla se genera a partir de [`config/main_menu.php`](../config/main_menu.php). Debe regenerarse cada vez que cambien los enlaces del menú principal.
 
-| URL | Etiqueta |
-| --- | -------- |
-| index.php | Inicio |
-| historia/historia.php | Nuestra Historia |
-| historia_cerezo/index.php | Historia de Cerezo |
-| historia/subpaginas/obispado_auca_cerezo.php | Obispado de Auca |
-| historia/influencia_romana.php | Influencia Romana |
-| alfoz/alfoz.php | El Alfoz |
-| lugares/lugares.php | Lugares Emblemáticos |
-| ruinas/index.php | Ruinas y Vestigios |
-| camino_santiago/camino_santiago.php | Camino de Santiago |
-| museo/galeria.php | Museo Colaborativo |
-| museo/museo_3d.php | Museo 3D |
-| museo/subir_pieza.php | Subir Pieza |
-| galeria/galeria_colaborativa.php | Galería Colaborativa |
-| tienda/index.php | Tienda |
-| visitas/visitas.php | Planifica Tu Visita |
-| citas/agenda.php | Programa de Citas |
-| cultura/cultura.php | Cultura y Legado |
-| personajes/indice_personajes.html | Personajes |
-| empresa/index.php | Gestión de Yacimientos |
-| foro/index.php | Foro |
-| blog.php | Blog |
-| contacto/contacto.php | Contacto |
+| URL                                          | Etiqueta               |
+| -------------------------------------------- | ---------------------- |
+| index.php                                    | Inicio                 |
+| historia/historia.php                        | Nuestra Historia       |
+| historia_cerezo/index.php                    | Historia de Cerezo     |
+| historia/subpaginas/obispado_auca_cerezo.php | Obispado de Auca       |
+| historia/influencia_romana.php               | Influencia Romana      |
+| alfoz/alfoz.php                              | El Alfoz               |
+| lugares/lugares.php                          | Lugares Emblemáticos   |
+| ruinas/index.php                             | Ruinas y Vestigios     |
+| camino_santiago/camino_santiago.php          | Camino de Santiago     |
+| museo/galeria.php                            | Museo Colaborativo     |
+| museo/museo_3d.php                           | Museo 3D               |
+| museo/subir_pieza.php                        | Subir Pieza            |
+| galeria/galeria_colaborativa.php             | Galería Colaborativa   |
+| tienda/index.php                             | Tienda                 |
+| visitas/visitas.php                          | Planifica Tu Visita    |
+| citas/agenda.php                             | Programa de Citas      |
+| cultura/cultura.php                          | Cultura y Legado       |
+| personajes/indice_personajes.html            | Personajes             |
+| empresa/index.php                            | Gestión de Yacimientos |
+| foro/index.php                               | Foro                   |
+| blog.php                                     | Blog                   |
+| contacto/contacto.php                        | Contacto               |
 
 ## Etiquetas de grupo
 

--- a/docs/parent_child_pairs.md
+++ b/docs/parent_child_pairs.md
@@ -2,11 +2,11 @@
 
 Lista de pares padre/madre e hijo/a extraídos de las biografías.
 
-| Progenitor | Descendiente |
-|-----------|--------------|
-| [Diego Rodriguez Porcelos](/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html) | [Fernando Díaz](/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html) |
-| Gonzalo Fernández (Primer Conde de Burgos | [Fernan Gonzalez](/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernan_gonzalez.html) |
-| [Magno Clemente Máximo](/personajes/Emperadores_Romanos_Hispanos_Auca/magno_clemente_maximo.html) | [Flavio Victor](/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_victor.html) |
-| Máximo | [Flavio Teodosio I El Grande](/personajes/Emperadores_Romanos_Hispanos_Auca/teodosio_i.html) |
-| Rodrigo | [Diego Rodriguez Porcelos](/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html) |
-| [Rodrigo El Conde](/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html) | [Diego Rodríguez Porcelos](/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html) |
+| Progenitor                                                                                                | Descendiente                                                                                              |
+| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [Diego Rodriguez Porcelos](/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html) | [Fernando Díaz](/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernando_diaz.html)                       |
+| Gonzalo Fernández (Primer Conde de Burgos                                                                 | [Fernan Gonzalez](/personajes/Condes_de_Castilla_Alava_y_Lantaron/fernan_gonzalez.html)                   |
+| [Magno Clemente Máximo](/personajes/Emperadores_Romanos_Hispanos_Auca/magno_clemente_maximo.html)         | [Flavio Victor](/personajes/Emperadores_Romanos_Hispanos_Auca/flavio_victor.html)                         |
+| Máximo                                                                                                    | [Flavio Teodosio I El Grande](/personajes/Emperadores_Romanos_Hispanos_Auca/teodosio_i.html)              |
+| Rodrigo                                                                                                   | [Diego Rodriguez Porcelos](/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html) |
+| [Rodrigo El Conde](/personajes/Condes_de_Castilla_Alava_y_Lantaron/rodrigo_el_conde.html)                 | [Diego Rodríguez Porcelos](/personajes/Condes_de_Castilla_Alava_y_Lantaron/diego_rodriguez_porcelos.html) |

--- a/docs/responsible-ai.md
+++ b/docs/responsible-ai.md
@@ -4,19 +4,25 @@ Este proyecto utiliza modelos de inteligencia artificial para generar algunos te
 Aunque los resultados se revisan, pueden contener errores o sesgos.
 
 Principios:
+
 - Transparencia sobre cuándo se usa IA.
 - Supervisión humana de los contenidos generados.
 - Corrección rápida de fallos o información inapropiada.
 
 Si detectas problemas, por favor avisa al equipo de administración.
+
 ## Protección de datos y privacidad
+
 La plataforma registra únicamente la información necesaria para prestar el servicio y nunca comparte datos personales con terceros. Los mensajes enviados a los modelos de IA se utilizan de forma transitoria y no se almacenan para entrenar sistemas externos. Cumplimos con la legislación española y el Reglamento General de Protección de Datos (RGPD).
 
 ## Transparencia hacia los usuarios
+
 Cada vez que se muestra un texto generado automáticamente se indica de forma explícita. El visitante puede identificar qué respuestas proceden de un modelo de IA y cuáles han sido escritas por el equipo editorial.
 
 ## Moderación del contenido generado
+
 Todo el material producido por IA pasa por un proceso de revisión. Los administradores pueden editar o retirar cualquier fragmento que infrinja nuestras normas de convivencia o contenga información inexacta.
 
 ## Cómo informar de contenido problemático
+
 Si detectas un resultado inadecuado o que crees que incumple esta política, envía un correo a [info@condadodecastilla.com](mailto:info@condadodecastilla.com) o utiliza el formulario de [contacto](../contacto/contacto.php). Incluye la URL y una breve descripción del problema para que podamos resolverlo con rapidez.

--- a/docs/roman_influence_graph.md
+++ b/docs/roman_influence_graph.md
@@ -29,13 +29,26 @@ Dentro del `<head>` de la misma página se define la adaptación al modo oscuro:
 
 ```html
 <style>
-    #roman-chart { position: relative; width: 100%; max-width: 700px; margin: 40px auto; }
-    .tooltip { background: rgba(255,255,255,0.9); color: var(--color-negro-contraste); }
-    @media (prefers-color-scheme: dark) {
-        .tooltip { background: rgba(0,0,0,0.85); color: var(--epic-text-light); }
-        #roman-chart .axis path,
-        #roman-chart .axis line { stroke: var(--epic-text-light); }
+  #roman-chart {
+    position: relative;
+    width: 100%;
+    max-width: 700px;
+    margin: 40px auto;
+  }
+  .tooltip {
+    background: rgba(255, 255, 255, 0.9);
+    color: var(--color-negro-contraste);
+  }
+  @media (prefers-color-scheme: dark) {
+    .tooltip {
+      background: rgba(0, 0, 0, 0.85);
+      color: var(--epic-text-light);
     }
+    #roman-chart .axis path,
+    #roman-chart .axis line {
+      stroke: var(--epic-text-light);
+    }
+  }
 </style>
 ```
 

--- a/docs/script_catalog.md
+++ b/docs/script_catalog.md
@@ -2,30 +2,30 @@
 
 Este documento recopila los scripts disponibles en el directorio `scripts/` y su propósito.
 
-| Script | Descripción |
-|-------|-------------|
-| `ai_whisper_generator.py` | Genera "whispers" o frases breves a partir de datos de personajes. |
-| `character_parser.py` | Extrae información de archivos HTML con biografías. |
-| `chat_cli.php` | Cliente en línea de comandos para el asistente IA. |
-| `check_alt_texts.sh` | Busca imágenes sin atributo `alt` en el proyecto. |
-| `check_db.sh` | Comprueba la conectividad con la base de datos PostgreSQL. |
-| `compress_images.sh` | Crea versiones optimizadas y miniaturas de imágenes. |
-| `daily_agent.py` | Ejecuta tareas periódicas como generar el sitemap o revisar enlaces. |
-| `export_menu_links.php` | Lista las URL del menú principal para revisarlas rápidamente. |
-| `extract_parent_child.py` | Genera `docs/parent_child_pairs.md` con relaciones de parentesco. |
-| `extract_translations.py` | Reúne cadenas de texto y produce archivos JSON de traducción. |
-| `gemini_request.sh` | Ejemplo de petición a la API Gemini. |
-| `generar_json_historia.php` | Convierte el contenido de `historia/` a archivos JSON estructurados. |
-| `generate_sitemap.py` | Crea `sitemap.xml` a partir de las páginas del sitio. |
-| `install_dev_deps.sh` | Instala dependencias de PHP y Python para desarrollo. |
-| `link_checker.py` | Escanea el HTML del repositorio y detecta enlaces rotos. |
-| `process_characters.py` | Combina el parser y el generador de whispers para producir datos enriquecidos. |
-| `run_accessibility_audit.sh` | Ejecuta Lighthouse para auditar la accesibilidad de varias páginas. |
-| `run_tests.sh` | Instala dependencias de Python y ejecuta la batería completa de pruebas. |
-| `setup_environment.sh` | Verifica e instala runtimes y dependencias básicas. |
-| `setup_frontend_libs.sh` | Descarga bibliotecas JS/CSS y las copia a `assets/vendor`. |
-| `setup_project.sh` | Configura el proyecto completo y crea archivos iniciales. |
-| `structure_analyzer.py` | Informa de duplicados y de etiquetas mal ubicadas en las plantillas. |
-| `test_gemini_error.php` | Demostración de manejo de errores al llamar a Gemini. |
+| Script                       | Descripción                                                                    |
+| ---------------------------- | ------------------------------------------------------------------------------ |
+| `ai_whisper_generator.py`    | Genera "whispers" o frases breves a partir de datos de personajes.             |
+| `character_parser.py`        | Extrae información de archivos HTML con biografías.                            |
+| `chat_cli.php`               | Cliente en línea de comandos para el asistente IA.                             |
+| `check_alt_texts.sh`         | Busca imágenes sin atributo `alt` en el proyecto.                              |
+| `check_db.sh`                | Comprueba la conectividad con la base de datos PostgreSQL.                     |
+| `compress_images.sh`         | Crea versiones optimizadas y miniaturas de imágenes.                           |
+| `daily_agent.py`             | Ejecuta tareas periódicas como generar el sitemap o revisar enlaces.           |
+| `export_menu_links.php`      | Lista las URL del menú principal para revisarlas rápidamente.                  |
+| `extract_parent_child.py`    | Genera `docs/parent_child_pairs.md` con relaciones de parentesco.              |
+| `extract_translations.py`    | Reúne cadenas de texto y produce archivos JSON de traducción.                  |
+| `gemini_request.sh`          | Ejemplo de petición a la API Gemini.                                           |
+| `generar_json_historia.php`  | Convierte el contenido de `historia/` a archivos JSON estructurados.           |
+| `generate_sitemap.py`        | Crea `sitemap.xml` a partir de las páginas del sitio.                          |
+| `install_dev_deps.sh`        | Instala dependencias de PHP y Python para desarrollo.                          |
+| `link_checker.py`            | Escanea el HTML del repositorio y detecta enlaces rotos.                       |
+| `process_characters.py`      | Combina el parser y el generador de whispers para producir datos enriquecidos. |
+| `run_accessibility_audit.sh` | Ejecuta Lighthouse para auditar la accesibilidad de varias páginas.            |
+| `run_tests.sh`               | Instala dependencias de Python y ejecuta la batería completa de pruebas.       |
+| `setup_environment.sh`       | Verifica e instala runtimes y dependencias básicas.                            |
+| `setup_frontend_libs.sh`     | Descarga bibliotecas JS/CSS y las copia a `assets/vendor`.                     |
+| `setup_project.sh`           | Configura el proyecto completo y crea archivos iniciales.                      |
+| `structure_analyzer.py`      | Informa de duplicados y de etiquetas mal ubicadas en las plantillas.           |
+| `test_gemini_error.php`      | Demostración de manejo de errores al llamar a Gemini.                          |
 
 Para ejemplos de uso y opciones adicionales, revisa cada archivo directamente en el directorio `scripts/`.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -2,38 +2,38 @@
 
 Esta guía resume la paleta de colores usada de forma consistente en todo el proyecto. Las variables CSS se definen en `assets/css/epic_theme.css` y pueden reutilizarse en cualquier página.
 
-| Variable | Descripción | Valor |
-|----------|-------------|-------|
-| `--color-primario-purpura` | Morado principal inspirado en el escudo | `#4A0D67` |
-| `--color-secundario-dorado` | Oro viejo para detalles y bordes | `#B8860B` |
-| `--color-acento-amarillo` | Acento amarillo brillante | `#FFD700` |
-| `--color-piedra-clara` | Beige claro para texto y fondos ligeros | `#EAE0C8` |
-| `--color-piedra-media` | Arenisca media para fondos secundarios | `#D2B48C` |
-| `--color-texto-principal` | Marrón oscuro para la tipografía | `#2c1d12` |
-| `--color-fondo-pagina` | Blanco hueso sutil de fondo | `#fdfaf6` |
-| `--epic-alabaster-bg` | Fondo principal de alabastro | `#fdfaf6` |
-| `--epic-alabaster-dawn` | Variante gris suave para el amanecer | `#e5e5e5` |
-| `--epic-gold-soft` | Oro pálido de las primeras horas | `#f3e5ab` |
-| `--epic-purple-vibrant` | Morado intenso para el día | `#6b46c1` |
-| `--epic-alabaster-dusk` | Fondo cálido del atardecer | `#efe2d2` |
-| `--epic-gold-dusk` | Dorado profundo del atardecer | `#f0b429` |
-| `--epic-orange-sunset` | Naranja brillante del ocaso | `#f97316` |
-| `--epic-text-night` | Texto claro para el modo nocturno | `#e0e0e0` |
-| `--color-negro-contraste` | Negro de alto contraste | `#1A1A1A` |
-| `--alert-bg` | Fondo de mensajes de alerta | `#ffdddd` |
-| `--alert-border` | Borde de mensajes de alerta | `#ff0000` |
-| `--alert-text` | Texto de mensajes de alerta | `#d8000c` |
-| `--menu-extra-offset` | Separación adicional para el menú consolidado | `60px` |
+| Variable                    | Descripción                                   | Valor     |
+| --------------------------- | --------------------------------------------- | --------- |
+| `--color-primario-purpura`  | Morado principal inspirado en el escudo       | `#4A0D67` |
+| `--color-secundario-dorado` | Oro viejo para detalles y bordes              | `#B8860B` |
+| `--color-acento-amarillo`   | Acento amarillo brillante                     | `#FFD700` |
+| `--color-piedra-clara`      | Beige claro para texto y fondos ligeros       | `#EAE0C8` |
+| `--color-piedra-media`      | Arenisca media para fondos secundarios        | `#D2B48C` |
+| `--color-texto-principal`   | Marrón oscuro para la tipografía              | `#2c1d12` |
+| `--color-fondo-pagina`      | Blanco hueso sutil de fondo                   | `#fdfaf6` |
+| `--epic-alabaster-bg`       | Fondo principal de alabastro                  | `#fdfaf6` |
+| `--epic-alabaster-dawn`     | Variante gris suave para el amanecer          | `#e5e5e5` |
+| `--epic-gold-soft`          | Oro pálido de las primeras horas              | `#f3e5ab` |
+| `--epic-purple-vibrant`     | Morado intenso para el día                    | `#6b46c1` |
+| `--epic-alabaster-dusk`     | Fondo cálido del atardecer                    | `#efe2d2` |
+| `--epic-gold-dusk`          | Dorado profundo del atardecer                 | `#f0b429` |
+| `--epic-orange-sunset`      | Naranja brillante del ocaso                   | `#f97316` |
+| `--epic-text-night`         | Texto claro para el modo nocturno             | `#e0e0e0` |
+| `--color-negro-contraste`   | Negro de alto contraste                       | `#1A1A1A` |
+| `--alert-bg`                | Fondo de mensajes de alerta                   | `#ffdddd` |
+| `--alert-border`            | Borde de mensajes de alerta                   | `#ff0000` |
+| `--alert-text`              | Texto de mensajes de alerta                   | `#d8000c` |
+| `--menu-extra-offset`       | Separación adicional para el menú consolidado | `60px`    |
 
 ## Tipografías
 
 Se definen dos familias de fuentes base disponibles a través de Tailwind. Las
 fuentes se gestionan mediante variables CSS:
 
-| Clase | Fuente |
-|-------|-------|
+| Clase            | Fuente                 |
+| ---------------- | ---------------------- |
 | `.font-headings` | `var(--font-headings)` |
-| `.font-body` | `var(--font-primary)` |
+| `.font-body`     | `var(--font-primary)`  |
 
 Estas utilidades permiten asignar de forma coherente la tipografía a títulos y
 textos de párrafo. Las clases se generan desde `tailwind.config.js`, donde se
@@ -51,12 +51,12 @@ Los equivalentes `-rgb` se encuentran en la misma hoja de estilos para crear tra
 El tema adapta automáticamente la interfaz cuando el navegador está en modo oscuro (`prefers-color-scheme: dark`).
 En ese caso se redefinen varios colores principales para mantener el contraste.
 
-| Variable | Descripción | Valor |
-|----------|-------------|-------|
-| `--epic-alabaster-bg` | Fondo principal oscuro | `#252B38` |
+| Variable                  | Descripción                  | Valor     |
+| ------------------------- | ---------------------------- | --------- |
+| `--epic-alabaster-bg`     | Fondo principal oscuro       | `#252B38` |
 | `--epic-alabaster-medium` | Tono intermedio para paneles | `#2a2f39` |
-| `--epic-text-color` | Texto principal claro | `#F0F0F0` |
-| `--epic-text-light` | Texto secundario | `#D8D8D8` |
+| `--epic-text-color`       | Texto principal claro        | `#F0F0F0` |
+| `--epic-text-light`       | Texto secundario             | `#D8D8D8` |
 
 ## Texto con degradado
 
@@ -111,7 +111,6 @@ Para agilizar la carga se recomienda emplear formatos modernos y limitar las dim
 
 Actualmente existen archivos superiores a 2&nbsp;MB en `assets/img/` (por ejemplo `GonzaloTellez.png`), conviene reconvertirlos a WebP o aplicar compresión.
 
-
 ## Accesibilidad
 
 Para resaltar los estados activos se emplean los atributos `aria-expanded` y `aria-hidden`.
@@ -120,11 +119,11 @@ Cuando un botón está expandido (`aria-expanded="true"`) o un panel visible
 
 ```css
 #consolidated-menu-button[aria-expanded="true"] {
-    background-color: var(--epic-gold-main);
-    color: var(--epic-purple-emperor);
+  background-color: var(--epic-gold-main);
+  color: var(--epic-purple-emperor);
 }
 .menu-panel[aria-hidden="false"] {
-    border: 2px solid var(--epic-gold-main);
+  border: 2px solid var(--epic-gold-main);
 }
 ```
 

--- a/docs/tareas.md
+++ b/docs/tareas.md
@@ -1,10 +1,12 @@
 # Lista de tareas
+
 - [x] Implementar menús deslizantes que compriman el contenido lateral.
 - [x] Aplicar paleta de morado y oro viejo según `docs/style-guide.md`.
 - [x] Añadir degradados de alto contraste en títulos.
 - [x] Crear un foro con cinco agentes expertos que dinamicen la comunidad.
 
 ## Nuevas tareas
+
 - [x] Documentar el crawler y la base de datos de grafo de conocimiento.
 - [x] Revisar la accesibilidad y el rendimiento en dispositivos móviles.
 - [x] Integrar el modo Homonexus y el chat IA en todas las páginas.
@@ -24,6 +26,7 @@ verificó que el botón `#consolidated-menu-button` permanece visible al hacer
 scroll en pantallas de 768 px o menos.
 
 ## Tareas en curso
+
 - [ ] Implementacion del efecto de compresion en los menus.
 - [ ] Creacion del componente de foro en React.
 - [ ] Extension de la API Flask para comentarios.

--- a/docs/test-results.md
+++ b/docs/test-results.md
@@ -1,15 +1,16 @@
 # Test Results - 2025-06-20
 
 ## `vendor/bin/phpunit`
+
 34 tests executed with 3 errors and 19 failures. Tras instalar `php-cgi` y
 `pdo_pgsql` las pruebas que requieren conexión a PostgreSQL siguen fallando
 porque la base de datos no está disponible.
 
 ## `python -m unittest`
+
 All tests passed.
 
 ## `npm run test:puppeteer`
+
 The suite failed with a timeout while waiting for `#google_translate_element`.
 Consulta la [Guia de Testing](testing.md) para revisar el paso a paso y la seccion de solucion de problemas.
-
-

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,32 +1,46 @@
 # Guía de Testing
 
 Esta guía explica cómo preparar el entorno y ejecutar las pruebas automatizadas del proyecto.
+
 ## Paso a paso
+
 1. Prepara el entorno y sus dependencias ejecutando `setup_environment.sh` (ver [script_catalog.md](script_catalog.md)):
+
 ```bash
 ./scripts/setup_environment.sh
 ```
+
 2. Si vas a ejecutar la suite de interfaz, abre otro terminal y arranca un servidor PHP local:
+
 ```bash
 php -S localhost:8080
 ```
+
 3. Ejecuta las pruebas de PHP:
+
 ```bash
 vendor/bin/phpunit
 ```
+
 4. Ejecuta las pruebas de Python:
    - Solo la suite de la interfaz de grafo:
+
 ```bash
 python -m unittest tests/test_graph_db_interface.py
 ```
-   - Toda la batería de pruebas de Python:
+
+- Toda la batería de pruebas de Python:
+
 ```bash
 python -m unittest discover -s tests
 ```
+
 5. Ejecuta las pruebas de interfaz con Puppeteer:
+
 ```bash
 npm run test:puppeteer
 ```
+
 ### Requisitos adicionales de PHP
 
 Las pruebas de PHP necesitan la interfaz **php-cgi** y la extensión
@@ -57,17 +71,17 @@ Consulta las opciones del script en [script_catalog.md](script_catalog.md).
 ./scripts/run_accessibility_audit.sh
 ```
 
-
-
-
 ## Solucion de problemas
 
 - Si al ejecutar `npm run test:puppeteer` obtienes un TimeoutError, comprueba que tienes un servidor PHP en marcha con:
+
 ```bash
 php -S localhost:8080
 ```
+
 - Si las dependencias fallaron al instalarse, consulta [script_catalog.md](script_catalog.md) para volver a ejecutar el script de preparación.
 - Si Puppeteer informa que no se encuentra Chromium, ejecuta `npm ci` para reinstalar las dependencias.
+
 ## Resultados del 20/06/2025
 
 - `vendor/bin/phpunit`: 34 tests executed with 3 errors and 19 failures. Tras instalar `php-cgi` y `pdo_pgsql` las pruebas que requieren conexión a PostgreSQL siguieron fallando porque la base de datos no estaba disponible.

--- a/docs/tradicion.md
+++ b/docs/tradicion.md
@@ -1,12 +1,15 @@
 # Tradición y cultura local
 
 ## Fiestas patronales
+
 Cerezo de Río Tirón celebra la memoria de San Formerio y San Vitores con procesiones y romerías que recuerdan el pasado romano y visigodo de la zona. Estas festividades unen a vecinos y visitantes en torno a la historia común del valle.
 
 ## Camino de Santiago
+
 Desde la Edad Media, el trazado del Camino de Santiago atravesaba la localidad. Los peregrinos encontraban hospitalidad y un puente sobre el río Tirón que facilitaba el paso hacia Burgos. Esta herencia se refleja hoy en la acogida y en las rutas que parten del casco urbano.
 
 ## Patrimonio vivo
+
 La arquitectura popular en alabastro y las tradiciones orales conservan la identidad de Cerezo. Las asociaciones locales promueven iniciativas para difundir el patrimonio cultural y mantener viva la huella de Castilla en este rincón burgalés.
 
 Para consultar el índice completo de la documentación, visita [nuevo4.md](../nuevo4.md).


### PR DESCRIPTION
## Summary
- run Prettier on the docs for consistent line wrapping
- ensure root README and guides maintain good legibility

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856dbf3caf48329afd0275e3334a62c