### PR TITLE
Add translation group keys

### DIFF
--- a/i18n/es.json
+++ b/i18n/es.json
@@ -22,5 +22,9 @@
   "menu_blog": "Blog",
   "menu_contacto": "Contacto",
   "menu_mapa_interactivo": "Mapa Interactivo",
-  "menu_documentacion": "Documentación"
+  "menu_documentacion": "Documentación",
+  "group_historia_cultura": "Historia y Cultura",
+  "group_lugares_patrimonio": "Lugares y Patrimonio",
+  "group_servicios_visitante": "Servicios al Visitante",
+  "group_comunidad": "Comunidad"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -2566,5 +2566,9 @@
   "← Volver al listado": "",
   "☰ Expertos": "",
   "🌙 Modo luna": "",
-  "🌿 Alfoz de Cerezo y Lantarón": ""
+  "🌿 Alfoz de Cerezo y Lantarón": "",
+  "group_historia_cultura": "History and Culture",
+  "group_lugares_patrimonio": "Places and Heritage",
+  "group_servicios_visitante": "Visitor Services",
+  "group_comunidad": "Community"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -2566,5 +2566,9 @@
   "← Volver al listado": "← Volver al listado",
   "☰ Expertos": "☰ Expertos",
   "🌙 Modo luna": "🌙 Modo luna",
-  "🌿 Alfoz de Cerezo y Lantarón": "🌿 Alfoz de Cerezo y Lantarón"
+  "🌿 Alfoz de Cerezo y Lantarón": "🌿 Alfoz de Cerezo y Lantarón",
+  "group_historia_cultura": "Historia y Cultura",
+  "group_lugares_patrimonio": "Lugares y Patrimonio",
+  "group_servicios_visitante": "Servicios al Visitante",
+  "group_comunidad": "Comunidad"
 }

--- a/translations/gl.json
+++ b/translations/gl.json
@@ -2566,5 +2566,9 @@
   "← Volver al listado": "",
   "☰ Expertos": "",
   "🌙 Modo luna": "",
-  "🌿 Alfoz de Cerezo y Lantarón": ""
+  "🌿 Alfoz de Cerezo y Lantarón": "",
+  "group_historia_cultura": "Historia e Cultura",
+  "group_lugares_patrimonio": "Lugares e Patrimonio",
+  "group_servicios_visitante": "Servizos ao Visitante",
+  "group_comunidad": "Comunidade"
 }


### PR DESCRIPTION
## Summary
- extend Spanish i18n dictionary with group keys
- add matching keys for English, Spanish and Galician translation datasets

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6856dbffacc083299db7fbd827e477fc