### PR TITLE
Add README for astro-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ Consulta el archivo [docker-compose.yml](docker-compose.yml) para conocer los se
 ## Museo en Astro
 
 Se añadió una página experimental en `frontend/astro-app` que usa **Astro** y **TailwindCSS** para mostrar las piezas del museo definidas en `museo/piezas.json`.
-Para ejecutarla:
+Para ejecutarla desde la raíz del proyecto basta con:
 
 ```bash
-npm install
 npm run dev:astro
 ```
+
+Consulta [frontend/astro-app/README.md](frontend/astro-app/README.md) si prefieres lanzarla dentro de su carpeta. Allí se detallan también la ubicación del directorio de salida y otros apuntes.
 
 La página principal se genera en `/piezas` y presenta las piezas en una cuadrícula adaptable.
 

--- a/frontend/astro-app/README.md
+++ b/frontend/astro-app/README.md
@@ -1,0 +1,10 @@
+# Astro App
+
+Esta carpeta contiene una prueba con **Astro** y **TailwindCSS**. Sigue estos pasos para ejecutarla en modo de desarrollo:
+
+```bash
+npm install
+npm run dev
+```
+
+El sitio compilado se genera en `../../dist/astro`, por lo que la salida queda al nivel raíz del repositorio bajo el directorio `dist/astro`.


### PR DESCRIPTION
## Summary
- document astro app installation and dev server
- link the astro app docs from project README

## Testing
- `npm run test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856dc3101c88329bb095e119fd7ff1a