### PR TITLE
Add Docker Compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,14 @@ COPY . ./
 EXPOSE 4321
 CMD ["pnpm", "run", "dev", "--host", "0.0.0.0"]
 
-# Backend stage for FastAPI
+# Backend stage for Flask
 FROM python:3.11-slim AS backend
-WORKDIR /app/backend
-COPY backend/requirements.txt ./
+WORKDIR /app
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-COPY backend ./
-EXPOSE 8000
-CMD ["uvicorn", "app.main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]
+COPY flask_app.py ./
+EXPOSE 5000
+CMD ["python", "flask_app.py"]
 
 # Development stage
 FROM python:3.11-slim AS development
@@ -26,6 +26,6 @@ COPY --from=backend /usr/local /usr/local
 COPY --from=frontend /usr/local /usr/local
 # Copy app sources
 COPY --from=frontend /app/frontend ./frontend
-COPY --from=backend /app/backend ./backend
-EXPOSE 4321 8000
-CMD sh -c "cd frontend && pnpm run dev --host 0.0.0.0 & cd ../backend && uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 && wait"
+COPY --from=backend /app/flask_app.py ./flask_app.py
+EXPOSE 4321 5000
+CMD sh -c "cd frontend && pnpm run dev --host 0.0.0.0 & cd .. && python flask_app.py & wait"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ docker-compose up --build
 ```
 
 Consulta el archivo [docker-compose.yml](docker-compose.yml) para conocer los servicios disponibles.
+El frontend se sirve en `http://localhost:4321` y la API de Flask en `http://localhost:5000`.
 
 ## Museo en Astro
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: frontend
+    ports:
+      - "4321:4321"
+    volumes:
+      - ./frontend:/app/frontend
+    command: ["pnpm", "run", "dev", "--host", "0.0.0.0"]
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: backend
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./:/app
+    command: ["python", "flask_app.py"]


### PR DESCRIPTION
## Summary
- add docker-compose.yml to run Astro frontend and Flask API
- switch Dockerfile backend stage to Flask
- document exposed ports in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856dc3472dc832997f053243ce74d0a