### PR TITLE
Update index-guide with extended history link

### DIFF
--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -33,6 +33,7 @@ El panel también incluye `admin-menu.php` y `social-menu.html` dentro de bloque
 * **Estilos**: modifica `assets/css/menus/consolidated-menu.css` para cambiar colores morado y oro viejo, anchura u otros efectos del panel `.menu-panel`.
 * **Comportamiento**: `assets/js/main.js` gestiona la apertura y cierre con el atributo `data-menu-target`.
 * **Añadir páginas**: edita `fragments/menus/main-menu.php` para crear nuevos enlaces y añade el archivo correspondiente en el directorio del proyecto.
+* **Historia ampliada**: para un recorrido más detallado consulta [historia_ampliada_nuevo4.md](historia_ampliada_nuevo4.md).
 
 ### Clase `menu-compressed` y transformación de la página
 


### PR DESCRIPTION
## Summary
- link to `historia_ampliada_nuevo4.md` under new pages section

## Testing
- `python -m unittest tests/test_graph_db_interface.py` *(fails: ModuleNotFoundError)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856dc5d6c648329b5f030d9c0dcdbf5