### PR TITLE
Add recursive menu rendering with unique submenu IDs

### DIFF
--- a/includes/menu.php
+++ b/includes/menu.php
@@ -9,6 +9,32 @@ function get_main_menu_items(): array {
     return $menu;
 }
 
+function render_menu_items(array $items, string $parentPath = '', int &$counter = 0, string $current = ''): void {
+    foreach ($items as $item) {
+        $label = htmlspecialchars(t($item['label']));
+        $path = $parentPath . '/' . $item['label'];
+
+        if (isset($item['children']) && is_array($item['children'])) {
+            $counter++;
+            $id = 'submenu-' . md5($path);
+            echo '<li class="has-submenu">';
+            echo '<button class="submenu-toggle" aria-expanded="false" aria-controls="' . $id . '">' . $label . '</button>';
+            echo '<ul id="' . $id . '" class="submenu" aria-hidden="true">';
+            render_menu_items($item['children'], $path, $counter, $current);
+            echo '</ul>';
+            echo '</li>';
+        } else {
+            $url = htmlspecialchars($item['url']);
+            $classes = [];
+            if ($current === $item['url']) {
+                $classes[] = 'active-link';
+            }
+            $classAttr = $classes ? ' class="'.implode(' ', $classes).'"' : '';
+            echo "<li><a href=\"$url\"$classAttr>$label</a></li>";
+        }
+    }
+}
+
 function render_main_menu(): void {
     $items = get_main_menu_items();
     $current = '';
@@ -17,15 +43,7 @@ function render_main_menu(): void {
     }
 
     echo '<ul id="main-menu" class="nav-links">';
-    foreach ($items as $item) {
-        $label = htmlspecialchars(t($item['label']));
-        $url = htmlspecialchars($item['url']);
-        $classes = [];
-        if ($current === $item['url']) {
-            $classes[] = 'active-link';
-        }
-        $classAttr = $classes ? ' class="'.implode(' ', $classes).'"' : '';
-        echo "<li><a href=\"$url\"$classAttr>$label</a></li>";
-    }
+    $counter = 0;
+    render_menu_items($items, '', $counter, $current);
     echo '</ul>';
 }


### PR DESCRIPTION
## Summary
- add `render_menu_items` to recursively output submenu lists
- generate submenu IDs using the full path hash and set `aria-controls`
- adjust `render_main_menu` to use the new helper

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856dc6812c08329b4203c76c32db661