### PR TITLE
Implement single photo fetch in gallery API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -147,6 +147,7 @@ Los estilos coinciden con `assets/css/pages/historia_subpaginas_auca_patricia_ub
 - [Documentación del crawler](crawler.md)
 - [Interfaz de la base de datos de grafo](graph_db.md)
 - [API de consulta de grafo](../api/graph)
+- [API de la Galería Colaborativa](galeria_api.md)
 - [Guía de Testing](testing.md)
 - [Gráfica de Influencia Romana](roman_influence_graph.md)
 - [Relaciones de Parentesco](parent_child_pairs.md)

--- a/docs/galeria_api.md
+++ b/docs/galeria_api.md
@@ -1,0 +1,17 @@
+# API de la Galería Colaborativa
+
+Este endpoint permite consultar y subir fotos de la comunidad.
+
+## Obtener todas las fotos
+
+`GET /api/galeria/fotos`
+
+Devuelve una lista con todas las entradas ordenadas por `fecha_subida`.
+Cada elemento incluye la URL completa de la imagen en el campo `imagenUrl`.
+
+## Obtener una foto por ID
+
+`GET /api/galeria/fotos/{id}`
+
+Si el identificador existe se devuelve un objeto con los mismos campos que
+la lista anterior. Si no existe la foto se responde con `404`.


### PR DESCRIPTION
## Summary
- add lookup by ID in `api_galeria.php`
- document new endpoint
- update docs README with reference to gallery API
- add PHPUnit test for single photo fetch and adjust helper

## Testing
- `vendor/bin/phpunit tests/ApiTest.php`
- `vendor/bin/phpunit` *(fails: Errors: 4, Failures: 11)*

------
https://chatgpt.com/codex/tasks/task_e_6856dc31ebec8329a47c2bb21bc6fb05