### PR TITLE
Add puppeteer setup hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Para detalles sobre la paleta de colores y la tipografía consulta [docs/style-g
 
 Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar todas las pruebas. Los pasos básicos son:
 
-1. Instala las dependencias con `./scripts/setup_environment.sh`.
+1. Instala las dependencias con `./scripts/setup_environment.sh`. Ese script
+   ejecuta `npm ci` para descargar **Puppeteer** y el resto de dependencias de
+   desarrollo.
 2. Si la suite incluye pruebas de interfaz, arranca un servidor PHP con:
    ```bash
    php -S localhost:8080

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,4 +5,22 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
 pip install -r requirements.txt
-python -m unittest discover -s tests
+
+# Ensure Node dev dependencies (e.g., Puppeteer) are available
+if command -v npm >/dev/null 2>&1; then
+    if ! node -e "require('puppeteer')" >/dev/null 2>&1; then
+        echo "Installing Node dev dependencies..."
+        npm ci
+    fi
+else
+    echo "Warning: npm not found; skipping Node dependency setup." >&2
+fi
+
+TMP_LOG=$(mktemp)
+if ! python -m unittest discover -s tests >"$TMP_LOG" 2>&1; then
+    if grep -q "ModuleNotFoundError" "$TMP_LOG"; then
+        echo "Error: faltan módulos de Python. Ejecuta 'pip install -r requirements.txt'." >&2
+    fi
+    cat "$TMP_LOG"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- mention `npm ci` to install puppeteer in README
- expand run_tests.sh to ensure node dev deps and catch missing modules

## Testing
- `./scripts/run_tests.sh` *(fails: ERESOLVE unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_6856dc72d8608329b2ce6a7021d515d6