### PR TITLE
Handle old caches on activate

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'assets-cache-v2';
+const CACHE_NAME = 'assets-cache-v3';
 const CORE_ROUTES = ['/index.php', '/foro/index.php'];
 self.addEventListener('install', event => {
   event.waitUntil(
@@ -7,7 +7,17 @@ self.addEventListener('install', event => {
   self.skipWaiting();
 });
 self.addEventListener('activate', event => {
-  event.waitUntil(clients.claim());
+  event.waitUntil(
+    caches.keys().then(cacheNames => {
+      return Promise.all(
+        cacheNames.map(name => {
+          if (name !== CACHE_NAME) {
+            return caches.delete(name);
+          }
+        })
+      );
+    }).then(() => self.clients.claim())
+  );
 });
 self.addEventListener('fetch', event => {
   const url = new URL(event.request.url);


### PR DESCRIPTION
## Summary
- remove outdated caches in `activate` handler
- bump cache name so new service worker update triggers fresh caches

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856dc743368832986ef09bb69b5e945