### PR TITLE
Use _footer.php in Tailwind demo

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -365,4 +365,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
     populateSidebarContents(); // Call it on initial load to populate the sidebar
+
+    // Simple mobile menu for tailwind_index.php
+    const simpleToggle = document.getElementById('menu-toggle');
+    const simpleMenu = document.getElementById('mobile-menu');
+    if (simpleToggle && simpleMenu) {
+        simpleToggle.addEventListener('click', () => {
+            simpleMenu.classList.toggle('open');
+            document.body.classList.toggle('menu-compressed', simpleMenu.classList.contains('open'));
+            document.body.classList.toggle('menu-open-left', simpleMenu.classList.contains('open'));
+        });
+    }
 });

--- a/tailwind_index.php
+++ b/tailwind_index.php
@@ -72,21 +72,6 @@
         </section>
     </main>
 
-    <footer class="bg-imperial-purple text-old-gold text-center py-4 texture-alabaster">
-        <p class="font-headings">© 2024 Condado de Castilla</p>
-        <p class="font-body">Difundiendo el legado de Castilla y Cerezo de Río Tirón.</p>
-    </footer>
-
-    <script>
-        const toggle = document.getElementById('menu-toggle');
-        const menu = document.getElementById('mobile-menu');
-        if (toggle && menu) {
-            toggle.addEventListener('click', () => {
-                menu.classList.toggle('open');
-                document.body.classList.toggle('menu-compressed', menu.classList.contains('open'));
-                document.body.classList.toggle('menu-open-left', menu.classList.contains('open'));
-            });
-        }
-    </script>
+    <?php require_once '_footer.php'; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use common `_footer.php` in `tailwind_index.php`
- move sliding menu script into `assets/js/main.js`

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6856dc764dd8832982ba4ce8f854d68b