### PR TITLE
Refactor logging in graph_db_interface

### DIFF
--- a/graph_db_interface.py
+++ b/graph_db_interface.py
@@ -6,15 +6,19 @@ import logging
 import os
 from filelock import FileLock
 
-# Configure module-level logger. This basic configuration writes
-# timestamped messages with the module name and log level.
-# Applications embedding this module can override the configuration
-# if needed.
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
-logger = logging.getLogger(__name__)
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- centralize logger setup in `graph_db_interface.py`
- use the helper to avoid repeated configuration

## Testing
- `python -m unittest tests.test_graph_db_interface`

------
https://chatgpt.com/codex/tasks/task_e_6856e665cdc883299153c2b35dc73e35