### PR TITLE
Add database service to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ El proyecto emplea PHP y Python con Flask. Para nuevos módulos se aconseja usar
 docker-compose up --build
 ```
 
-Consulta el archivo [docker-compose.yml](docker-compose.yml) para conocer los servicios disponibles.
-El frontend se sirve en `http://localhost:4321` y la API de Flask en `http://localhost:5000`.
+Consulta el archivo [docker-compose.yml](docker-compose.yml) para conocer los servicios disponibles (`frontend`, `backend` y `db`).
+El frontend se sirve en `http://localhost:4321`, la API de Flask en `http://localhost:5000` y la base de datos PostgreSQL en `localhost:5432`.
 
 ## Museo en Astro
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,26 @@ services:
     volumes:
       - ./:/app
     command: ["python", "flask_app.py"]
+    depends_on:
+      - db
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: ${DB_NAME:-condado_castilla_db}
+      DB_USER: ${DB_USER:-condado_user}
+      CONDADO_DB_PASSWORD: ${CONDADO_DB_PASSWORD:-condado_password}
+
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_NAME:-condado_castilla_db}
+      POSTGRES_USER: ${DB_USER:-condado_user}
+      POSTGRES_PASSWORD: ${CONDADO_DB_PASSWORD:-condado_password}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- extend docker-compose.yml with a PostgreSQL database service
- update quick start instructions with db info

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856e637ba108329914c6561aa3a16ee