### PR TITLE
Add translation keys test

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,6 +29,12 @@ vendor/bin/phpunit
 python -m unittest tests/test_graph_db_interface.py
 ```
 
+   - Comprobar que todas las traducciones contienen las mismas claves:
+
+```bash
+python -m unittest tests/test_translation_keys.py
+```
+
 - Toda la batería de pruebas de Python:
 
 ```bash

--- a/tests/test_translation_keys.py
+++ b/tests/test_translation_keys.py
@@ -1,0 +1,26 @@
+import json
+import unittest
+from pathlib import Path
+
+class TranslationKeysTest(unittest.TestCase):
+    def test_all_files_have_same_keys(self):
+        translation_dir = Path(__file__).resolve().parent.parent / 'translations'
+        files = list(translation_dir.glob('*.json'))
+        self.assertTrue(files, 'No translation files found')
+
+        key_sets = {}
+        all_keys = set()
+
+        for file in files:
+            with open(file, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            keys = set(data.keys())
+            key_sets[file.name] = keys
+            all_keys.update(keys)
+
+        for name, keys in key_sets.items():
+            missing = all_keys - keys
+            self.assertFalse(missing, f'Missing keys in {name}: {", ".join(sorted(missing))}')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add test_translation_keys.py to check that all translation files share the same keys
- document how to run the new test

## Testing
- `python -m unittest tests.test_translation_keys`

------
https://chatgpt.com/codex/tasks/task_e_6856e6360cd48329960276c9da61aa86