### PR TITLE
Support offline Python deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__/
 .DS_Store
 Thumbs.db
 vendor/
+!vendor/python-deps/
 !assets/vendor/
 .phpunit.result.cache
 .php-cs-fixer.cache

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -71,6 +71,20 @@ Consulta las opciones del script en [script_catalog.md](script_catalog.md).
 ./scripts/run_accessibility_audit.sh
 ```
 
+### Dependencias de Python sin conexión
+
+Si necesitas ejecutar las pruebas en un entorno sin acceso a Internet, descarga
+los paquetes indicados en `requirements.txt` y guárdalos en el directorio
+`vendor/python-deps/`:
+
+```bash
+pip download -d vendor/python-deps -r requirements.txt
+```
+
+Al lanzar `setup_environment.sh` se detectará el contenido de esa carpeta y se
+ejecutará `pip install --no-index --find-links vendor/python-deps -r
+requirements.txt` para instalar desde esos archivos locales.
+
 ## Solucion de problemas
 
 - Si al ejecutar `npm run test:puppeteer` obtienes un TimeoutError, comprueba que tienes un servidor PHP en marcha con:

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -101,7 +101,12 @@ fi
 
 # Install Python dependencies
 if command -v pip >/dev/null 2>&1; then
-    if ! pip install -r requirements.txt; then
+    PYTHON_DEPS_DIR="vendor/python-deps"
+    PIP_EXTRA_ARGS=""
+    if [ -d "$PYTHON_DEPS_DIR" ] && ls "$PYTHON_DEPS_DIR"/*.whl "$PYTHON_DEPS_DIR"/*.tar.gz >/dev/null 2>&1; then
+        PIP_EXTRA_ARGS="--no-index --find-links $PYTHON_DEPS_DIR"
+    fi
+    if ! pip install $PIP_EXTRA_ARGS -r requirements.txt; then
         echo "Warning: pip install failed." >&2
     fi
 else


### PR DESCRIPTION
## Summary
- add vendor/python-deps folder for offline wheels
- install from this folder in `setup_environment.sh` when available
- document offline dependency setup in `docs/testing.md`
- keep vendor folder tracked via `.gitignore`

## Testing
- `bash scripts/run_tests.sh`
- `bash scripts/setup_environment.sh` *(fails: composer install needs ext-dom, npm dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6856e635edf08329a8c1bbffb12ddc88