### PR TITLE
Add Historia Ampliada page

### DIFF
--- a/assets/css/pages/historia_historia_ampliada.css
+++ b/assets/css/pages/historia_historia_ampliada.css
@@ -1,0 +1,11 @@
+.section.article-content {
+    padding: 2rem;
+    background-color: var(--epic-alabaster-dawn);
+}
+.section.article-content h2,
+.section.article-content h3 {
+    color: transparent;
+    background-image: linear-gradient(45deg, var(--epic-purple-vibrant), var(--epic-gold-dusk));
+    -webkit-background-clip: text;
+    background-clip: text;
+}

--- a/config/main_menu.php
+++ b/config/main_menu.php
@@ -2,6 +2,7 @@
 return [
     ['label' => 'menu_inicio', 'url' => 'index.php'],
     ['label' => 'menu_historia', 'url' => 'historia/historia.php'],
+    ['label' => 'menu_historia_ampliada', 'url' => 'historia/historia_ampliada.php'],
     ['label' => 'menu_historia_cerezo', 'url' => 'historia_cerezo/index.php'],
     ['label' => 'menu_obispado_auca', 'url' => 'historia/subpaginas/obispado_auca_cerezo.php'],
     ['label' => 'menu_influencia_romana', 'url' => 'historia/influencia_romana.php'],

--- a/docs/menu-structure.md
+++ b/docs/menu-structure.md
@@ -6,6 +6,7 @@ La siguiente tabla se genera a partir de [`config/main_menu.php`](../config/main
 | -------------------------------------------- | ---------------------- |
 | index.php                                    | Inicio                 |
 | historia/historia.php                        | Nuestra Historia       |
+| historia/historia_ampliada.php               | Historia Ampliada      |
 | historia_cerezo/index.php                    | Historia de Cerezo     |
 | historia/subpaginas/obispado_auca_cerezo.php | Obispado de Auca       |
 | historia/influencia_romana.php               | Influencia Romana      |

--- a/historia/historia_ampliada.php
+++ b/historia/historia_ampliada.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../includes/head_common.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+use League\CommonMark\CommonMarkConverter;
+
+function render_markdown_file(string $path): string {
+    static $converter = null;
+    if ($converter === null) {
+        $converter = new CommonMarkConverter();
+    }
+    $markdown = file_get_contents($path);
+    return $converter->convert($markdown)->getContent();
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <?php
+    require_once __DIR__ . '/../includes/load_page_css.php';
+    load_page_css();
+    ?>
+    <title>Historia Ampliada - Cerezo de Río Tirón</title>
+</head>
+<body class="alabaster-bg">
+    <?php require_once __DIR__ . '/../fragments/header.php'; ?>
+    <main class="container page-content-block">
+        <h1 class="gradient-text">Historia Ampliada</h1>
+        <section class="section article-content">
+            <?php echo render_markdown_file(__DIR__ . '/../docs/historia_ampliada_nuevo4.md'); ?>
+        </section>
+    </main>
+    <?php require_once __DIR__ . '/../fragments/footer.php'; ?>
+</body>
+</html>

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -1,6 +1,7 @@
 {
   "menu_inicio": "Inicio",
   "menu_historia": "Nuestra Historia",
+  "menu_historia_ampliada": "Historia Ampliada",
   "menu_historia_cerezo": "Historia de Cerezo",
   "menu_obispado_auca": "Obispado de Auca",
   "menu_influencia_romana": "Influencia Romana",


### PR DESCRIPTION
## Summary
- create new PHP page `historia/historia_ampliada.php` to render `docs/historia_ampliada_nuevo4.md`
- style new page with alabaster background and gradient headings
- add menu entry `menu_historia_ampliada` in main menu
- translate new menu label in Spanish i18n file
- document menu change in `docs/menu-structure.md`

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests`
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856ff1539308329a4df2d590e8176cf