### PR TITLE
Enhance sliding menu transitions

### DIFF
--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -4,6 +4,10 @@
     --old-gold: var(--epic-gold-main, #CFB53B);
 }
 
+body {
+    transition: transform 0.3s ease;
+}
+
 #fixed-header {
     position: fixed;
     top: 0;
@@ -77,23 +81,32 @@ body.menu-open-right {
     transform-origin: right center;
 }
 
+body.sidebar-active {
+    transform: translateX(260px) scale(0.96);
+    transform-origin: left center;
+    margin-left: 0 !important;
+}
+
 #slide-menu-right ul {
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
-#slide-menu-right a {
+.slide-menu a {
     display: block;
     padding: 0.5rem 1rem;
-    color: var(--primary-purple);
+    font-weight: 600;
+    background: linear-gradient(45deg, var(--old-gold), var(--primary-purple));
+    -webkit-background-clip: text;
+    color: transparent;
     text-decoration: none;
 }
 
-#slide-menu-right a:hover,
-#slide-menu-right a:focus-visible {
-    background: var(--epic-gold-main);
-    color: var(--primary-purple);
+.slide-menu a:hover,
+.slide-menu a:focus-visible {
+    background: var(--primary-purple);
+    color: var(--old-gold);
 }
 
 @media (max-width: 768px) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -49,7 +49,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const open = !menu.classList.contains('sidebar-visible');
         menu.classList.toggle('sidebar-visible', open);
         document.body.classList.toggle('sidebar-active', open);
-        document.body.classList.toggle('menu-compressed', open);
         updateAria(btn, menu, open);
 
         if (open) {
@@ -94,7 +93,6 @@ document.addEventListener('DOMContentLoaded', () => {
                     : (menu.classList.contains('right-panel') ? 'right' : '');
         const open = !menu.classList.contains('active');
         menu.classList.toggle('active', open);
-        document.body.classList.toggle('menu-compressed', open);
         updateAria(btn, menu, open);
         if (side) document.body.classList.toggle(`menu-open-${side}`, open);
 


### PR DESCRIPTION
## Summary
- animate body transform changes for menu state
- add high-contrast gradient links in slide menus
- rely on a single function to manage `menu-compressed`

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856ff1677f08329a5527eb0df98c542