### PR TITLE
Consolidate demo frontend apps

### DIFF
--- a/docs/frontend-structure.md
+++ b/docs/frontend-structure.md
@@ -1,27 +1,29 @@
 # Frontend Structure
 
 This directory hosts small demo projects using React and Svelte. All projects
-import `frontend/styles/theme.css`, which simply re-exports the shared
-variables from `assets/css/epic_theme.css` using `@import`.
+import `frontend/styles/theme.css`, which exposes the purple and gold gradient
+utilities and re‑exports the shared variables from `assets/css/epic_theme.css`.
+Reusable UI pieces now live under `frontend/components` so the examples do not
+duplicate markup.
 
 For colour references see the [style guide](style-guide.md).
 
 ## Building the forum application
 
-1. Navigate to the React project and install dependencies:
+1. Install the dependencies inside `frontend/forum-app`:
 
    ```bash
-   cd frontend/forum-app
-   npm install
+   cd frontend/forum-app && npm install
    ```
 
-2. Create the production bundle:
+2. From the repository root, build all frontend assets (Tailwind and the React
+   forum) with:
 
    ```bash
-   npm run build
+   npm run build:frontend
    ```
 
-   The compiled assets are written to `assets/forum-app/` at the project root.
+   The compiled forum assets are written to `assets/forum-app/`.
 
 3. Deploy by copying or syncing the `assets/forum-app` directory to the
    web server. The `foro/index.php` page loads `forum.js` from this location.

--- a/frontend/components/Heading.jsx
+++ b/frontend/components/Heading.jsx
@@ -1,0 +1,5 @@
+import '../styles/theme.css';
+
+export default function Heading({ text }) {
+  return <h1 className="text-purple-gold-gradient">{text}</h1>;
+}

--- a/frontend/components/Heading.svelte
+++ b/frontend/components/Heading.svelte
@@ -1,0 +1,9 @@
+<script>
+  export let text;
+</script>
+
+<style global>
+  @import '../styles/theme.css';
+</style>
+
+<h1 class="text-purple-gold-gradient">{text}</h1>

--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -1,9 +1,9 @@
-import '../styles/theme.css';
+import Heading from '../components/Heading.jsx';
 
 export default function App() {
   return (
     <div className="app">
-      <h1 style={{ color: 'var(--epic-gold-main)' }}>React Example</h1>
+      <Heading text="React Example" />
     </div>
   );
 }

--- a/frontend/styles/theme.css
+++ b/frontend/styles/theme.css
@@ -1,2 +1,14 @@
 /* Re-export Epic theme variables */
 @import url("../../assets/css/epic_theme.css");
+
+/* Shared gradient utilities */
+.text-purple-gold-gradient {
+  background-image: linear-gradient(45deg, var(--epic-purple-emperor), var(--epic-gold-main));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.bg-purple-gold-gradient {
+  background-image: linear-gradient(45deg, var(--epic-purple-emperor), var(--epic-gold-main));
+}

--- a/frontend/svelte-app/src/App.svelte
+++ b/frontend/svelte-app/src/App.svelte
@@ -1,7 +1,7 @@
-<style global>
-@import '../styles/theme.css';
-</style>
+<script>
+  import Heading from '../components/Heading.svelte';
+</script>
 
 <main>
-  <h1 style="color: var(--epic-gold-main)">Svelte Example</h1>
+  <Heading text="Svelte Example" />
 </main>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test:playwright": "playwright test tests/phpRoutes.spec.js",
     "test": "npm run start:php && npm run test:puppeteer && npm run test:playwright; npm run stop:php",
     "build": "vite build && npx sass assets/scss/custom.scss assets/css/custom.css --no-source-map",
+    "build:forum": "npm --prefix frontend/forum-app run build",
+    "build:frontend": "npm run build && npm run build:forum",
     "dev:astro": "astro dev",
     "build:astro": "astro build"
   }


### PR DESCRIPTION
## Summary
- add gradient utility classes in `frontend/styles/theme.css`
- create shared Heading component in React and Svelte
- refactor demos to use shared components
- document new structure and build scripts
- expose `build:forum` and `build:frontend` npm scripts

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856ff16aebc83298410323ed5c7f88a