### PR TITLE
Add render_main_menu HTML tests

### DIFF
--- a/includes/menu.php
+++ b/includes/menu.php
@@ -42,7 +42,7 @@ function render_main_menu(): void {
         $current = ltrim($_SERVER['SCRIPT_NAME'], '/');
     }
 
-    echo '<ul id="main-menu" class="nav-links">';
+    echo '<ul id="main-menu" class="nav-links" role="menu">';
     $counter = 0;
     render_menu_items($items, '', $counter, $current);
     echo '</ul>';

--- a/tests/RenderMainMenuTest.php
+++ b/tests/RenderMainMenuTest.php
@@ -1,0 +1,47 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/menu.php';
+
+class RenderMainMenuTest extends TestCase {
+    public function testMainMenuHasRoleAttribute(): void {
+        ob_start();
+        render_main_menu();
+        $html = ob_get_clean();
+
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadHTML($html);
+        $ul = $dom->getElementById('main-menu');
+        $this->assertNotNull($ul, 'Main menu element not found');
+        $this->assertSame('nav-links', $ul->getAttribute('class'));
+        $this->assertSame('menu', $ul->getAttribute('role'));
+    }
+
+    public function testNestedListsHaveSubmenuClass(): void {
+        $items = [
+            [
+                'label' => 'Parent',
+                'url' => '#',
+                'children' => [
+                    ['label' => 'Child', 'url' => '#child']
+                ]
+            ]
+        ];
+
+        ob_start();
+        render_menu_items($items);
+        $html = ob_get_clean();
+
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadHTML($html);
+        $xpath = new DOMXPath($dom);
+        $submenus = $xpath->query('//ul[contains(@class, "submenu")]');
+        $this->assertGreaterThan(0, $submenus->length, 'No submenu lists found');
+        foreach ($submenus as $submenu) {
+            $this->assertSame('submenu', $submenu->getAttribute('class'));
+        }
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- test `render_main_menu` markup
- ensure submenus keep the `submenu` class
- add role attribute to main menu

## Testing
- `./vendor/bin/phpunit tests/RenderMainMenuTest.php`
- `./vendor/bin/phpunit` *(fails: ToolsMenuLinksTest::testLinkLoads data provider invalid, ReadOnlyModeTest::testMainMenuLinksExist, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6856ff186a408329878f0a4170f3a8a9