### PR TITLE
Add PHP and Node testing to run_tests script

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar
    ```bash
    python -m unittest discover -s tests
    ```
-5. Ejecuta las pruebas de Node (Puppeteer):
+5. Ejecuta las pruebas de Node (Puppeteer y Playwright):
    ```bash
-   npm run test:puppeteer
+   npm run test:puppeteer && npm run test:playwright
    ```
 
-También se proporciona `scripts/run_tests.sh` para instalar `requirements.txt` y lanzar la suite de forma directa.
+También se proporciona `scripts/run_tests.sh` para instalar dependencias, arrancar y detener el servidor PHP y ejecutar todas las pruebas de PHP, Python y Node de forma directa.

--- a/docs/script_catalog.md
+++ b/docs/script_catalog.md
@@ -21,7 +21,7 @@ Este documento recopila los scripts disponibles en el directorio `scripts/` y su
 | `link_checker.py`            | Escanea el HTML del repositorio y detecta enlaces rotos.                       |
 | `process_characters.py`      | Combina el parser y el generador de whispers para producir datos enriquecidos. |
 | `run_accessibility_audit.sh` | Ejecuta Lighthouse para auditar la accesibilidad de varias páginas.            |
-| `run_tests.sh`               | Instala dependencias de Python y ejecuta la batería completa de pruebas.       |
+| `run_tests.sh`               | Ejecuta todas las pruebas de PHP, Python y Node arrancando y deteniendo el servidor PHP automáticamente. |
 | `setup_environment.sh`       | Verifica e instala runtimes y dependencias básicas.                            |
 | `setup_frontend_libs.sh`     | Descarga bibliotecas JS/CSS y las copia a `assets/vendor`.                     |
 | `setup_project.sh`           | Configura el proyecto completo y crea archivos iniciales.                      |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,19 +11,21 @@ Esta guía explica cómo preparar el entorno y ejecutar las pruebas automatizada
 ```
 > **Nota:** ejecuta `pip install -r requirements.txt` o `scripts/setup_environment.sh` antes de lanzar cualquier prueba.
 
-2. Si vas a ejecutar la suite de interfaz, abre otro terminal y arranca un servidor PHP local:
+2. Para lanzar todas las pruebas en un único paso ejecuta `scripts/run_tests.sh`. Este script instala dependencias, arranca y detiene el servidor PHP y ejecuta las suites de PHP, Python y Node.
+
+3. Si vas a ejecutar la suite de interfaz manualmente, abre otro terminal y arranca un servidor PHP local:
 
 ```bash
 php -S localhost:8080
 ```
 
-3. Ejecuta las pruebas de PHP:
+4. Ejecuta las pruebas de PHP:
 
 ```bash
 vendor/bin/phpunit
 ```
 
-4. Ejecuta las pruebas de Python:
+5. Ejecuta las pruebas de Python:
    - Solo la suite de la interfaz de grafo:
 
 ```bash
@@ -42,7 +44,7 @@ python -m unittest tests/test_translation_keys.py
 python -m unittest discover -s tests
 ```
 
-5. Ejecuta las pruebas de interfaz con Puppeteer:
+6. Ejecuta las pruebas de interfaz con Puppeteer o Playwright:
 
 ```bash
 npm run test:puppeteer

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -6,3 +6,27 @@ cd "$PROJECT_ROOT"
 
 pip install -r requirements.txt
 python -m unittest discover -s tests
+
+# Install PHP dependencies if needed
+if [ -f composer.json ]; then
+    composer install --no-interaction
+fi
+
+# Start PHP built-in server in the background as package.json does
+php -S localhost:8080 >/dev/null 2>&1 & echo $! > .php_server.pid
+
+# Ensure the server is stopped on script exit
+cleanup() {
+    if [ -f .php_server.pid ]; then
+        kill "$(cat .php_server.pid)"
+        rm .php_server.pid
+    fi
+}
+trap cleanup EXIT
+
+# Run PHP tests
+vendor/bin/phpunit
+
+# Run Node tests
+npm run test:puppeteer
+npm run test:playwright


### PR DESCRIPTION
## Summary
- run PHP and Node tests in `scripts/run_tests.sh`
- document combined testing workflow in `docs/testing.md`
- note updated script in `docs/script_catalog.md`
- document Node test command in README

## Testing
- `bash scripts/run_tests.sh` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ff28918c83298397284d406931d5