### PR TITLE
Improve testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Para detalles sobre la paleta de colores y la tipografía consulta [docs/style-g
 
 Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar todas las pruebas. Los pasos básicos son:
 
-1. Instala las dependencias con [`scripts/setup_environment.sh`](scripts/setup_environment.sh).
+1. Ejecuta [`scripts/setup_environment.sh`](scripts/setup_environment.sh) **antes de cualquier prueba**. El script instala Python
+   (`flask`, `filelock`, etc.) y las extensiones de PHP necesarias (`php-cgi`,
+   `pdo_pgsql`, `php-xml`).
 2. Si la suite incluye pruebas de interfaz, arranca un servidor PHP con:
    ```bash
    php -S localhost:8080

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,12 +4,18 @@ Esta guía explica cómo preparar el entorno y ejecutar las pruebas automatizada
 
 ## Paso a paso
 
-1. Prepara el entorno y sus dependencias ejecutando `setup_environment.sh` (ver [script_catalog.md](script_catalog.md)):
+1. Prepara el entorno y sus dependencias ejecutando
+   `setup_environment.sh` (ver
+   [script_catalog.md](script_catalog.md)):
 
 ```bash
 ./scripts/setup_environment.sh
 ```
-> **Nota:** ejecuta `pip install -r requirements.txt` o `scripts/setup_environment.sh` antes de lanzar cualquier prueba.
+Este script instala paquetes de Python como **Flask** y **filelock**,
+además de las extensiones de PHP necesarias (**php-cgi**, **pdo_pgsql** y
+**php-xml**).
+> **Nota:** ejecuta `pip install -r requirements.txt` o
+> `scripts/setup_environment.sh` antes de lanzar cualquier prueba.
 
 2. Si vas a ejecutar la suite de interfaz, abre otro terminal y arranca un servidor PHP local:
 


### PR DESCRIPTION
## Summary
- mention setup_environment.sh in README and clarify dependencies
- expand testing guide with required packages like Flask and PHP extensions

## Testing
- `./scripts/setup_environment.sh` *(fails: PHP 8.1 or higher is required)*
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'filelock')*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6856ff310d808329bd83c5acc08edaa4