### PR TITLE
Replace prints with logger

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -3,6 +3,21 @@ from bs4 import BeautifulSoup
 from urllib.parse import urljoin, urlparse
 import uuid
 from datetime import datetime
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 class WebCrawler:
     def __init__(self, user_agent="KnowledgeGraphBot/0.1"):
@@ -132,41 +147,41 @@ if __name__ == '__main__':
     crawler = WebCrawler()
 
     # Test with the example.com URL
-    print("Crawling http://example.com...")
+    logger.info("Crawling http://example.com...")
     resource, links, error = crawler.crawl("http://example.com")
     if error:
-        print(f"Error: {error}")
+        logger.error("Error: %s", error)
     else:
-        print("\nWebResource Data:")
-        print(resource)
-        print("\nLinks Data:")
+        logger.info("\nWebResource Data:")
+        logger.info(resource)
+        logger.info("\nLinks Data:")
         for link in links:
-            print(link)
+            logger.info(link)
 
-    print("\n" + "="*50 + "\n")
+    logger.info("\n" + "=" * 50 + "\n")
 
     # Test with another example.com URL
-    print("Crawling http://example.com/another-page...")
+    logger.info("Crawling http://example.com/another-page...")
     resource, links, error = crawler.crawl("http://example.com/another-page")
     if error:
-        print(f"Error: {error}")
+        logger.error("Error: %s", error)
     else:
-        print("\nWebResource Data:")
-        print(resource)
-        print("\nLinks Data:")
+        logger.info("\nWebResource Data:")
+        logger.info(resource)
+        logger.info("\nLinks Data:")
         for link in links:
-            print(link)
+            logger.info(link)
 
-    print("\n" + "="*50 + "\n")
+    logger.info("\n" + "=" * 50 + "\n")
 
     # Test with a non-implemented URL
-    print("Crawling http://nonexistentpage.com...")
+    logger.info("Crawling http://nonexistentpage.com...")
     resource, links, error = crawler.crawl("http://nonexistentpage.com")
     if error:
-        print(f"Error: {error}")
+        logger.error("Error: %s", error)
     else:
-        print("\nWebResource Data:")
-        print(resource)
-        print("\nLinks Data:")
+        logger.info("\nWebResource Data:")
+        logger.info(resource)
+        logger.info("\nLinks Data:")
         for link in links:
-            print(link)
+            logger.info(link)

--- a/examples/content_processor_demo.py
+++ b/examples/content_processor_demo.py
@@ -1,4 +1,19 @@
 from content_processor import ContentProcessor
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 """Demonstration of ContentProcessor usage."""
 
 if __name__ == '__main__':
@@ -26,28 +41,28 @@ if __name__ == '__main__':
     </html>
     """
 
-    print("Original HTML:\n", sample_html)
+    logger.info("Original HTML:\n%s", sample_html)
 
     # Test extract_text_from_html
     extracted_text = processor.extract_text_from_html(sample_html)
-    print("\nExtracted Text (from extract_text_from_html):\n", extracted_text)
+    logger.info("\nExtracted Text (from extract_text_from_html):\n%s", extracted_text)
 
     # Test extract_main_content
     main_content_text = processor.extract_main_content(sample_html)
-    print("\nMain Content Text (from extract_main_content):\n", main_content_text)
+    logger.info("\nMain Content Text (from extract_main_content):\n%s", main_content_text)
 
     # Test process_content
     processed_data = processor.process_content(sample_html)
-    print("\nProcessed Data (from process_content):\n", processed_data)
+    logger.info("\nProcessed Data (from process_content):\n%s", processed_data)
 
     # Test with empty HTML
     empty_html = ""
-    print("\nProcessing empty HTML string:")
+    logger.info("\nProcessing empty HTML string:")
     processed_empty = processor.process_content(empty_html)
-    print("Processed Data for empty HTML:\n", processed_empty)
+    logger.info("Processed Data for empty HTML:\n%s", processed_empty)
 
     # Test with HTML having only script/style
     script_style_only_html = "<script>var x=1;</script><style>p{color:red;}</style>"
-    print("\nProcessing HTML with only script/style tags:")
+    logger.info("\nProcessing HTML with only script/style tags:")
     processed_script_style = processor.process_content(script_style_only_html)
-    print("Processed Data for script/style only HTML:\n", processed_script_style)
+    logger.info("Processed Data for script/style only HTML:\n%s", processed_script_style)

--- a/examples/link_discoverer_demo.py
+++ b/examples/link_discoverer_demo.py
@@ -2,6 +2,21 @@ from link_discoverer import LinkDiscoverer
 from graph_db_interface import GraphDBInterface
 import uuid
 from datetime import datetime
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 """Demonstration of LinkDiscoverer usage."""
 
 if __name__ == "__main__":
@@ -74,32 +89,32 @@ if __name__ == "__main__":
     discoverer = LinkDiscoverer(db)
 
     # 3. Call find_uncrawled_links()
-    print("\n--- Finding Uncrawled Links ---")
+    logger.info("\n--- Finding Uncrawled Links ---")
     uncrawled = discoverer.find_uncrawled_links(limit=5)
-    print("\nUncrawled URLs found:")
+    logger.info("\nUncrawled URLs found:")
     if uncrawled:
         for url in uncrawled:
-            print(f"  - {url}")
+            logger.info("  - %s", url)
     else:
-        print("  No uncrawled URLs found (up to limit).")
+        logger.info("  No uncrawled URLs found (up to limit).")
 
     # Expected: no_content_res_url, placeholder_content_res_url, non_existent_url1, non_existent_url2
 
     # 4. Call suggest_search_queries_from_topics()
-    print("\n--- Suggesting Search Queries ---")
+    logger.info("\n--- Suggesting Search Queries ---")
     queries = discoverer.suggest_search_queries_from_topics(top_n_resources=3)
-    print("\nSuggested Search Queries:")
+    logger.info("\nSuggested Search Queries:")
     if queries:
         for q in queries:
-            print(f"  - \"{q}\"")
+            logger.info("  - \"%s\"", q)
     else:
-        print("  No queries suggested.")
+        logger.info("  No queries suggested.")
 
     # Expected queries based on titles of "Crawled Page Title", "No Content Page Title", "Placeholder Content Page Title"
 
-    print("\n--- Verifying DB state (placeholders for non-existent links are created by GraphDBInterface.add_link) ---")
+    logger.info("\n--- Verifying DB state (placeholders for non-existent links are created by GraphDBInterface.add_link) ---")
     all_db_resources = db.get_all_resources()
-    print(f"Total resources in DB: {len(all_db_resources)}")
+    logger.info("Total resources in DB: %d", len(all_db_resources))
     # for res in all_db_resources:
     #     print(f"  URL: {res['url']}, Content: '{res.get('content', '')[:30]}...'")
     assert db.resource_exists(non_existent_url1) # Should have been created as placeholder by add_link
@@ -108,4 +123,4 @@ if __name__ == "__main__":
     res_ne1 = db.get_resource(non_existent_url1)
     assert res_ne1 and res_ne1.get("content") == "N/A (placeholder)"
 
-    print("\nDemo complete.")
+    logger.info("\nDemo complete.")

--- a/link_discoverer.py
+++ b/link_discoverer.py
@@ -1,6 +1,21 @@
-from graph_db_interface import GraphDBInterface # Assuming graph_db_interface.py is in the same directory
+from graph_db_interface import GraphDBInterface  # Assuming graph_db_interface.py is in the same directory
 from datetime import datetime
 import uuid
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 class LinkDiscoverer:
     def __init__(self, db_interface: GraphDBInterface):
@@ -8,7 +23,7 @@ class LinkDiscoverer:
         Initializes the discoverer with a GraphDBInterface instance.
         """
         self.db = db_interface
-        print("LinkDiscoverer initialized.")
+        logger.info("LinkDiscoverer initialized.")
 
     def find_uncrawled_links(self, limit: int = 10) -> list[str]:
         """
@@ -20,7 +35,7 @@ class LinkDiscoverer:
         all_links = self.db.get_all_links()
         uncrawled_urls = set() # Use a set to store unique URLs
 
-        print(f"\nFinding uncrawled links (limit: {limit})...")
+        logger.info("\nFinding uncrawled links (limit: %d)...", limit)
         for link_data in all_links:
             target_url = link_data.get("target_url")
             if not target_url:
@@ -31,15 +46,24 @@ class LinkDiscoverer:
             is_uncrawled = False
             if not resource:
                 is_uncrawled = True
-                print(f"  Target URL {target_url} not found in DB (considered uncrawled).")
+                logger.info(
+                    "  Target URL %s not found in DB (considered uncrawled).",
+                    target_url,
+                )
             else:
                 # Using 'content' as a proxy for 'processed_content' as per problem description
                 content = resource.get("content")
                 if not content or content.strip() == "" or content == "N/A (placeholder)":
                     is_uncrawled = True
-                    print(f"  Target URL {target_url} found but content is missing/placeholder (considered uncrawled).")
+                    logger.info(
+                        "  Target URL %s found but content is missing/placeholder (considered uncrawled).",
+                        target_url,
+                    )
                 else:
-                    print(f"  Target URL {target_url} found and has content (considered crawled).")
+                    logger.info(
+                        "  Target URL %s found and has content (considered crawled).",
+                        target_url,
+                    )
 
             if is_uncrawled:
                 uncrawled_urls.add(target_url)
@@ -47,7 +71,7 @@ class LinkDiscoverer:
                     break
 
         result_list = list(uncrawled_urls)
-        print(f"Found {len(result_list)} unique uncrawled URLs.")
+        logger.info("Found %d unique uncrawled URLs.", len(result_list))
         return result_list
 
     def suggest_search_queries_from_topics(self, top_n_resources: int = 3) -> list[str]:
@@ -65,20 +89,26 @@ class LinkDiscoverer:
 
         resources_to_consider = all_resources[:top_n_resources]
 
-        print(f"\nSuggesting search queries from top {top_n_resources} resources...")
+        logger.info(
+            "\nSuggesting search queries from top %d resources...",
+            top_n_resources,
+        )
         for resource_data in resources_to_consider:
             metadata = resource_data.get("metadata", {})
             title = metadata.get("title")
             if title and title.strip() != "":
                 suggested_queries.append(f"More about {title}")
-                print(f"  Generated query from title: '{title}'")
+                logger.info("  Generated query from title: '%s'", title)
 
         if not suggested_queries:
             default_query = "latest technology trends"
             suggested_queries.append(default_query)
-            print(f"  No suitable titles found, using default query: '{default_query}'")
+            logger.info(
+                "  No suitable titles found, using default query: '%s'",
+                default_query,
+            )
 
-        print(f"Suggested {len(suggested_queries)} queries.")
+        logger.info("Suggested %d queries.", len(suggested_queries))
         return suggested_queries
 
 # For a usage demonstration, see examples/link_discoverer_demo.py

--- a/scripts/ai_whisper_generator.py
+++ b/scripts/ai_whisper_generator.py
@@ -1,5 +1,20 @@
 import random
 import re
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 # Keywords that might be found in bios, and associated descriptive terms
 BIO_KEYWORDS_MAP = {
@@ -162,21 +177,21 @@ if __name__ == '__main__':
         'file_path': 'path/to/formerio.html'
     }
 
-    print("--- Generating Whispers ---")
+    logger.info("--- Generating Whispers ---")
     for i in range(3): # Generate a few for each to see variety
-        print(f"\nWhisper for {sample_data_1['name']} ({i+1}):")
-        print(generate_whisper(sample_data_1))
+        logger.info("\nWhisper for %s (%d):", sample_data_1['name'], i + 1)
+        logger.info(generate_whisper(sample_data_1))
 
     for i in range(3):
-        print(f"\nWhisper for {sample_data_2['name']} ({i+1}):")
-        print(generate_whisper(sample_data_2))
+        logger.info("\nWhisper for %s (%d):", sample_data_2['name'], i + 1)
+        logger.info(generate_whisper(sample_data_2))
 
     for i in range(3):
-        print(f"\nWhisper for {sample_data_3['name']} ({i+1}):")
-        print(generate_whisper(sample_data_3))
+        logger.info("\nWhisper for %s (%d):", sample_data_3['name'], i + 1)
+        logger.info(generate_whisper(sample_data_3))
 
     for i in range(3):
-        print(f"\nWhisper for {sample_data_4['name']} ({i+1}):")
-        print(generate_whisper(sample_data_4))
+        logger.info("\nWhisper for %s (%d):", sample_data_4['name'], i + 1)
+        logger.info(generate_whisper(sample_data_4))
 
-    print("\n--- Whisper generation test finished ---")
+    logger.info("\n--- Whisper generation test finished ---")

--- a/scripts/character_parser.py
+++ b/scripts/character_parser.py
@@ -1,5 +1,20 @@
 import os
 from bs4 import BeautifulSoup
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 def parse_character_html(file_path):
     """
@@ -46,7 +61,7 @@ def parse_character_html(file_path):
 
     except Exception as e:
         # This error would be very unusual for basic path operations
-        print(f"Error extracting category from path {file_path}: {e}")
+        logger.error("Error extracting category from path %s: %s", file_path, e)
         category_name = "Unknown"
 
     character_data = {
@@ -61,10 +76,10 @@ def parse_character_html(file_path):
         with open(file_path, 'r', encoding='utf-8') as f:
             html_content = f.read()
     except FileNotFoundError:
-        print(f"Error: File not found at {file_path}")
+        logger.error("Error: File not found at %s", file_path)
         return None
     except Exception as e:
-        print(f"Error reading file {file_path}: {e}")
+        logger.error("Error reading file %s: %s", file_path, e)
         return None
 
     soup = BeautifulSoup(html_content, 'html.parser')
@@ -200,26 +215,26 @@ if __name__ == '__main__':
     os.makedirs(os.path.dirname(dummy_html_path), exist_ok=True)
     with open(dummy_html_path, 'w', encoding='utf-8') as f:
         f.write(dummy_html_content)
-    print(f"Created dummy HTML file at: {dummy_html_path}")
+    logger.info("Created dummy HTML file at: %s", dummy_html_path)
 
-    print(f"\n--- Parsing {dummy_html_path} ---")
+    logger.info("\n--- Parsing %s ---", dummy_html_path)
     parsed_data = parse_character_html(dummy_html_path)
     if parsed_data:
-        print(f"Name: {parsed_data['name']}")
-        print(f"Bio Snippet: {parsed_data['bio_snippet']}")
-        print(f"Key Facts: {parsed_data['key_facts']}")
-        print(f"File Path: {parsed_data['file_path']}")
-        print(f"Category: {parsed_data['category']} (Expected: {dummy_category_name})")
+        logger.info("Name: %s", parsed_data['name'])
+        logger.info("Bio Snippet: %s", parsed_data['bio_snippet'])
+        logger.info("Key Facts: %s", parsed_data['key_facts'])
+        logger.info("File Path: %s", parsed_data['file_path'])
+        logger.info("Category: %s (Expected: %s)", parsed_data['category'], dummy_category_name)
     else:
-        print("No data parsed or file not suitable.")
+        logger.info("No data parsed or file not suitable.")
 
     # Test with a non-existent file
-    print(f"\n--- Parsing non_existent_file.html ---")
+    logger.info("\n--- Parsing non_existent_file.html ---")
     parsed_data_non_existent = parse_character_html("personajes/non_existent_file.html")
     if parsed_data_non_existent:
-        print("Parsed data from non-existent file (should not happen).")
+        logger.info("Parsed data from non-existent file (should not happen).")
     else:
-        print("Correctly handled non-existent file.")
+        logger.info("Correctly handled non-existent file.")
 
     # Test with a file that might be missing some elements (e.g. no Hitos)
     dummy_no_hitos_path = "personajes/dummy_no_hitos.html"
@@ -231,18 +246,21 @@ if __name__ == '__main__':
     os.makedirs(os.path.dirname(dummy_no_hitos_path), exist_ok=True)
     with open(dummy_no_hitos_path, 'w', encoding='utf-8') as f:
         f.write(dummy_no_hitos_content)
-    print(f"Created dummy HTML file (no hitos) at: {dummy_no_hitos_path}")
+    logger.info("Created dummy HTML file (no hitos) at: %s", dummy_no_hitos_path)
 
-    print(f"\n--- Parsing {dummy_no_hitos_path} ---")
+    logger.info("\n--- Parsing %s ---", dummy_no_hitos_path)
     parsed_data_no_hitos = parse_character_html(dummy_no_hitos_path)
     if parsed_data_no_hitos:
-        print(f"Name: {parsed_data_no_hitos['name']}")
-        print(f"Bio Snippet: {parsed_data_no_hitos['bio_snippet']}")
-        print(f"Key Facts: {parsed_data_no_hitos['key_facts']} (Expected: [])")
-        print(f"File Path: {parsed_data_no_hitos['file_path']}")
-        print(f"Category: {parsed_data_no_hitos['category']} (Expected: personajes or Unknown based on path)")
+        logger.info("Name: %s", parsed_data_no_hitos['name'])
+        logger.info("Bio Snippet: %s", parsed_data_no_hitos['bio_snippet'])
+        logger.info("Key Facts: %s (Expected: [])", parsed_data_no_hitos['key_facts'])
+        logger.info("File Path: %s", parsed_data_no_hitos['file_path'])
+        logger.info(
+            "Category: %s (Expected: personajes or Unknown based on path)",
+            parsed_data_no_hitos['category'],
+        )
     else:
-        print("No data parsed or file not suitable for no-hitos test.")
+        logger.info("No data parsed or file not suitable for no-hitos test.")
 
     # Test with a real file path if available (example, adjust if needed)
     # This path needs to exist in the repo structure when the script is run.
@@ -258,4 +276,4 @@ if __name__ == '__main__':
     # else:
     #     print(f"\nSkipping test for real file {real_file_path} as it does not exist at this location.")
 
-    print("\n--- Parser script finished ---")
+    logger.info("\n--- Parser script finished ---")

--- a/scripts/daily_agent.py
+++ b/scripts/daily_agent.py
@@ -1,15 +1,30 @@
 import os
 import subprocess
 from pathlib import Path
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def run(cmd: str) -> bool:
-    print(f"Running: {cmd}")
+    logger.info("Running: %s", cmd)
     result = subprocess.run(cmd, shell=True, cwd=REPO_ROOT)
     if result.returncode != 0:
-        print(f"Command failed with code {result.returncode}: {cmd}")
+        logger.error("Command failed with code %s: %s", result.returncode, cmd)
         return False
     return True
 
@@ -27,13 +42,13 @@ def main() -> None:
     if os.getenv("CONDADO_DB_PASSWORD"):
         success &= run("./scripts/check_db.sh")
     else:
-        print("CONDADO_DB_PASSWORD not set, skipping database check.")
+        logger.info("CONDADO_DB_PASSWORD not set, skipping database check.")
 
     # Optional Gemini API test
     if os.getenv("GEMINI_API_KEY") or os.getenv("GeminiAPI"):
         run("bash scripts/gemini_request.sh")
     else:
-        print("GEMINI_API_KEY not set, skipping Gemini API test.")
+        logger.info("GEMINI_API_KEY not set, skipping Gemini API test.")
 
     if not success:
         raise SystemExit(1)

--- a/scripts/extract_parent_child.py
+++ b/scripts/extract_parent_child.py
@@ -3,6 +3,21 @@ import re
 import json
 import unicodedata
 from bs4 import BeautifulSoup
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 
 def normalize(name: str) -> str:
@@ -76,4 +91,4 @@ with open(output_path, 'w', encoding='utf-8') as f:
     f.write("\n".join(lines))
     f.write("\n")
 
-print(f"Generated {output_path} with {len(unique_pairs)} pairs.")
+logger.info("Generated %s with %d pairs.", output_path, len(unique_pairs))

--- a/scripts/extract_translations.py
+++ b/scripts/extract_translations.py
@@ -2,6 +2,21 @@ import os
 import re
 import json
 from bs4 import BeautifulSoup
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 EXCLUDE_DIRS = {"tests", "assets"}
 FILE_EXTENSIONS = {".php", ".html"}
@@ -69,7 +84,7 @@ def main() -> None:
     with open('translations/gl.json', 'w', encoding='utf-8') as f:
         json.dump(gl, f, ensure_ascii=False, indent=2)
 
-    print(f"Extracted {len(all_strings)} unique strings.")
+    logger.info("Extracted %d unique strings.", len(all_strings))
 
 
 if __name__ == '__main__':

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -2,6 +2,21 @@ import os
 import xml.etree.ElementTree as ET
 from xml.dom import minidom
 from datetime import datetime
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 # Base URL used in each entry of the sitemap. Can be overridden with an
 # environment variable for local testing or different deployments.
@@ -57,7 +72,7 @@ def main() -> None:
     paths = collect_files('.')
     tree = build_sitemap(paths)
     write_pretty_xml(tree, 'sitemap.xml')
-    print(f"Generated sitemap with {len(paths)} entries.")
+    logger.info("Generated sitemap with %d entries.", len(paths))
 
 
 if __name__ == '__main__':

--- a/scripts/link_checker.py
+++ b/scripts/link_checker.py
@@ -1,6 +1,21 @@
 import os
 from html.parser import HTMLParser
 from urllib.parse import urldefrag
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 class LinkExtractor(HTMLParser):
     def __init__(self, current_file_path):
@@ -77,7 +92,7 @@ def main():
             with open(html_file_path, 'r', encoding='utf-8', errors='ignore') as f:
                 content = f.read()
         except Exception as e:
-            print(f"Error reading file {html_file_path}: {e}")
+            logger.error("Error reading file %s: %s", html_file_path, e)
             continue
 
         # Relative path from repo root for reporting
@@ -109,13 +124,13 @@ def main():
                 })
 
     if broken_links_report:
-        print("Broken links found:")
+        logger.info("Broken links found:")
         for entry in broken_links_report:
-            print(f"- Source HTML: {entry['source_file']}")
-            print(f"  Link Href: {entry['link_href']}")
-            print(f"  Resolved Path (Broken): {entry['resolved_path']}\n")
+            logger.info("- Source HTML: %s", entry['source_file'])
+            logger.info("  Link Href: %s", entry['link_href'])
+            logger.info("  Resolved Path (Broken): %s\n", entry['resolved_path'])
     else:
-        print("No broken links found.")
+        logger.info("No broken links found.")
 
 if __name__ == "__main__":
     main()

--- a/scripts/parse_parent_child_pairs_to_json.py
+++ b/scripts/parse_parent_child_pairs_to_json.py
@@ -1,5 +1,20 @@
 import re, json
 from pathlib import Path
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 table_path = Path('docs/parent_child_pairs.md')
 output_path = Path('personajes/parent_child_pairs.json')
@@ -30,4 +45,4 @@ for line in table_path.read_text(encoding='utf-8').splitlines():
         })
 
 output_path.write_text(json.dumps(pairs, ensure_ascii=False, indent=2), encoding='utf-8')
-print(f"Wrote {output_path} with {len(pairs)} records")
+logger.info("Wrote %s with %d records", output_path, len(pairs))

--- a/scripts/structure_analyzer.py
+++ b/scripts/structure_analyzer.py
@@ -12,6 +12,21 @@ import os
 from pathlib import Path
 from collections import defaultdict
 from bs4 import BeautifulSoup
+import logging
+
+
+def configure_logger() -> logging.Logger:
+    """Return a logger configured once for this module."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+    return logger
+
+
+logger = configure_logger()
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -115,7 +130,7 @@ def generate_report() -> str:
 
 
 def main() -> None:
-    print(generate_report())
+    logger.info(generate_report())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- instantiate module-level loggers across CLI and scripts
- convert `print` statements to `logger` calls
- mirror graph_db_interface logging style in examples

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6856ff32faa08329af46138fce95c901