### PR TITLE
Expand run_tests to run PHP and Node suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,5 @@ Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar
    npm run test:puppeteer
    ```
 
-También se proporciona `scripts/run_tests.sh` para instalar `requirements.txt` y lanzar la suite de forma directa.
+También se proporciona `scripts/run_tests.sh` para instalar dependencias y
+ejecutar de manera secuencial las pruebas de PHP, Node y Python.

--- a/docs/script_catalog.md
+++ b/docs/script_catalog.md
@@ -21,7 +21,7 @@ Este documento recopila los scripts disponibles en el directorio `scripts/` y su
 | `link_checker.py`            | Escanea el HTML del repositorio y detecta enlaces rotos.                       |
 | `process_characters.py`      | Combina el parser y el generador de whispers para producir datos enriquecidos. |
 | `run_accessibility_audit.sh` | Ejecuta Lighthouse para auditar la accesibilidad de varias páginas.            |
-| `run_tests.sh`               | Instala dependencias de Python y ejecuta la batería completa de pruebas.       |
+| `run_tests.sh`               | Instala dependencias y ejecuta las pruebas de PHP, Node y Python de forma secuencial. |
 | `setup_environment.sh`       | Verifica e instala runtimes y dependencias básicas.                            |
 | `setup_frontend_libs.sh`     | Descarga bibliotecas JS/CSS y las copia a `assets/vendor`.                     |
 | `setup_project.sh`           | Configura el proyecto completo y crea archivos iniciales.                      |

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,4 +5,28 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
 pip install -r requirements.txt
-python -m unittest discover -s tests
+
+RESULT=0
+
+if [ -x vendor/bin/phpunit ]; then
+    echo "Ejecutando pruebas de PHP..."
+    vendor/bin/phpunit || RESULT=$?
+else
+    echo "PHPUnit no encontrado. Omitiendo pruebas de PHP." >&2
+fi
+
+if [ -f package.json ]; then
+    if command -v npm >/dev/null 2>&1; then
+        echo "Ejecutando pruebas de Node..."
+        npm test || RESULT=$?
+    else
+        echo "npm no está instalado. Omitiendo pruebas de Node." >&2
+    fi
+else
+    echo "package.json no encontrado. Omitiendo pruebas de Node." >&2
+fi
+
+echo "Ejecutando pruebas de Python..."
+python -m unittest discover -s tests || RESULT=$?
+
+exit $RESULT


### PR DESCRIPTION
## Summary
- run PHP, Node and Python tests from `run_tests.sh`
- update docs with new test running behavior

## Testing
- `bash scripts/run_tests.sh` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68570030b28c8329a351dd9127905f9b