### PR TITLE
Update documentation for JS modules and mobile menu

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,20 @@
 # Documentación
 
 Este directorio reúne todas las guías del proyecto **Condado de Castilla**.
+
 La misión principal es _promocionar el turismo en Cerezo de Río Tirón y_
 _proteger su patrimonio arqueológico y cultural_.
+
+## Estructura principal
+
+- `assets/` – imágenes, estilos y scripts. Los módulos JavaScript se agrupan en
+  `assets/js` y se describen brevemente en
+  [js-modules-overview.md](js-modules-overview.md).
+- `includes/` – fragmentos PHP y utilidades comunes.
+- `museo/` – páginas del museo y fichas de piezas.
+- `foro/` – área gestionada por agentes expertos.
+- `backend/` – API en Flask e integración de IA.
+- `docs/` – documentación completa.
 
 ## Árbol de directorios
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -133,3 +133,12 @@ Todas las páginas emplean la regla `scroll-behavior: smooth;` definida en
 `assets/css/epic_theme.css`. Basta con incluir una lista de enlaces internos,
 como el índice generado por `toc-generator.js`, para que los saltos entre
 secciones realicen una animación de desplazamiento fluida.
+
+## Menú móvil
+
+Los paneles de menú deslizante utilizan la clase `.open` para mostrarse y
+desaparecer al quitársela. Al activarse, `assets/js/main.js` añade la clase
+`menu-compressed` al elemento `<body>` junto con `menu-open-left` o
+`menu-open-right` según el lateral. Esta combinación desplaza la página y aplica
+detalles en morado principal (`--color-primario-purpura`) con bordes en oro viejo
+(`--color-secundario-dorado`) para resaltar el estado activo.


### PR DESCRIPTION
## Summary
- add 'Estructura principal' section to documentation README
- document that JS modules live under `assets/js`
- explain mobile menu `.open` state and interaction with `menu-compressed` and `menu-open-left`

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68570043b2d483298f0fa9d18f1f81a2