### PR TITLE
Refactor mobile menu into module

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,5 @@
 // assets/js/main.js - simplified menu controller and theme toggle
+import { initMobileMenu } from './mobile-menu.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const paletteClasses = ['palette-dawn','palette-day','palette-dusk','palette-night'];
@@ -308,61 +309,5 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // IA chat toggle and Homonexus functionality removed
-
-    function setupMobileAIChatTrigger() {
-        if (window.innerWidth <= 768) {
-            const originalTrigger = document.getElementById('ai-chat-trigger');
-            const placeholderMobile = document.getElementById('ai-chat-trigger-placeholder-mobile');
-
-            if (originalTrigger && placeholderMobile && placeholderMobile.children.length === 0) {
-                const clonedTrigger = originalTrigger.cloneNode(true);
-                clonedTrigger.id = 'ai-chat-trigger-mobile';
-                // Ensure the data-menu-target is still correct for the cloned button.
-                // If event listeners were attached by ID, they might need re-attaching or using class based listeners.
-                // However, the current main click listener uses e.target.closest('[data-menu-target]'), which will work.
-                placeholderMobile.appendChild(clonedTrigger);
-            }
-        }
-    }
-    setupMobileAIChatTrigger(); // Call it on initial load
-
-    // Also consider calling setupMobileAIChatTrigger in handleResize if the trigger should be added/removed dynamically
-    // For now, it's only added if on mobile on load. If resizing from desktop to mobile, it won't be there.
-    // And if resizing from mobile to desktop, it will remain in the sidebar unless explicitly removed.
-    // The subtask asks for it to be cloned when mobile sidebar is initialized/opened or on DOMContentLoaded.
-    // For simplicity, DOMContentLoaded is chosen here. A more robust solution might involve the resize handler.
-
-    function populateSidebarContents() {
-        const mainMenuPlaceholder = document.getElementById('main-menu-placeholder');
-        const adminMenuPlaceholder = document.getElementById('admin-menu-placeholder');
-        const socialMenuPlaceholder = document.getElementById('social-menu-placeholder');
-
-        const mainMenuSource = document.getElementById('main-menu'); // This is <ul id="main-menu">
-        const adminMenuSourceContent = document.getElementById('admin-menu-source-content');
-        const socialMenuSourceContent = document.getElementById('social-menu-source-content');
-
-        if (mainMenuPlaceholder && mainMenuSource && mainMenuPlaceholder.childElementCount === 0) {
-            // Clone the UL and its children to avoid issues if original is modified or events are tied
-            const clonedMainMenu = mainMenuSource.cloneNode(true);
-            mainMenuPlaceholder.appendChild(clonedMainMenu);
-        }
-
-        if (adminMenuPlaceholder && adminMenuSourceContent && adminMenuPlaceholder.childElementCount === 0) {
-            // adminMenuSourceContent is a div wrapper, we want its children (the actual ul)
-            // Clone its children to avoid issues
-            Array.from(adminMenuSourceContent.children).forEach(child => {
-                adminMenuPlaceholder.appendChild(child.cloneNode(true));
-            });
-        }
-
-        if (socialMenuPlaceholder && socialMenuSourceContent && socialMenuPlaceholder.childElementCount === 0) {
-            // socialMenuSourceContent is a div wrapper, we want its children (the actual links/icons)
-            // Clone its children
-            Array.from(socialMenuSourceContent.children).forEach(child => {
-                socialMenuPlaceholder.appendChild(child.cloneNode(true));
-            });
-        }
-    }
-    populateSidebarContents(); // Call it on initial load to populate the sidebar
+    initMobileMenu();
 });

--- a/assets/js/mobile-menu.js
+++ b/assets/js/mobile-menu.js
@@ -1,0 +1,44 @@
+export function initMobileMenu() {
+    function setupMobileAIChatTrigger() {
+        if (window.innerWidth <= 768) {
+            const originalTrigger = document.getElementById('ai-chat-trigger');
+            const placeholderMobile = document.getElementById('ai-chat-trigger-placeholder-mobile');
+
+            if (originalTrigger && placeholderMobile && placeholderMobile.children.length === 0) {
+                const clonedTrigger = originalTrigger.cloneNode(true);
+                clonedTrigger.id = 'ai-chat-trigger-mobile';
+                placeholderMobile.appendChild(clonedTrigger);
+            }
+        }
+    }
+
+    function populateSidebarContents() {
+        const mainMenuPlaceholder = document.getElementById('main-menu-placeholder');
+        const adminMenuPlaceholder = document.getElementById('admin-menu-placeholder');
+        const socialMenuPlaceholder = document.getElementById('social-menu-placeholder');
+
+        const mainMenuSource = document.getElementById('main-menu');
+        const adminMenuSourceContent = document.getElementById('admin-menu-source-content');
+        const socialMenuSourceContent = document.getElementById('social-menu-source-content');
+
+        if (mainMenuPlaceholder && mainMenuSource && mainMenuPlaceholder.childElementCount === 0) {
+            const clonedMainMenu = mainMenuSource.cloneNode(true);
+            mainMenuPlaceholder.appendChild(clonedMainMenu);
+        }
+
+        if (adminMenuPlaceholder && adminMenuSourceContent && adminMenuPlaceholder.childElementCount === 0) {
+            Array.from(adminMenuSourceContent.children).forEach(child => {
+                adminMenuPlaceholder.appendChild(child.cloneNode(true));
+            });
+        }
+
+        if (socialMenuPlaceholder && socialMenuSourceContent && socialMenuPlaceholder.childElementCount === 0) {
+            Array.from(socialMenuSourceContent.children).forEach(child => {
+                socialMenuPlaceholder.appendChild(child.cloneNode(true));
+            });
+        }
+    }
+
+    setupMobileAIChatTrigger();
+    populateSidebarContents();
+}

--- a/fragments/footer.php
+++ b/fragments/footer.php
@@ -29,7 +29,8 @@
         <li>Consulta la agenda de eventos culturales.</li>
     </ul>
 </div>
-<script defer src="/assets/js/main.js"></script>
+<script type="module" src="/assets/js/mobile-menu.js"></script>
+<script type="module" src="/assets/js/main.js"></script>
 <script src="/assets/js/cave_mask.js"></script>
 <script src="/assets/js/hero.js"></script>
 <script src="/assets/js/scroll-fade.js"></script>

--- a/tailwind_index.php
+++ b/tailwind_index.php
@@ -77,5 +77,8 @@
         <p class="font-body">Difundiendo el legado de Castilla y Cerezo de Río Tirón.</p>
     </footer>
 
+    <script type="module" src="/assets/js/mobile-menu.js"></script>
+    <script type="module" src="/assets/js/main.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract mobile menu helpers to `mobile-menu.js`
- import and invoke `initMobileMenu` from `main.js`
- load the module scripts in the site footer
- add the new scripts to `tailwind_index.php`

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68570045c38c8329a889313a569e033f