### PR TITLE
Use dynamic year placeholder in translations

### DIFF
--- a/includes/i18n.php
+++ b/includes/i18n.php
@@ -18,11 +18,13 @@ function t(string $key, ?string $lang = null): string {
     }
 
     if (array_key_exists($key, $catalogs[$lang])) {
-        return $catalogs[$lang][$key];
+        $result = $catalogs[$lang][$key];
+    } else {
+        mark_untranslated($key, $lang);
+        $result = $key;
     }
 
-    mark_untranslated($key, $lang);
-    return $key;
+    return str_replace('%YEAR%', date('Y'), $result);
 }
 
 /** @var array<string,array<string,bool>> */

--- a/tailwind_index.php
+++ b/tailwind_index.php
@@ -73,7 +73,7 @@
     </main>
 
     <footer class="bg-imperial-purple text-old-gold text-center py-4 texture-alabaster">
-        <p class="font-headings">© 2024 Condado de Castilla</p>
+        <p class="font-headings"><?php echo t('© %YEAR% Condado de Castilla'); ?></p>
         <p class="font-body">Difundiendo el legado de Castilla y Cerezo de Río Tirón.</p>
     </footer>
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -2515,7 +2515,7 @@
   "y sus 1200 metros de largo con capacidad para albergar el Palacio o Alcázar su corte condal de funcionarios y sus soldados.": "",
   "y, muy posiblemente, por una cerca o muralla propia que envolviera el caserío principal, Cerezo vería consolidarse sus calles, barrios (collaciones) y espacios públicos.": "",
   "¡Prepárate para una aventura histórica! Aquí encontrarás la información esencial para organizar tu visita a Cerezo de Río Tirón y explorar el legado del Condado de Castilla.": "",
-  "© 2024 Condado de Castilla": "",
+  "© %YEAR% Condado de Castilla": "",
   "« Volver a Nuestra Historia": "",
   "« Volver a la página principal de Nuestra Historia": "",
   "« Volver al Índice Detallado": "",

--- a/translations/es.json
+++ b/translations/es.json
@@ -2515,7 +2515,7 @@
   "y sus 1200 metros de largo con capacidad para albergar el Palacio o Alcázar su corte condal de funcionarios y sus soldados.": "y sus 1200 metros de largo con capacidad para albergar el Palacio o Alcázar su corte condal de funcionarios y sus soldados.",
   "y, muy posiblemente, por una cerca o muralla propia que envolviera el caserío principal, Cerezo vería consolidarse sus calles, barrios (collaciones) y espacios públicos.": "y, muy posiblemente, por una cerca o muralla propia que envolviera el caserío principal, Cerezo vería consolidarse sus calles, barrios (collaciones) y espacios públicos.",
   "¡Prepárate para una aventura histórica! Aquí encontrarás la información esencial para organizar tu visita a Cerezo de Río Tirón y explorar el legado del Condado de Castilla.": "¡Prepárate para una aventura histórica! Aquí encontrarás la información esencial para organizar tu visita a Cerezo de Río Tirón y explorar el legado del Condado de Castilla.",
-  "© 2024 Condado de Castilla": "© 2024 Condado de Castilla",
+  "© %YEAR% Condado de Castilla": "© %YEAR% Condado de Castilla",
   "« Volver a Nuestra Historia": "« Volver a Nuestra Historia",
   "« Volver a la página principal de Nuestra Historia": "« Volver a la página principal de Nuestra Historia",
   "« Volver al Índice Detallado": "« Volver al Índice Detallado",

--- a/translations/gl.json
+++ b/translations/gl.json
@@ -2515,7 +2515,7 @@
   "y sus 1200 metros de largo con capacidad para albergar el Palacio o Alcázar su corte condal de funcionarios y sus soldados.": "",
   "y, muy posiblemente, por una cerca o muralla propia que envolviera el caserío principal, Cerezo vería consolidarse sus calles, barrios (collaciones) y espacios públicos.": "",
   "¡Prepárate para una aventura histórica! Aquí encontrarás la información esencial para organizar tu visita a Cerezo de Río Tirón y explorar el legado del Condado de Castilla.": "",
-  "© 2024 Condado de Castilla": "",
+  "© %YEAR% Condado de Castilla": "",
   "« Volver a Nuestra Historia": "",
   "« Volver a la página principal de Nuestra Historia": "",
   "« Volver al Índice Detallado": "",


### PR DESCRIPTION
## Summary
- replace hardcoded year with `%YEAR%` in translation JSON files
- handle `%YEAR%` placeholder in translation helper
- show current year in Tailwind test page footer

## Testing
- `python -m unittest tests/test_translation_keys.py`
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'filelock')*

------
https://chatgpt.com/codex/tasks/task_e_6857005bd7408329aba8b1a9a6257104