### PR TITLE
Add page transition docs and README mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ El script `scripts/daily_agent.py` se ejecuta cada noche mediante GitHub Actions
 
 Para detalles sobre la paleta de colores y la tipografía consulta [docs/style-guide.md](docs/style-guide.md), en especial las líneas 1‑24 que enumeran todas las variables CSS.
 
+## Transiciones de página
+
+Se añadió un módulo de **transiciones de página** que aprovecha `GSAP` para animar la entrada y salida de contenido. Gracias a la suavidad de estos efectos, la visita resulta más atractiva y ayuda a cumplir la misión de *promocionar el turismo en Cerezo de Río Tirón y proteger su patrimonio arqueológico y cultural*.
+
+Para empaquetar los scripts y estilos utiliza:
+
+```bash
+npm run build
+```
+
+El comando genera los archivos finales en `dist/` y `assets/css`. Consulta [docs/page-transitions.md](docs/page-transitions.md) para obtener todos los detalles de configuración.
+
 ## Testing
 
 Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar todas las pruebas. Los pasos básicos son:

--- a/docs/page-transitions.md
+++ b/docs/page-transitions.md
@@ -1,0 +1,27 @@
+# Page Transitions
+
+This guide explains how to configure the optional page-transition module used by the website.
+
+## Installing dependencies
+
+The transitions rely on GSAP and custom CSS. Install JS dependencies with:
+
+```bash
+npm install
+```
+
+## Building assets
+
+To bundle the transition scripts and styles run:
+
+```bash
+npm run build
+```
+
+The output CSS is written to `assets/css/custom.css` and the JS bundle in `dist/`.
+
+## Usage
+
+Include the generated files in your template and call `initPageTransitions()` from `js/page-transitions.js`.
+
+The module fades the old page out and slides in the new content using Cerezo purple and old gold colors. The effect reinforces the mission by offering a smooth and appealing navigation experience that invites visitors to explore the heritage of **Cerezo de Río Tirón**.


### PR DESCRIPTION
## Summary
- document how to use the new page-transition module
- describe the feature in README and show how it supports the mission
- note npm build step and provide link to full config

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_685700878c788329ae3ebbb494d4f2c5