### PR TITLE
Add page transitions

### DIFF
--- a/assets/css/page-transitions.css
+++ b/assets/css/page-transitions.css
@@ -1,0 +1,12 @@
+#page-transition-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(var(--epic-alabaster-bg-rgb), 0.85);
+  pointer-events: none;
+  opacity: 0;
+  z-index: 9999;
+}
+
+#page-transition-overlay.active {
+  pointer-events: auto;
+}

--- a/assets/js/page-transitions.js
+++ b/assets/js/page-transitions.js
@@ -1,0 +1,41 @@
+// assets/js/page-transitions.js - simple GSAP page transitions
+
+document.addEventListener('DOMContentLoaded', () => {
+  const overlay = document.createElement('div');
+  overlay.id = 'page-transition-overlay';
+  document.body.appendChild(overlay);
+
+  const fade = () => gsap.fromTo(overlay, {opacity: 0}, {opacity: 1, duration: 0.5});
+  const slide = () => gsap.fromTo(overlay, {x: '-100%', opacity: 0}, {x: '0%', opacity: 1, duration: 0.5});
+  const rotate = () => gsap.fromTo(overlay, {rotation: 0, opacity: 0}, {rotation: 360, opacity: 1, duration: 0.6});
+  const transitions = [fade, slide, rotate];
+
+  const runTransition = (link) => {
+    overlay.classList.add('active');
+    const anim = transitions[Math.floor(Math.random() * transitions.length)];
+    anim();
+    gsap.delayedCall(0.6, () => { window.location.href = link.href; });
+  };
+
+  document.addEventListener('click', (e) => {
+    const a = e.target.closest('a[href]');
+    if (!a) return;
+    const url = new URL(a.href, location.href);
+    if (url.origin !== location.origin || url.hash || a.target === '_blank' || a.hasAttribute('download')) return;
+    e.preventDefault();
+    if (!window.gsap) {
+      const script = document.createElement('script');
+      script.src = 'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.13.0/gsap.min.js';
+      script.onload = () => runTransition(a);
+      script.onerror = () => {
+        const fallback = document.createElement('script');
+        fallback.src = '/assets/vendor/js/gsap.min.js';
+        fallback.onload = () => runTransition(a);
+        document.head.appendChild(fallback);
+      };
+      document.head.appendChild(script);
+    } else {
+      runTransition(a);
+    }
+  });
+});

--- a/docs/page-transitions.md
+++ b/docs/page-transitions.md
@@ -1,0 +1,15 @@
+# Page Transitions
+
+This module applies simple GSAP animations when navigating between internal pages.
+
+## Usage
+
+1. The script `page-transitions.js` is loaded automatically via `includes/head_common.php`.
+2. Any click on an internal `<a>` element triggers a random transition: **fade**, **slide** or **rotate**.
+3. An overlay with id `page-transition-overlay` covers the page during the animation.
+
+The overlay color uses `rgba(var(--epic-alabaster-bg-rgb), 0.85)` so it blends with the alabaster background defined in [style-guide.md](style-guide.md). Customize this value in `assets/css/page-transitions.css` if needed.
+
+## Development notes
+
+Transitions rely on GSAP 3.13.0. The script attempts to load GSAP from CDN and falls back to the bundled copy in `/assets/vendor/js/gsap.min.js` when offline.

--- a/includes/head_common.php
+++ b/includes/head_common.php
@@ -33,6 +33,9 @@ require_once __DIR__ . '/env_loader.php';
 <link rel="preload" href="/assets/js/torch_cursor.js" as="script">
 <script defer src="/assets/js/torch_cursor.js"></script>
 <link rel="preload" href="/assets/js/main.js" as="script">
+<link rel="stylesheet" href="/assets/css/page-transitions.css">
+<link rel="preload" href="/assets/js/page-transitions.js" as="script">
+<script defer src="/assets/js/page-transitions.js"></script>
 <link rel="stylesheet" href="/assets/css/glow_filter.css">
 <link rel="stylesheet" href="/assets/css/custom-pointer.css">
 <link rel="stylesheet" href="/assets/css/mobile_contrast.css" media="(max-width: 768px)">

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start:php": "sh -c 'php -S localhost:8080 >/dev/null 2>&1 & echo $! > .php_server.pid'",
     "stop:php": "sh -c 'if [ -f .php_server.pid ]; then kill $(cat .php_server.pid); rm .php_server.pid; fi'",
-    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuKeyboardNavigationTest.js && node tests/timelineDataTest.js",
+    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuKeyboardNavigationTest.js && node tests/timelineDataTest.js && node tests/pageTransitionsTest.js",
     "test:playwright": "playwright test tests/phpRoutes.spec.js",
     "test": "npm run start:php && npm run test:puppeteer && npm run test:playwright; npm run stop:php",
     "build": "vite build && npx sass assets/scss/custom.scss assets/css/custom.css --no-source-map",

--- a/tests/manual/test_page_transitions.html
+++ b/tests/manual/test_page_transitions.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <title>Test Page Transitions</title>
+    <?php require_once __DIR__ . '/../../includes/head_common.php'; ?>
+</head>
+<body>
+<a id="nav-link" href="/index.php">Ir al inicio</a>
+</body>
+</html>

--- a/tests/pageTransitionsTest.js
+++ b/tests/pageTransitionsTest.js
@@ -1,0 +1,12 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/tests/manual/test_page_transitions.html');
+  await page.waitForSelector('#nav-link');
+  await page.click('#nav-link');
+  await page.waitForSelector('#page-transition-overlay.active');
+  console.log('Overlay activated');
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- create `page-transitions.js` with GSAP animations
- style alabaster overlay in `page-transitions.css`
- load new files from `head_common.php`
- document page transitions
- add puppeteer test and manual page
- run `npm test` *(fails: puppeteer missing)*

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68570088df0c83298a71c02a9ea6f87e