### PR TITLE
Add npm ci reminder before Node tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Para detalles sobre la paleta de colores y la tipografía consulta [docs/style-g
 Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar todas las pruebas. Los pasos básicos son:
 
 1. Ejecuta [`scripts/setup_environment.sh`](scripts/setup_environment.sh) **antes de cualquier prueba**. El script instala Python
-   (`flask`, `filelock`, etc.) y las extensiones de PHP necesarias (`php-cgi`,
-   `pdo_pgsql`, `php-xml`).
+   (`flask`, `filelock`, etc.), las extensiones de PHP necesarias (`php-cgi`,
+   `pdo_pgsql`, `php-xml`) y las dependencias de Node.
 2. Si la suite incluye pruebas de interfaz, arranca un servidor PHP con:
    ```bash
    php -S localhost:8080
@@ -94,7 +94,7 @@ Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar
    ```bash
    python -m unittest discover -s tests
    ```
-5. Ejecuta las pruebas de Node (Puppeteer):
+5. Ejecuta las pruebas de Node (Puppeteer) tras instalar las dependencias con `npm ci` (o usando `scripts/setup_environment.sh`):
    ```bash
    npm run test:puppeteer
    ```

--- a/docs/script_catalog.md
+++ b/docs/script_catalog.md
@@ -21,7 +21,7 @@ Este documento recopila los scripts disponibles en el directorio `scripts/` y su
 | `link_checker.py`            | Escanea el HTML del repositorio y detecta enlaces rotos.                       |
 | `process_characters.py`      | Combina el parser y el generador de whispers para producir datos enriquecidos. |
 | `run_accessibility_audit.sh` | Ejecuta Lighthouse para auditar la accesibilidad de varias páginas.            |
-| `run_tests.sh`               | Instala dependencias de Python y ejecuta la batería completa de pruebas.       |
+| `run_tests.sh`               | Instala dependencias de Python y ejecuta la batería completa de pruebas. Ejecuta `npm ci` o `setup_environment.sh` antes de las pruebas de Node.       |
 | `setup_environment.sh`       | Verifica e instala runtimes y dependencias básicas.                            |
 | `setup_frontend_libs.sh`     | Descarga bibliotecas JS/CSS y las copia a `assets/vendor`.                     |
 | `setup_project.sh`           | Configura el proyecto completo y crea archivos iniciales.                      |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,13 +68,13 @@ credenciales se definan en `.env` antes de lanzar PHPUnit.
 
 ### Dependencias de Node para Puppeteer
 
-Antes de lanzar la suite de interfaz instala las dependencias de Node:
+Antes de lanzar la suite de interfaz instala las dependencias de Node. Ejecuta:
 
 ```bash
 npm ci
 ```
 
-Esto descargará `puppeteer` y los binarios de Chrome.
+o bien lanza `scripts/setup_environment.sh`, que realiza la misma instalación.
 
 ### Auditorías de accesibilidad
 


### PR DESCRIPTION
## Summary
- mention Node dependencies in README testing section
- document that `npm ci` or `setup_environment.sh` should run before Node tests in docs/testing
- update run_tests.sh entry in script catalog

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857028f19b08329889f4518b31feda4