### PR TITLE
Check for composer in test script

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,5 +4,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
+if command -v composer >/dev/null 2>&1; then
+    composer install --no-interaction --prefer-dist
+else
+    echo "Warning: Composer not found. Consider running scripts/setup_environment.sh" >&2
+fi
+
 pip install -r requirements.txt
 python -m unittest discover -s tests


### PR DESCRIPTION
## Summary
- check if Composer exists before installing dependencies in `run_tests.sh`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685702930bb08329955c1c54e87c663c