### PR TITLE
Add test to check i18n keys

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,6 +42,13 @@ python -m unittest tests/test_graph_db_interface.py
 python -m unittest tests/test_translation_keys.py
 ```
 
+   - Verificar que `i18n/es.json` usa el mismo conjunto de claves que los
+     archivos en `translations/`:
+
+```bash
+python -m unittest tests/test_i18n_keys.py
+```
+
 - Toda la batería de pruebas de Python:
 
 ```bash

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,4 +5,5 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
 pip install -r requirements.txt
+python -m unittest tests/test_i18n_keys.py
 python -m unittest discover -s tests

--- a/tests/test_i18n_keys.py
+++ b/tests/test_i18n_keys.py
@@ -1,0 +1,27 @@
+import json
+import unittest
+from pathlib import Path
+
+
+class I18nKeysTest(unittest.TestCase):
+    def test_i18n_and_translation_keys_match(self):
+        project_root = Path(__file__).resolve().parent.parent
+        base_file = project_root / 'i18n' / 'es.json'
+        translation_dir = project_root / 'translations'
+
+        files = [base_file] + list(translation_dir.glob('*.json'))
+        self.assertTrue(files, 'No translation files found')
+
+        key_sets = []
+        for fpath in files:
+            with open(fpath, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            key_sets.append((fpath.name, set(data.keys())))
+
+        base_keys = key_sets[0][1]
+        for name, keys in key_sets[1:]:
+            self.assertEqual(base_keys, keys, f'Key mismatch in {name}')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Python unittest to verify i18n/es.json keys match translation files
- run the new test from `run_tests.sh`
- document the test in docs/testing.md

## Testing
- `python -m unittest tests/test_i18n_keys.py` *(fails: Key mismatch)*
- `python -m unittest discover -s tests` *(fails: Key mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6857029cf6f08329a6c770296cf59974