### PR TITLE
Add forum build helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ npm run dev:astro
 
 Consulta [frontend/astro-app/README.md](frontend/astro-app/README.md) si prefieres lanzarla dentro de su carpeta. Allí se detallan también la ubicación del directorio de salida y otros apuntes.
 
+Si modificas el código del foro es necesario regenerar sus archivos estáticos. Basta con ejecutar desde la raíz:
+
+```bash
+./scripts/build_forum.sh
+```
+
+El script compila el proyecto con Vite y deja la salida en `assets/forum-app/`.
+
 La página principal se genera en `/piezas` y presenta las piezas en una cuadrícula adaptable.
 
 ## Mapa interactivo

--- a/scripts/build_forum.sh
+++ b/scripts/build_forum.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build the forum app using the package.json script
+npm --prefix frontend/forum-app run build
+
+# Copy build output to assets directory if a dist folder exists
+if [ -d frontend/forum-app/dist ]; then
+  cp -r frontend/forum-app/dist/* assets/forum-app/
+fi


### PR DESCRIPTION
## Summary
- add `scripts/build_forum.sh` to compile the React forum and copy assets
- document in README how to rebuild the forum

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857029c1a8083298f8a82065b11e5d2