### PR TITLE
Nueva web skeleton

### DIFF
--- a/nuevaweb/README.md
+++ b/nuevaweb/README.md
@@ -1,0 +1,11 @@
+# Nueva Web
+
+Este subdirectorio contiene la evolución del proyecto Condado de Castilla.
+Usa la paleta en morados y tonos de oro viejo con fondos de alabastro.
+Integra PHP para el sitio público y un API minimal en Flask.
+
+## Estructura
+- `index.php` – página principal con menú deslizante.
+- `assets/` – hojas de estilo y scripts.
+- `flask_app.py` – API en Python.
+- `templates/` – plantillas de Flask.

--- a/nuevaweb/assets/css/style.css
+++ b/nuevaweb/assets/css/style.css
@@ -1,0 +1,46 @@
+@import "../../assets/css/epic_theme.css";
+
+body {
+    background: var(--epic-alabaster-bg);
+    color: var(--epic-text-color);
+    font-family: var(--font-body);
+    margin: 0;
+}
+
+.gradient-text {
+    background: linear-gradient(45deg, var(--epic-purple-emperor), var(--epic-gold-main));
+    -webkit-background-clip: text;
+    color: transparent;
+}
+
+.slider-menu {
+    position: relative;
+}
+
+.slider-menu ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: fixed;
+    top: 0;
+    left: -220px;
+    width: 200px;
+    height: 100%;
+    background: var(--epic-purple-emperor);
+    transition: left 0.3s ease;
+}
+
+.slider-menu ul.open {
+    left: 0;
+}
+
+.slider-menu a {
+    display: block;
+    padding: 1rem;
+    color: var(--epic-gold-main);
+    text-decoration: none;
+}
+
+body.menu-compressed {
+    overflow: hidden;
+}

--- a/nuevaweb/assets/js/menu.js
+++ b/nuevaweb/assets/js/menu.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('menu-toggle');
+    const menu = document.getElementById('menu');
+    if (!btn || !menu) return;
+    btn.addEventListener('click', () => {
+        const open = menu.classList.toggle('open');
+        document.body.classList.toggle('menu-compressed', open);
+        btn.setAttribute('aria-expanded', open);
+    });
+});

--- a/nuevaweb/flask_app.py
+++ b/nuevaweb/flask_app.py
@@ -1,0 +1,10 @@
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route('/api/hello')
+def hello():
+    return jsonify(message='Hola desde nuevaweb')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/nuevaweb/index.php
+++ b/nuevaweb/index.php
@@ -1,0 +1,19 @@
+<?php require_once __DIR__ . '/../fragments/header.php'; ?>
+<link rel="stylesheet" href="/nuevaweb/assets/css/style.css">
+
+<main class="container-epic px-4 py-8">
+    <h1 class="gradient-text text-3xl font-headings mb-4">Descubre Cerezo de Río Tirón</h1>
+    <p class="font-body mb-6">Proyecto en desarrollo para promover el turismo y preservar el patrimonio cultural.</p>
+
+    <nav class="slider-menu">
+        <button id="menu-toggle" aria-expanded="false" class="cta-button">Menú</button>
+        <ul id="menu">
+            <li><a href="#patrimonio">Patrimonio</a></li>
+            <li><a href="#arqueologia">Arqueología</a></li>
+            <li><a href="#foro">Foro</a></li>
+        </ul>
+    </nav>
+</main>
+
+<script src="/nuevaweb/assets/js/menu.js"></script>
+<?php require_once __DIR__ . '/../fragments/footer.php'; ?>

--- a/nuevaweb/templates/index.html
+++ b/nuevaweb/templates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Nueva Web</title>
+    <link rel="stylesheet" href="/nuevaweb/assets/css/style.css">
+</head>
+<body>
+    <h1 class="gradient-text">Bienvenido a la Nueva Web</h1>
+    <p>Contenido generado con Flask.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `nuevaweb` directory with initial README
- add PHP index with sliding menu
- include starter CSS and JS for new theme
- provide minimal Flask API and template

## Testing
- `python -m unittest discover -s tests`
- `npm run test` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68571e476188832981d3acbb1379b848