### PR TITLE
Fix overlay after page transitions

### DIFF
--- a/assets/css/page-transitions.css
+++ b/assets/css/page-transitions.css
@@ -1,0 +1,12 @@
+#page-transition-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: var(--epic-purple-emperor);
+  z-index: 9999;
+  transition: opacity 0.4s ease-out;
+}
+
+#page-transition-overlay.fade-out {
+  opacity: 0;
+  pointer-events: none;
+}

--- a/assets/js/page-transitions.js
+++ b/assets/js/page-transitions.js
@@ -1,0 +1,25 @@
+(function() {
+  function cleanupOverlay() {
+    var overlay = document.getElementById('page-transition-overlay');
+    if (!overlay) return;
+    overlay.classList.add('fade-out');
+    overlay.addEventListener('transitionend', function() {
+      if (overlay && overlay.parentNode) {
+        overlay.parentNode.removeChild(overlay);
+      }
+    });
+    // Fallback in case transitionend doesn't fire
+    setTimeout(function() {
+      if (overlay && overlay.parentNode) {
+        overlay.parentNode.removeChild(overlay);
+      }
+    }, 1000);
+  }
+
+  if (document.readyState === 'complete') {
+    cleanupOverlay();
+  } else {
+    window.addEventListener('load', cleanupOverlay);
+    document.addEventListener('DOMContentLoaded', cleanupOverlay);
+  }
+})();


### PR DESCRIPTION
## Summary
- add page-transitions overlay cleanup JS
- add fade-out effect for overlay

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*
- `./scripts/setup_environment.sh` *(fails: PHP 8.1 or higher is required but not found)*

------
https://chatgpt.com/codex/tasks/task_e_685705a7f320832997c3fae9c0cb4ac1