### PR TITLE
Run npm ci in test workflow

### DIFF
--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install test dependencies
         run: ./scripts/install_dev_deps.sh
 
+      - name: Install Node modules
+        run: npm ci
+
       - name: Run PHPUnit
         run: vendor/bin/phpunit
 


### PR DESCRIPTION
## Summary
- ensure Node modules installed before tests

## Testing
- `npm ci --verbose` *(fails: unable to resolve dependency tree)*
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*
- `node tests/pageTransitionsTest.js` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_685705a81e748329916560e2d4c26229