### PR TITLE
Update commit message guidelines and template

### DIFF
--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,0 +1,6 @@
+# Commit Message Template
+
+# Title (imperative, max 72 chars)
+
+# Body (optional): describe what and why in short sentences.
+# Example: Add GSAP page transitions with overlay and tests

--- a/README.md
+++ b/README.md
@@ -157,4 +157,6 @@ También se proporciona `scripts/run_tests.sh` para instalar `requirements.txt` 
 
 ## Estilo de mensajes de commit
 
-Utiliza títulos breves en modo imperativo que describan el cambio, p.ej. `Add recursive menu renderer with root flag`. Si añades un cuerpo opcional, explica _qué_ y _por qué_. Consulta [docs/commit-style.md](docs/commit-style.md) para ver la guía completa.
+Utiliza títulos breves en modo imperativo que describan el cambio, p.ej. `Add GSAP page transitions with overlay and tests`. Si añades un cuerpo opcional, explica _qué_ y _por qué_. Consulta [docs/commit-style.md](docs/commit-style.md) para ver la guía completa.
+
+Se incluye `.gitmessage.txt` como plantilla de ejemplo. Puedes activarla con `git config commit.template .gitmessage.txt` para redactar mensajes consistentes.

--- a/docs/commit-style.md
+++ b/docs/commit-style.md
@@ -11,9 +11,19 @@ Sigue estas pautas para mantener un historial claro y uniforme.
 ## Ejemplos
 
 - `Add menu group translations (es/en/gl)`
-  
+
   Cuerpo: "Adds `about.us` and `forum.rules` keys".
 - `Fix broken link in footer`
 - `Update gallery API docs`
+- `Add GSAP page transitions with overlay and tests`
 
 Al añadir traducciones, enumera en el cuerpo las claves nuevas o modificadas.
+
+## Plantilla
+
+El repositorio incluye `.gitmessage.txt` como ejemplo de plantilla. Puedes
+configurarla con:
+
+```bash
+git config commit.template .gitmessage.txt
+```


### PR DESCRIPTION
## Summary
- add GSAP commit message example
- note template usage in commit guidelines
- provide `.gitmessage.txt` template

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685705a7079c8329be0f062428317561