### PR TITLE
Add comment referencing forum agents docs

### DIFF
--- a/config/forum_agents.php
+++ b/config/forum_agents.php
@@ -1,4 +1,5 @@
 <?php
+// Field descriptions are listed in docs/forum_agents.md
 return [
     'historian' => [
         'name' => 'Alicia la Historiadora',


### PR DESCRIPTION
## Summary
- note docs with field descriptions in `config/forum_agents.php`

## Testing
- `./scripts/setup_environment.sh` *(fails: PHP 8.1 not found)*
- `vendor/bin/phpunit` *(fails: command not found)*
- `python -m unittest discover -s tests` *(fails: missing Flask and filelock)*
- `npm run test:puppeteer` *(fails: cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685720deede083299c127940148b1893