### PR TITLE
Add nuevaweb services

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ El proyecto emplea PHP y Python con Flask. Para nuevos módulos se aconseja usar
 docker-compose up --build
 ```
 
-Consulta el archivo [docker-compose.yml](docker-compose.yml) para conocer los servicios disponibles (`frontend`, `backend` y `db`).
-El frontend se sirve en `http://localhost:4321`, la API de Flask en `http://localhost:5000` y la base de datos PostgreSQL en `localhost:5432`.
+Consulta el archivo [docker-compose.yml](docker-compose.yml) para conocer los servicios disponibles (`frontend`, `backend`, `nuevaweb_php`, `nuevaweb_flask` y `db`).
+El frontend se sirve en `http://localhost:4321`, la API de Flask principal en `http://localhost:5000`, la web PHP de `nuevaweb` en `http://localhost:8082`, la API secundaria de Flask en `http://localhost:5002` y la base de datos PostgreSQL en `localhost:5432`.
 
 ## Ejecuci\u00f3n manual
 
 Si no deseas usar Docker Compose puedes arrancar cada servicio por separado:
 
-1. **API de Flask**:
+1. **API de Flask (raíz)**:
    ```bash
    pip install -r requirements.txt
    python flask_app.py
@@ -58,7 +58,16 @@ Si no deseas usar Docker Compose puedes arrancar cada servicio por separado:
    pnpm install
    pnpm run dev --host 0.0.0.0
    ```
-3. **PostgreSQL**:
+3. **Web PHP de nuevaweb**:
+   ```bash
+   php -S localhost:8082 -t nuevaweb
+   ```
+4. **API de Flask de nuevaweb**:
+   ```bash
+   pip install flask
+   python nuevaweb/flask_app.py
+   ```
+5. **PostgreSQL**:
    ```bash
    docker run --name condado_db -p 5432:5432 \
       -e POSTGRES_DB=condado_castilla_db \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,27 @@ services:
       DB_USER: ${DB_USER:-condado_user}
       CONDADO_DB_PASSWORD: ${CONDADO_DB_PASSWORD:-condado_password}
 
+  nuevaweb_php:
+    image: php:8.2-cli
+    ports:
+      - "8082:8082"
+    volumes:
+      - ./nuevaweb:/var/www/html/nuevaweb
+    working_dir: /var/www/html
+    command: php -S 0.0.0.0:8082 -t nuevaweb
+
+  nuevaweb_flask:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: backend
+    ports:
+      - "5002:5002"
+    volumes:
+      - ./:/app
+    working_dir: /app/nuevaweb
+    command: ["python", "flask_app.py"]
+
   db:
     image: postgres:16
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add PHP service serving `nuevaweb/index.php`
- add Flask service running `nuevaweb/flask_app.py`
- document new ports and services

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685720e1a5f883298c5dfef41ee39e88