### PR TITLE
Add vitest menu toggle test

### DIFF
--- a/tests/menuJsToggle.spec.js
+++ b/tests/menuJsToggle.spec.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { JSDOM } from 'jsdom'
+import fs from 'fs'
+
+const menuScript = fs.readFileSync('nuevaweb/src/js/menu.js', 'utf8')
+
+describe('menu.js toggle behavior', () => {
+  it('toggles aria-expanded and open class', () => {
+    const dom = new JSDOM('<button id="menu-toggle"></button><div id="menu"></div>', { runScripts: 'dangerously' })
+    const { window } = dom
+
+    const scriptEl = window.document.createElement('script')
+    scriptEl.textContent = menuScript
+    window.document.body.appendChild(scriptEl)
+
+    // Trigger DOMContentLoaded so the script initializes
+    window.document.dispatchEvent(new window.Event('DOMContentLoaded'))
+
+    const btn = window.document.getElementById('menu-toggle')
+    const menu = window.document.getElementById('menu')
+
+    btn.click()
+    expect(menu.classList.contains('open')).toBe(true)
+    expect(window.document.body.classList.contains('menu-compressed')).toBe(true)
+    expect(btn.getAttribute('aria-expanded')).toBe('true')
+
+    btn.click()
+    expect(menu.classList.contains('open')).toBe(false)
+    expect(window.document.body.classList.contains('menu-compressed')).toBe(false)
+    expect(btn.getAttribute('aria-expanded')).toBe('false')
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,5 @@
+export default {
+  test: {
+    environment: 'jsdom',
+  },
+}


### PR DESCRIPTION
## Summary
- add Vitest config with jsdom environment
- test menu.js toggle behavior sets aria-expanded and open class

## Testing
- `npx vitest run tests/menuJsToggle.spec.js --config vitest.config.js` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6857475d453083299cc715f8088726ba