### PR TITLE
Fix custom colors in CSS

### DIFF
--- a/assets/css/cave_mask.css
+++ b/assets/css/cave_mask.css
@@ -2,7 +2,7 @@
     pointer-events:none;
     position:fixed;
     inset:0;
-    background:rgba(0,0,0,0.7);
+    background:rgba(var(--color-negro-contraste-rgb),0.7); /* see docs/style-guide.md */
     opacity:0.3;
     -webkit-mask-image:radial-gradient(circle var(--mask-radius,20vw) at var(--mask-x,50vw) var(--mask-y,50vh),transparent 0,black 100%);
     mask-image:radial-gradient(circle var(--mask-radius,20vw) at var(--mask-x,50vw) var(--mask-y,50vh),transparent 0,black 100%);

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -64,8 +64,8 @@ header[id^="hero-"] h1 {
 }
 
 .alabaster-bg {
-    background-color: var(--epic-alabaster-bg, #F9F7F4);
-    background-image: var(--alabaster-background-image, url(/assets/img/alabastro.jpg));
+    background-color: var(--epic-alabaster-bg); /* see docs/style-guide.md */
+    background-image: var(--alabaster-background-image); /* see docs/style-guide.md */
     background-size: cover;
     background-attachment: fixed;
 }

--- a/assets/css/custom-pointer.css
+++ b/assets/css/custom-pointer.css
@@ -9,7 +9,7 @@
 #custom-pointer .outer{
   width:2.5rem;
   height:2.5rem;
-  border:2px solid rgba(207,181,59,0.6);
+  border:2px solid rgba(var(--epic-gold-main-rgb),0.6); /* see docs/style-guide.md */
   border-radius:9999px;
 }
 #custom-pointer .inner{
@@ -18,12 +18,12 @@
   left:50%;
   width:0.625rem;
   height:0.625rem;
-  background-color:#cfb53b;
+  background-color:var(--epic-gold-main); /* see docs/style-guide.md */
   border-radius:9999px;
   transform:translate(-50%,-50%);
 }
 #custom-pointer.active .outer{
-  border-color:#800080;
+  border-color:var(--epic-purple-emperor); /* see docs/style-guide.md */
 }
 body.cursor-none{
   cursor:none;

--- a/assets/css/header/ia-chat.css
+++ b/assets/css/header/ia-chat.css
@@ -56,8 +56,8 @@ body.menu-open-right #ai-chat-panel { /* This selector might need JS to add 'men
 #gemini-chat-area {
     height: 250px;
     overflow-y: auto;
-    border: 1px solid var(--epic-neutral-border, #ddd);
-    background-color: var(--epic-neutral-bg, #f9f9f9);
+    border: 1px solid var(--epic-neutral-border); /* see docs/style-guide.md */
+    background-color: var(--epic-neutral-bg); /* see docs/style-guide.md */
     padding: 10px;
     margin-top: 1rem; /* Space between ia-tools-menu and chat area */
     margin-bottom: 10px;
@@ -76,7 +76,7 @@ body.menu-open-right #ai-chat-panel { /* This selector might need JS to add 'men
 #gemini-chat-input {
     flex-grow: 1;
     padding: 8px 10px;
-    border: 1px solid var(--epic-input-border, #ccc);
+    border: 1px solid var(--epic-input-border); /* see docs/style-guide.md */
     border-radius: 4px;
     margin-right: 8px;
 }

--- a/assets/css/header/nav.css
+++ b/assets/css/header/nav.css
@@ -281,7 +281,7 @@ body.sidebar-active #sidebar-toggle:hover .bar {
 #sidebar .nav-links a {
     display: block;
     padding: 12px 15px;
-    color: var(--epic-text-dark, #333333); /* Light text for dark sidebar */
+    color: var(--epic-text-color); /* see docs/style-guide.md */
     font-family: var(--font-headings);
     font-size: 1.1em;
     font-weight: 600;
@@ -344,7 +344,7 @@ body.sidebar-active {
     }
     #sidebar .nav-links a {
         /* Explicitly define for mobile - consistent with desktop for now */
-        color: var(--epic-text-dark, #333333);
+        color: var(--epic-text-color); /* see docs/style-guide.md */
     }
 }
 

--- a/assets/css/lighting.css
+++ b/assets/css/lighting.css
@@ -14,7 +14,7 @@
     height: 100vh;
     z-index: 9998;
     mix-blend-mode: lighten;
-    background-image: radial-gradient(circle var(--linterna-radio) at var(--mouse-x) var(--mouse-y), #fef08a 0%, transparent 60%), url('/assets/img/alabastro.jpg');
+    background-image: radial-gradient(circle var(--linterna-radio) at var(--mouse-x) var(--mouse-y), var(--color-acento-amarillo) 0%, transparent 60%), url('/assets/img/alabastro.jpg'); /* see docs/style-guide.md */
     background-size: var(--linterna-radio) var(--linterna-radio), cover;
     background-repeat: no-repeat;
     background-position: center center;

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -1,7 +1,8 @@
 :root {
-    --header-bg: var(--epic-alabaster-bg, #fdfaf6);
-    --primary-purple: var(--epic-purple-emperor, #4A0D67);
-    --old-gold: var(--epic-gold-main, #CFB53B);
+    --header-bg: var(--epic-alabaster-bg);
+    --primary-purple: var(--epic-purple-emperor);
+    --old-gold: var(--epic-gold-main);
+    /* Palette defined in docs/style-guide.md */
 }
 
 body {
@@ -14,7 +15,7 @@ body {
     left: 0;
     right: 0;
     background: var(--header-bg);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 4px rgba(var(--color-negro-contraste-rgb), 0.1); /* see docs/style-guide.md */
     z-index: 10000;
     display: flex;
     align-items: center;
@@ -51,7 +52,7 @@ body {
     top: 0;
     bottom: 0;
     width: 280px;
-    background: rgba(var(--epic-alabaster-bg-rgb, 253,250,246), 0.45);
+    background: rgba(var(--epic-alabaster-bg-rgb), 0.45); /* see docs/style-guide.md */
     backdrop-filter: blur(8px);
     overflow-y: auto;
     transition: transform 0.3s ease;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -69,7 +69,7 @@ header { /* New header for hamburger only */
     left: 0;
     width: 100%;
     z-index: 1030; /* Above sidebar but below modals if any */
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 4px rgba(var(--color-negro-contraste-rgb),0.1); /* see docs/style-guide.md */
 }
 
 #menu-toggle {
@@ -93,7 +93,7 @@ header { /* New header for hamburger only */
     padding-top: 60px; /* Espacio para el header fijo */
     transition: left 0.3s ease-in-out;
     overflow-y: auto;
-    box-shadow: 2px 0 5px rgba(0,0,0,0.1);
+    box-shadow: 2px 0 5px rgba(var(--color-negro-contraste-rgb),0.1); /* see docs/style-guide.md */
 }
 
 #sidebar.open {
@@ -189,7 +189,7 @@ header { /* New header for hamburger only */
     height: 100%;
     background-color: var(--current-sidebar-bg); /* Usar el mismo fondo que el sidebar */
     color: var(--current-text);
-    box-shadow: -3px 0 8px rgba(0,0,0,0.15);
+    box-shadow: -3px 0 8px rgba(var(--color-negro-contraste-rgb),0.15); /* see docs/style-guide.md */
     z-index: 1050; /* Encima de otros elementos */
     transition: right 0.35s ease-in-out;
     display: flex;

--- a/assets/css/torch_cursor.css
+++ b/assets/css/torch_cursor.css
@@ -5,9 +5,9 @@
   left: 0;
   width: 8px;
   height: 8px;
-  background: #271700;
+  background: var(--color-negro-contraste); /* see docs/style-guide.md */
   border-radius: 50%;
-  box-shadow: 0 0 15px 5px rgba(253,184,67,0.9);
+  box-shadow: 0 0 15px 5px rgba(var(--epic-gold-main-rgb),0.9); /* see docs/style-guide.md */
   transform: translate(-50%, -50%);
   z-index: 10000;
 }
@@ -20,7 +20,7 @@
   width: 60px;
   height: 60px;
   border-radius: 50%;
-  background: rgba(253,184,67,0.6);
+  background: rgba(var(--epic-gold-main-rgb),0.6); /* see docs/style-guide.md */
   mix-blend-mode: lighten;
   filter: blur(20px);
   transform: translate(-50%, -50%);
@@ -28,7 +28,7 @@
 }
 
 #torch-cursor.focus::after {
-  background: rgba(104,60,180,0.8);
+  background: rgba(var(--epic-purple-emperor-rgb),0.8); /* see docs/style-guide.md */
   width: 40px;
   height: 40px;
 }


### PR DESCRIPTION
## Summary
- keep only theme variables in menu CSS
- switch pointer and torch cursor colors to theme variables
- remove hard-coded colors in lighting, mask, component, nav and chat styles
- replace dark box-shadow values with theme vars

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6857475fa37083299dc17af6131de2b9