### PR TITLE
Update nuevaweb README with server start instructions

### DIFF
--- a/nuevaweb/README.md
+++ b/nuevaweb/README.md
@@ -12,13 +12,25 @@ Integra PHP para el sitio público y un API minimal en Flask.
 
 ## Uso rápido
 1. Instala las dependencias de PHP con `composer install` y las de Python con `pip install -r ../requirements.txt`.
-2. Sirve `index.php` con el servidor integrado de PHP:
+2. Sirve `index.php` con el servidor integrado de PHP desde la raíz del repositorio:
    ```bash
-   php -S localhost:8000
+   php -S localhost:8000 -t nuevaweb
    ```
 3. Ejecuta la API Flask en otra terminal:
    ```bash
    python3 flask_app.py
    ```
+
+4. Como alternativa a los pasos anteriores puedes usar Docker Compose para
+   levantar ambos servicios ya configurados:
+   ```bash
+   docker-compose up nuevaweb_php nuevaweb_flask
+   ```
+   Esto expondrá la web en `http://localhost:8082` y la API en
+   `http://localhost:5002`.
+
+5. Abre tu navegador y navega a
+   `http://localhost:8000/nuevaweb/index.php` para ver la página inicial
+   (o `http://localhost:8082/nuevaweb/index.php` si utilizas Docker).
 
 Consulta la [guía de estilo](../docs/style-guide.md) para ver la paleta completa y otras recomendaciones.


### PR DESCRIPTION
## Summary
- explain how to launch PHP server from repo root
- describe running Flask API
- mention Docker Compose services
- include browser navigation instructions

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857476097c48329a63a5a276550bd85