### PR TITLE
Update testing environment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,16 @@ El comando genera los archivos finales en `dist/` y `assets/css`. Consulta [docs
 ## Testing
 
 Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar todas las pruebas. Los pasos básicos son:
+1. Instala todas las dependencias. Puedes ejecutar `scripts/setup_environment.sh` para instalarlas automáticamente o hacerlo manualmente:
 
-1. Ejecuta [`scripts/setup_environment.sh`](scripts/setup_environment.sh) **antes de cualquier prueba**. El script instala Python
-   (`flask`, `filelock`, etc.), las extensiones de PHP necesarias (`php-cgi`,
-   `pdo_pgsql`, `php-xml`) y las dependencias de Node.
+   ```bash
+   pip install -r requirements.txt
+   npm install
+   composer install
+   ```
+
+   Estos pasos garantizan que `phpunit`, `puppeteer` y las librerías de Python estén disponibles.
+
 2. Si la suite incluye pruebas de interfaz, arranca un servidor PHP con:
    ```bash
    php -S localhost:8080
@@ -159,7 +165,7 @@ Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar
    ```bash
    python -m unittest discover -s tests
    ```
-5. Ejecuta las pruebas de Node (Puppeteer) tras instalar las dependencias con `npm ci` (o usando `scripts/setup_environment.sh`):
+5. Ejecuta las pruebas de Node (Puppeteer) tras instalar las dependencias con `npm install` (o usando `scripts/setup_environment.sh`):
    ```bash
    npm run test:puppeteer
    ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,21 +4,15 @@ Esta guía explica cómo preparar el entorno y ejecutar las pruebas automatizada
 
 ## Paso a paso
 
-1. **Antes de ejecutar cualquier prueba, prepara el entorno**
-   lanzando `scripts/setup_environment.sh` (consulta
-   [script_catalog.md](script_catalog.md)):
+1. **Prepara el entorno de desarrollo**. Puedes ejecutar `scripts/setup_environment.sh` para instalar todo de forma automática o instalar cada grupo de dependencias manualmente:
 
-```bash
-./scripts/setup_environment.sh
-```
-Este script instala los paquetes indicados en `requirements.txt`
-(incluyendo **Flask** y **filelock**) y las extensiones de PHP necesarias
-(**php-cgi**, **pdo_pgsql** y **php-xml**).
+   ```bash
+   pip install -r requirements.txt
+   npm install
+   composer install
+   ```
 
-> **Nota:** si lo prefieres puedes ejecutar manualmente
-> `pip install -r requirements.txt`, pero la forma recomendada es usar
-> `scripts/setup_environment.sh` para asegurar la instalación de todas las
-> dependencias.
+   Esto asegura que las librerías de Python, las dependencias de Node (incluido `puppeteer`) y `phpunit` estén disponibles.
 
 2. Si vas a ejecutar la suite de interfaz, abre otro terminal y arranca un servidor PHP local:
 
@@ -74,7 +68,7 @@ credenciales se definan en `.env` antes de lanzar PHPUnit.
 Antes de lanzar la suite de interfaz instala las dependencias de Node. Ejecuta:
 
 ```bash
-npm ci
+npm install
 ```
 
 o bien lanza `scripts/setup_environment.sh`, que realiza la misma instalación.
@@ -110,7 +104,7 @@ php -S localhost:8080
 ```
 
 - Si las dependencias fallaron al instalarse, consulta [script_catalog.md](script_catalog.md) para volver a ejecutar el script de preparación.
-- Si Puppeteer informa que no se encuentra Chromium, ejecuta `npm ci` para reinstalar las dependencias.
+- Si Puppeteer informa que no se encuentra Chromium, ejecuta `npm install` para reinstalar las dependencias.
 
 ## Resultados del 20/06/2025
 


### PR DESCRIPTION
## Summary
- document optional manual setup in README and testing guide
- mention `pip install -r requirements.txt`, `npm install`, and `composer install`
- clarify Node dependency step

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68574762ebcc83299f17e7333f6c84d1