### PR TITLE
Clarify purpose of nuevaweb Flask demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Promocionar el turismo de **Cerezo de Río Tirón** y proteger su patrimonio arq
 - `museo/` – páginas del museo y fichas de piezas.
 - `foro/` – área de debate gestionada por cinco agentes expertos.
 - `backend/` – API en Python (Flask) y herramientas de IA.
-- `nuevaweb/` – rediseño experimental del sitio ([nuevaweb/README.md](nuevaweb/README.md)).
+- `nuevaweb/` – rediseño experimental del sitio ([nuevaweb/README.md](nuevaweb/README.md)). Incluye un API Flask de demo (`flask_app.py`) independiente de la API principal.
 - `docs/` – documentación completa.
 - `scripts/` – utilidades de desarrollo y mantenimiento.
 - `scripts_admin.php` – interfaz protegida para ejecutar esos scripts y revisar la salida.

--- a/nuevaweb/README.md
+++ b/nuevaweb/README.md
@@ -2,7 +2,7 @@
 
 Este subdirectorio contiene la evolución del proyecto Condado de Castilla.
 Usa la paleta en morados y tonos de oro viejo con fondos de alabastro.
-Integra PHP para el sitio público y un API minimal en Flask.
+Integra PHP para el sitio público y un API minimal en Flask. Este servicio es solo un ejemplo y no está conectado con la API oficial ubicada en `../flask_app.py`.
 
 ## Estructura
 - `index.php` – página principal con menú deslizante.
@@ -20,5 +20,9 @@ Integra PHP para el sitio público y un API minimal en Flask.
    ```bash
    python3 flask_app.py
    ```
+
+### API de ejemplo
+
+`flask_app.py` implementa un único endpoint `/api/hello`. Su función es mostrar la estructura básica de un servicio Flask y no se integra con la API principal del proyecto.
 
 Consulta la [guía de estilo](../docs/style-guide.md) para ver la paleta completa y otras recomendaciones.


### PR DESCRIPTION
## Summary
- document that `nuevaweb/flask_app.py` is an isolated demo
- explain the example API in `nuevaweb/README.md`

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68574761df8083298edee3b44f25c2fc