### PR TITLE
Add vibration feedback to menu interactions

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -23,6 +23,12 @@ document.addEventListener('DOMContentLoaded', () => {
         applyPalette(detectPalette());
     }
 
+    const vibrateFeedback = () => {
+        if (navigator.vibrate) {
+            navigator.vibrate([50]);
+        }
+    };
+
     const sidebarMenuId = 'sidebar'; // Assuming 'sidebar' is the ID of your sidebar
 
     const updateAria = (btn, menu, open) => {
@@ -37,6 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (btn) btn.focus();
         // Recalculate anyOpen and update body classes
         updateGlobalMenuState();
+        vibrateFeedback();
     };
 
     const toggleMobileSidebar = (btn) => {
@@ -57,6 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         // Recalculate anyOpen and update body classes
         updateGlobalMenuState();
+        vibrateFeedback();
     };
 
     const closeMenu = (menu, triggerButton = null) => { // Added triggerButton for focus
@@ -69,6 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (side) document.body.classList.remove(`menu-open-${side}`);
         // Recalculate anyOpen and update body classes
         updateGlobalMenuState();
+        vibrateFeedback();
     };
 
     const toggleMenu = (btn) => {
@@ -112,6 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 chatArea.focus();
             }
         }
+        vibrateFeedback();
     };
 
     const updateGlobalMenuState = () => {
@@ -132,6 +142,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const btn = e.target.closest('[data-menu-target]');
         if (btn) {
             e.preventDefault();
+            vibrateFeedback();
             if (btn.id === 'consolidated-menu-button' && window.innerWidth <= 768) {
                 toggleMobileSidebar(btn);
             } else {
@@ -156,6 +167,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (touchHandled) {
             touchHandled = false;
             return;
+        }
+        if (e.target.closest('button')) {
+            vibrateFeedback();
         }
         handleToggleEvent(e);
     });

--- a/docs/page-transitions.md
+++ b/docs/page-transitions.md
@@ -25,3 +25,7 @@ The output CSS is written to `assets/css/custom.css` and the JS bundle in `dist/
 Include the generated files in your template and call `initPageTransitions()` from `js/page-transitions.js`.
 
 The module fades the old page out and slides in the new content using Cerezo purple and old gold colors. The effect reinforces the mission by offering a smooth and appealing navigation experience that invites visitors to explore the heritage of **Cerezo de Río Tirón**.
+
+## Haptic feedback
+
+Menu interactions trigger a short vibration when supported. This subtle cue helps users notice when sidebars or panels open and close. The vibration also fires on general button clicks, providing consistent physical feedback across the site.


### PR DESCRIPTION
## Summary
- add `vibrateFeedback` helper in `main.js`
- trigger vibration when opening/closing menus and on button clicks
- document haptic feedback in `docs/page-transitions.md`

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685751b41ea083298d60d7d43bb3b19e