### PR TITLE
Remove binary sound files

### DIFF
--- a/assets/js/audio-controller.js
+++ b/assets/js/audio-controller.js
@@ -6,10 +6,10 @@
 
         if (!isMuted) {
             if (open) {
-                const audioOpen = new Audio('assets/sounds/menu-open.mp3');
+                const audioOpen = new Audio('https://example.com/audio/menu-open.mp3');
                 audioOpen.play().catch(error => console.error("Error playing menu open sound:", error));
             } else {
-                const audioClose = new Audio('assets/sounds/menu-close.mp3');
+                const audioClose = new Audio('https://example.com/audio/menu-close.mp3');
                 audioClose.play().catch(error => console.error("Error playing menu close sound:", error));
             }
         }

--- a/assets/sounds/README.md
+++ b/assets/sounds/README.md
@@ -1,0 +1,10 @@
+# Sound Assets
+
+The menu open/close audio files are not stored in this repository to keep the repository size small.
+
+Download the following files and place them in this directory:
+
+- `menu-open.mp3` – <https://example.com/audio/menu-open.mp3>
+- `menu-close.mp3` – <https://example.com/audio/menu-close.mp3>
+
+Once downloaded, the menu toggle sound effects will play correctly.

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -21,6 +21,15 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `assets/js/toc-generator.js`     | Builds a table of contents from headings inside `<main>` and injects a list of links styled with Tailwind.                                                                                                      |
 
 Deprecated or merged scripts such as `js/menu-controller.js` and `js/sliding-menu.js` have been removed in favour of `assets/js/main.js`. The old header loading helper was also dropped as noted in the project README.
+## Sound Assets
+
+Small audio clips provide feedback when the menu opens or closes. To keep the repository lightweight, the MP3 files are not included.
+
+Download them from the links below and place them under `assets/sounds/`:
+
+- `menu-open.mp3` – <https://example.com/audio/menu-open.mp3>
+- `menu-close.mp3` – <https://example.com/audio/menu-close.mp3>
+
 
 ## Simplified Translation
 


### PR DESCRIPTION
## Summary
- document remote download URLs for menu sound effects
- reference new URLs in `audio-controller.js`
- remove MP3 files from the repo

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm test --silent` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685751b2e0588329bb87db5d53cd2510