### PR TITLE
Add local page transition sound option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ npm run build
 ```
 
 El comando genera los archivos finales en `dist/` y `assets/css`. Consulta [docs/page-transitions.md](docs/page-transitions.md) para obtener todos los detalles de configuración.
+Puedes añadir sonido opcional copiando `assets/sounds/transition.mp3` durante el proceso de bundling. Si el archivo no está presente, la animación se reproducirá en silencio.
 
 ## Testing
 

--- a/assets/js/page-transitions.js
+++ b/assets/js/page-transitions.js
@@ -1,8 +1,28 @@
 (function() {
+  var TRANSITION_SOUND_PATH = '/assets/sounds/transition.mp3';
+  function isMuted() {
+    var btn = document.getElementById('mute-toggle');
+    return btn && btn.getAttribute('aria-pressed') === 'true';
+  }
+
+  function playTransitionSound() {
+    if (isMuted()) return;
+    try {
+      var audio = new Audio(TRANSITION_SOUND_PATH);
+      audio.play();
+    } catch (err) {
+      console.error('Error playing transition sound:', err);
+    }
+  }
+
   function cleanupOverlay() {
     var overlay = document.getElementById('page-transition-overlay');
-    if (!overlay) return;
+    if (!overlay) {
+      playTransitionSound();
+      return;
+    }
     overlay.classList.add('fade-out');
+    playTransitionSound();
     overlay.addEventListener('transitionend', function() {
       if (overlay && overlay.parentNode) {
         overlay.parentNode.removeChild(overlay);

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -8,6 +8,8 @@ This document summarizes the purpose of the main JavaScript files present in the
 | `assets/js/homonexus-toggle.js`  | Toggles Homonexus mode, storing the preference in a cookie.                                                                                                                                                     |
 | `assets/js/foro.js`              | Simple toggling for the forum agents menu.                                                                                                                                                                      |
 | `/assets/js/audio-controller.js` | Lowers audio/video volume when sliding menus open. Other scripts, such as `assets/js/main.js`, invoke its `handleMenuToggle` function directly.                                                                 |
+| `assets/js/page-transitions.js`  | Handles overlay fade-outs and optionally plays `assets/sounds/transition.mp3` while respecting the global mute toggle.
+    |
 | `js/config.js`                   | Defines `API_BASE_URL` and `DEBUG_MODE` globals for other scripts.                                                                                                                                              |
 | `js/layout.js`                   | Loads external CSS/JS libraries on demand, initializes the flashlight effect and other page-level utilities. If CDN requests fail, it falls back to bundled copies of GSAP and AOS located in `assets/vendor/`. |
 | ~~Header loader script~~         | **Deprecated.** The header is now loaded directly without this helper. See the README note on its removal.                                                                                                      |

--- a/docs/page-transitions.md
+++ b/docs/page-transitions.md
@@ -25,3 +25,7 @@ The output CSS is written to `assets/css/custom.css` and the JS bundle in `dist/
 Include the generated files in your template and call `initPageTransitions()` from `js/page-transitions.js`.
 
 The module fades the old page out and slides in the new content using Cerezo purple and old gold colors. The effect reinforces the mission by offering a smooth and appealing navigation experience that invites visitors to explore the heritage of **Cerezo de Río Tirón**.
+
+## Audio feedback
+
+`assets/js/page-transitions.js` reproduce un sonido de transición cuando la superposición desaparece o se carga una página nueva. Para habilitarlo, coloca `assets/sounds/transition.mp3` junto al resto de archivos estáticos. Si el archivo no existe o el sitio está silenciado mediante `assets/js/audio-controller.js`, no se reproduce nada.


### PR DESCRIPTION
## Summary
- play `assets/sounds/transition.mp3` when transitions complete
- mention new optional asset in docs and README
- keep `assets/sounds/` folder under version control

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685751b2a3e08329b281021b06bf7f46