### PR TITLE
Update service worker caching routes

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,10 @@
-const CACHE_NAME = 'assets-cache-v3';
-const CORE_ROUTES = ['/index.php', '/foro/index.php'];
+const CACHE_NAME = 'assets-cache-v4';
+const CORE_ROUTES = [
+  '/index.php',
+  '/foro/index.php',
+  '/museo/museo.php',
+  '/lugares/lugares.php'
+];
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ROUTES))
@@ -35,7 +40,9 @@ self.addEventListener('fetch', event => {
     );
     return;
   }
-  if (url.pathname.startsWith('/assets/')) {
+  if (url.pathname.startsWith('/assets/') ||
+      url.pathname.startsWith('/museo/') ||
+      url.pathname.startsWith('/lugares/')) {
     event.respondWith(
       caches.match(event.request).then(resp => {
         if (resp) return resp;


### PR DESCRIPTION
## Summary
- cache new pages and JS assets in service worker
- bump cache name to force invalidation

## Testing
- `scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_685754c669188329a77b69bb814fa6b4