### PR TITLE
Add blend-mode and gradient fallbacks

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -229,6 +229,30 @@ h1 {
     text-shadow: 2px 2px 4px rgba(var(--color-negro-contraste-rgb), 0.8);
 }
 
+/* Fallbacks for browsers without background-clip:text */
+@supports not ((-webkit-background-clip: text) or (background-clip: text)) {
+    h1,
+    .gradient-text {
+        background-image: none;
+        -webkit-background-clip: initial;
+        background-clip: initial;
+        color: var(--epic-purple-emperor);
+        text-shadow: none;
+    }
+    h1 {
+        color: var(--epic-gold-main);
+    }
+}
+
+/* Optional class to disable clipped text manually */
+.no-clip-text h1,
+.no-clip-text .gradient-text {
+    background-image: none;
+    -webkit-background-clip: initial;
+    background-clip: initial;
+    color: var(--epic-purple-emperor);
+}
+
 /* Utility classes to apply blend modes on text */
 .blend-screen {
     mix-blend-mode: screen;
@@ -240,6 +264,22 @@ h1 {
     mix-blend-mode: overlay;
     display: inline-block;
     color: var(--epic-gold-main); /* Ensure visibility when blend modes are unsupported */
+}
+
+/* Fallbacks for browsers without mix-blend-mode */
+@supports not (mix-blend-mode: screen) {
+    .blend-screen,
+    .blend-overlay {
+        mix-blend-mode: normal;
+        color: var(--epic-gold-main);
+    }
+}
+
+/* Optional class to disable blend modes manually */
+.no-blend .blend-screen,
+.no-blend .blend-overlay {
+    mix-blend-mode: normal;
+    color: var(--epic-gold-main);
 }
 
 /* --- Paragraphs --- */

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -75,6 +75,11 @@ se lean con claridad incluso en pantallas pequeñas.
 <h1 class="gradient-text">Descubre Cerezo</h1>
 ```
 
+Si el navegador no soporta `background-clip: text` se aplica
+automáticamente un color sólido mediante una regla `@supports`.
+También puedes añadir la clase `.no-clip-text` al contenedor para
+forzar esta versión.
+
 ## Botones de llamada a la acción
 
 Los botones de tipo CTA están definidos en
@@ -99,6 +104,11 @@ Para integrar titulares sobre fondos complejos se disponen las clases `.blend-sc
 <h1 class="blend-overlay">Título</h1>
 <p class="blend-screen">Texto destacado</p>
 ```
+
+Los navegadores que no admiten `mix-blend-mode` muestran estos
+elementos en un color sólido. El CSS incluye una regla `@supports`
+para gestionar este caso y una clase opcional `.no-blend` que puede
+añadirse manualmente.
 
 ## Optimización de imágenes
 


### PR DESCRIPTION
## Summary
- add @supports fallbacks in `epic_theme.css`
- document `.no-clip-text` and `.no-blend` usage

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685754c814cc832999ee56c02b8f16e9