### PR TITLE
Add CLI help test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,15 @@
+import subprocess
+import unittest
+
+class CliHelpTestCase(unittest.TestCase):
+    def test_help_includes_commands(self):
+        result = subprocess.run([
+            'python', 'cli.py', '--help'
+        ], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0)
+        output = result.stdout
+        self.assertIn('add_url', output)
+        self.assertIn('run_consistency', output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure CLI help shows commands

## Testing
- `python -m unittest tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_685755fe28a8832991f29b101312c705