### PR TITLE
Update README with accessibility audit instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar
 
 También se proporciona `scripts/run_tests.sh` para instalar `requirements.txt` y lanzar la suite de forma directa.
 
+Para verificar la accesibilidad del sitio ejecuta `scripts/run_accessibility_audit.sh`. El script inicia un servidor PHP local, ejecuta **Lighthouse** sobre las páginas principales y guarda los informes HTML en `reports/accessibility/`. Tras la ejecución, abre esos archivos en tu navegador para revisar los resultados.
+
 ## Estilo de mensajes de commit
 
 Utiliza títulos breves en modo imperativo que describan el cambio, p.ej. `Add GSAP page transitions with overlay and tests`. Si añades un cuerpo opcional, explica _qué_ y _por qué_. Consulta [docs/commit-style.md](docs/commit-style.md) para ver la guía completa.


### PR DESCRIPTION
## Summary
- document how to run `scripts/run_accessibility_audit.sh` in the Testing section

## Testing
- `scripts/run_tests.sh`
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*
- `scripts/run_accessibility_audit.sh` *(fails: CHROME_PATH not set)*

------
https://chatgpt.com/codex/tasks/task_e_685755fb0100832989db449920bdec0a