### PR TITLE
Add Puppeteer test for command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start:php": "sh -c 'php -S localhost:8080 >/dev/null 2>&1 & echo $! > .php_server.pid'",
     "stop:php": "sh -c 'if [ -f .php_server.pid ]; then kill $(cat .php_server.pid); rm .php_server.pid; fi'",
-    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuKeyboardNavigationTest.js && node tests/timelineDataTest.js && node tests/tailwindMobileMenuTest.js",
+    "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuKeyboardNavigationTest.js && node tests/timelineDataTest.js && node tests/tailwindMobileMenuTest.js && node tests/commandPaletteTest.js",
     "test:playwright": "playwright test tests/phpRoutes.spec.js",
     "test": "npm run start:php && npm run test:puppeteer && npm run test:playwright; npm run stop:php",
     "build": "vite build && npx sass assets/scss/custom.scss assets/css/custom.css --no-source-map",

--- a/tests/commandPaletteTest.js
+++ b/tests/commandPaletteTest.js
@@ -1,0 +1,37 @@
+const puppeteer = require('puppeteer');
+const path = require('path');
+
+(async () => {
+  const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1024, height: 800 });
+  const filePath = path.resolve(__dirname, '../index.html');
+  await page.goto('file://' + filePath);
+  await page.waitForSelector('#commandPaletteOverlay');
+
+  await page.keyboard.down('Control');
+  await page.keyboard.press('k');
+  await page.keyboard.up('Control');
+  await page.waitForTimeout(300);
+
+  const openClass = await page.$eval('#commandPaletteOverlay', el => el.classList.contains('is-open'));
+  const ariaOpen = await page.$eval('#commandPaletteOverlay', el => el.getAttribute('aria-hidden') === 'false');
+  if (!openClass || !ariaOpen) {
+    console.error('Command palette did not open with Ctrl+K');
+    await browser.close();
+    process.exit(1);
+  }
+
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(300);
+  const closedClass = await page.$eval('#commandPaletteOverlay', el => !el.classList.contains('is-open'));
+  const ariaClosed = await page.$eval('#commandPaletteOverlay', el => el.getAttribute('aria-hidden') === 'true');
+  if (!closedClass || !ariaClosed) {
+    console.error('Command palette did not close with Escape');
+    await browser.close();
+    process.exit(1);
+  }
+
+  console.log('Command palette toggles correctly with keyboard');
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- create `tests/commandPaletteTest.js` to verify keyboard shortcuts toggle the command palette
- run this new test as part of the `npm run test:puppeteer` suite

## Testing
- `npm install --legacy-peer-deps`
- `npm run start:php`
- `npm run test:puppeteer` *(fails: TimeoutError waiting for `#google_translate_element`)*
- `npm run stop:php`


------
https://chatgpt.com/codex/tasks/task_e_68575602099883298e712a33ae3385c4