### PR TITLE
Add forum agents endpoint

### DIFF
--- a/config/forum_agents.json
+++ b/config/forum_agents.json
@@ -1,0 +1,37 @@
+{
+    "historian": {
+        "name": "Alicia la Historiadora",
+        "bio": "Con años de investigación tras ella, Alicia relata los episodios que forjaron la identidad de Cerezo y Castilla.",
+        "expertise": "Historia medieval y orígenes de Castilla",
+        "avatar": "/assets/img/GonzaloTellez.png",
+        "role_icon": "fas fa-scroll"
+    },
+    "archaeologist": {
+        "name": "Bruno el Arqueólogo",
+        "bio": "Bruno dirige campañas de excavación y vela por la preservación de nuestros tesoros ocultos.",
+        "expertise": "Excavaciones y conservación de hallazgos",
+        "avatar": "/assets/img/FernandoDiaz.png",
+        "role_icon": "fas fa-landmark"
+    },
+    "guide": {
+        "name": "Clara la Guía Turística",
+        "bio": "Clara comparte anécdotas locales y diseña recorridos inolvidables.",
+        "expertise": "Rutas turísticas y patrimonio cultural vivo",
+        "avatar": "/assets/img/estrella.png",
+        "role_icon": "fas fa-map-signs"
+    },
+    "manager": {
+        "name": "Diego el Gestor Cultural",
+        "bio": "Diego articula iniciativas para que la cultura florezca y llegue a todos los públicos.",
+        "expertise": "Gestión de eventos y proyectos culturales sostenibles",
+        "avatar": "/assets/img/estrellaGordita.png",
+        "role_icon": "fas fa-users-cog"
+    },
+    "technologist": {
+        "name": "Elena la Tecnóloga",
+        "bio": "Elena incorpora las últimas tecnologías para difundir el patrimonio de forma interactiva.",
+        "expertise": "Innovación digital aplicada al turismo y la cultura",
+        "avatar": "/assets/img/Casio.png",
+        "role_icon": "fas fa-robot"
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -160,6 +160,7 @@ Los estilos coinciden con `assets/css/pages/historia_subpaginas_auca_patricia_ub
 - [Interfaz de la base de datos de grafo](graph_db.md)
 - [API de consulta de grafo](../api/graph)
 - [API de la Galería Colaborativa](galeria_api.md)
+- [API de agentes del foro](forum_agents_api.md)
 - [Guía de Testing](testing.md)
 - [Gráfica de Influencia Romana](roman_influence_graph.md)
 - [Relaciones de Parentesco](parent_child_pairs.md)

--- a/docs/forum_agents_api.md
+++ b/docs/forum_agents_api.md
@@ -1,0 +1,23 @@
+# API de agentes del foro
+
+Este breve servicio forma parte del backend en Flask y expone la lista de expertos que participan en el foro.
+
+## `GET /api/forum/agents`
+
+Devuelve un objeto JSON con los agentes definidos en `config/forum_agents.json`.
+Cada clave identifica al agente y su valor incluye nombre, biografía, especialidad y avatares.
+
+```json
+{
+  "historian": {
+    "name": "Alicia la Historiadora",
+    "bio": "Con años de investigación tras ella, Alicia relata los episodios que forjaron la identidad de Cerezo y Castilla.",
+    "expertise": "Historia medieval y orígenes de Castilla",
+    "avatar": "/assets/img/GonzaloTellez.png",
+    "role_icon": "fas fa-scroll"
+  },
+  "archaeologist": { "...": "..." }
+}
+```
+
+Este endpoint ayuda a construir interfaces dinámicas que muestran la información de los expertos sin duplicar datos en el frontend.

--- a/flask_app.py
+++ b/flask_app.py
@@ -12,6 +12,7 @@ from graph_db_interface import GraphDBInterface
 import os
 import subprocess
 import sqlite3
+import json
 
 app = Flask(__name__)
 cache = Cache(app, config={
@@ -36,6 +37,16 @@ def get_forum_comments_from_db():
         comments.setdefault(row['agent'], []).append({'comment': row['comment'], 'created_at': row['created_at']})
     conn.close()
     return comments
+
+
+def get_forum_agents():
+    """Return forum agents from config/forum_agents.json"""
+    path = os.path.join(os.path.dirname(__file__), 'config', 'forum_agents.json')
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception:
+        return {}
 
 @app.route('/api/resource', methods=['GET', 'POST'])
 def resource_collection():
@@ -73,6 +84,15 @@ def chat_handler():
             error_msg = result.stderr.strip() or 'Unknown error'
             return jsonify({'error': f'PHP error: {error_msg}'}), 500
         return jsonify({'response': result.stdout.strip()})
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 500
+
+
+@app.route('/api/forum/agents', methods=['GET'])
+def forum_agents_handler():
+    try:
+        agents = get_forum_agents()
+        return jsonify(agents)
     except Exception as exc:
         return jsonify({'error': str(exc)}), 500
 

--- a/tests/test_flask_api.py
+++ b/tests/test_flask_api.py
@@ -77,5 +77,12 @@ class FlaskApiTestCase(unittest.TestCase):
         self.assertEqual(res.status_code, 500)
         self.assertIn('error', res.get_json())
 
+    def test_forum_agents_endpoint(self):
+        res = self.client.get('/api/forum/agents')
+        self.assertEqual(res.status_code, 200)
+        data = res.get_json()
+        self.assertIsInstance(data, dict)
+        self.assertGreaterEqual(len(data), 5)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- expose new Flask endpoint `/api/forum/agents`
- document the endpoint and link it in the docs
- provide JSON config for forum agents
- test the new route

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6857562770ec832986029c0598b75ec6