### PR TITLE
refactor: use const/let for JS variables

### DIFF
--- a/assets/js/custom-pointer.js
+++ b/assets/js/custom-pointer.js
@@ -2,18 +2,18 @@
   document.addEventListener('DOMContentLoaded',function(){
     if ('ontouchstart' in window || navigator.maxTouchPoints > 0) return;
     document.body.classList.add('cursor-none');
-    var wrapper=document.createElement('div');
+    const wrapper=document.createElement('div');
     wrapper.id='custom-pointer';
-    var outer=document.createElement('div');
+    const outer=document.createElement('div');
     outer.className='outer';
-    var inner=document.createElement('div');
+    const inner=document.createElement('div');
     inner.className='inner';
     wrapper.appendChild(outer);
     wrapper.appendChild(inner);
     document.body.appendChild(wrapper);
-    var x=window.innerWidth/2, y=window.innerHeight/2;
-    var tx=x, ty=y;
-    function lerp(a,b,n){ return a+(b-a)*n; }
+    let x=window.innerWidth/2, y=window.innerHeight/2;
+    let tx=x, ty=y;
+    const lerp=(a,b,n)=> a+(b-a)*n;
     document.addEventListener('mousemove',function(e){
       tx=e.clientX;
       ty=e.clientY;

--- a/assets/js/page-transitions.js
+++ b/assets/js/page-transitions.js
@@ -1,6 +1,6 @@
 (function() {
   function cleanupOverlay() {
-    var overlay = document.getElementById('page-transition-overlay');
+    const overlay = document.getElementById('page-transition-overlay');
     if (!overlay) return;
     overlay.classList.add('fade-out');
     overlay.addEventListener('transitionend', function() {

--- a/assets/js/polyfills.js
+++ b/assets/js/polyfills.js
@@ -1,6 +1,6 @@
 (function(){
     function loadScript(src, callback){
-        var s = document.createElement('script');
+        const s = document.createElement('script');
         s.src = src;
         s.onload = callback || function(){};
         document.head.appendChild(s);
@@ -16,7 +16,7 @@
     }
     if(typeof HTMLDialogElement === 'undefined'){
         loadScript('https://cdn.jsdelivr.net/npm/dialog-polyfill@0.5/dist/dialog-polyfill.min.js', function(){
-            var link = document.createElement('link');
+            const link = document.createElement('link');
             link.rel = 'stylesheet';
             link.href = 'https://cdn.jsdelivr.net/npm/dialog-polyfill@0.5/dist/dialog-polyfill.min.css';
             document.head.appendChild(link);

--- a/assets/js/torch_cursor.js
+++ b/assets/js/torch_cursor.js
@@ -1,12 +1,12 @@
 (function(){
   document.addEventListener('DOMContentLoaded', function(){
     if ('ontouchstart' in window) return;
-    var cursor = document.createElement('div');
+    const cursor = document.createElement('div');
     cursor.id = 'torch-cursor';
     document.body.appendChild(cursor);
-    var x = window.innerWidth / 2, y = window.innerHeight / 2;
-    var targetX = x, targetY = y;
-    var lerp = function(a,b,n){ return a + (b - a) * n; };
+    let x = window.innerWidth / 2, y = window.innerHeight / 2;
+    let targetX = x, targetY = y;
+    const lerp = function(a,b,n){ return a + (b - a) * n; };
     document.addEventListener('mousemove', function(e){
       targetX = e.clientX;
       targetY = e.clientY;
@@ -19,7 +19,7 @@
       requestAnimationFrame(update);
     }
     update();
-    var focusEls = document.querySelectorAll('a, .clickable');
+    const focusEls = document.querySelectorAll('a, .clickable');
     focusEls.forEach(function(el){
       el.addEventListener('mouseenter', function(){ cursor.classList.add('focus'); });
       el.addEventListener('mouseleave', function(){ cursor.classList.remove('focus'); });

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -11,7 +11,7 @@ function loadGoogleTranslate(callback) {
         }, 'google_translate_element');
         if (typeof callback === 'function') callback();
     };
-    var script = document.createElement('script');
+    const script = document.createElement('script');
     script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
     script.async = true;
     script.onload = function() { window.googleTranslateLoaded = true; };


### PR DESCRIPTION
## Summary
- replace `var` with `const` or `let` in various front-end scripts

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_6857562945c88329b504e1889fe73d81