### PR TITLE
Implement playTransitionSound and add error handling

### DIFF
--- a/assets/js/audio-controller.js
+++ b/assets/js/audio-controller.js
@@ -48,5 +48,18 @@
         });
     });
 
-    window.audioController = { handleMenuToggle };
+    function playTransitionSound(){
+        const globalMuteButton = document.getElementById('mute-toggle');
+        const isMuted = globalMuteButton ? globalMuteButton.getAttribute('aria-pressed') === 'true' : false;
+
+        if (isMuted) {
+            return Promise.resolve();
+        }
+
+        const audio = new Audio('https://example.com/audio/transition.mp3');
+        audio.currentTime = 0;
+        return audio.play().catch(err => console.error('Error playing transition sound:', err));
+    }
+
+    window.audioController = { handleMenuToggle, playTransitionSound };
 })();


### PR DESCRIPTION
## Summary
- add `playTransitionSound` in `audio-controller`
- return the play promise and log errors

## Testing
- `node tests/muteToggleTest.js` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6857562adc688329964521b7503f961d