### PR TITLE
Replace fixed waits in Puppeteer tests

### DIFF
--- a/tests/languagePanelBodyClassTest.js
+++ b/tests/languagePanelBodyClassTest.js
@@ -6,7 +6,7 @@ const puppeteer = require('puppeteer');
   await page.goto('http://localhost:8080/tests/manual/test_language_panel.html');
   await page.waitForSelector('#flag-toggle');
   await page.click('#flag-toggle');
-  await page.waitForTimeout(300);
+  await page.waitForFunction(() => document.body.classList.contains('menu-open-right'));
   await page.waitForSelector('#language-panel #google_translate_element', {visible: true});
   const hasClass = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
   if (!hasClass) {
@@ -15,7 +15,7 @@ const puppeteer = require('puppeteer');
     process.exit(1);
   }
   await page.click('#flag-toggle');
-  await page.waitForTimeout(300);
+  await page.waitForFunction(() => !document.body.classList.contains('menu-open-right'));
   const stillHas = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
   if (stillHas) {
     console.error('menu-open-right not removed');

--- a/tests/manual/langBarOffsetTest.js
+++ b/tests/manual/langBarOffsetTest.js
@@ -7,8 +7,10 @@ const puppeteer = require('puppeteer');
   await page.waitForSelector('#flag-toggle');
   await page.click('#flag-toggle');
   await page.waitForSelector('#google_translate_element', {visible: true});
-  // give time for height calculation
-  await page.waitForTimeout(500);
+  await page.waitForFunction(() => {
+    const el = document.getElementById('google_translate_element');
+    return el && el.offsetHeight > 0;
+  });
 
   const barHeight = await page.$eval('#google_translate_element', el => el.offsetHeight);
   const bodyStyles = await page.evaluate(() => ({

--- a/tests/manual/languagePanelOffsetTest.js
+++ b/tests/manual/languagePanelOffsetTest.js
@@ -11,7 +11,7 @@ const puppeteer = require('puppeteer');
   const top = await page.$eval('#language-panel', el => getComputedStyle(el).top);
   console.log('Panel top offset:', top);
   await page.click('#flag-toggle');
-  await page.waitForTimeout(300);
+  await page.waitForFunction(() => !document.getElementById('language-panel').classList.contains('active'));
   const isActive = await page.evaluate(() => document.getElementById('language-panel').classList.contains('active'));
   if (isActive) {
     console.error('Panel did not close');

--- a/tests/menuCompressionTest.js
+++ b/tests/menuCompressionTest.js
@@ -6,7 +6,7 @@ const puppeteer = require('puppeteer');
   await page.goto('http://localhost:8080/index.php');
   await page.waitForSelector('#consolidated-menu-button');
   await page.click('#consolidated-menu-button');
-  await page.waitForTimeout(500);
+  await page.waitForFunction(() => document.body.classList.contains('menu-compressed'));
   const hasClass = await page.evaluate(() => document.body.classList.contains('menu-compressed'));
   if (!hasClass) {
     console.error('menu-compressed class not added');
@@ -14,7 +14,7 @@ const puppeteer = require('puppeteer');
     process.exit(1);
   }
   await page.click('#consolidated-menu-button');
-  await page.waitForTimeout(500);
+  await page.waitForFunction(() => !document.body.classList.contains('menu-compressed'));
   const stillHasClass = await page.evaluate(() => document.body.classList.contains('menu-compressed'));
   if (stillHasClass) {
     console.error('menu-compressed class not removed');

--- a/tests/menuKeyboardNavigationTest.js
+++ b/tests/menuKeyboardNavigationTest.js
@@ -7,7 +7,14 @@ const puppeteer = require('puppeteer');
   await page.waitForSelector('#consolidated-menu-button');
   await page.focus('#consolidated-menu-button');
   await page.keyboard.press('Enter');
-  await page.waitForTimeout(300);
+  await page.waitForFunction(() => {
+    const menu = document.getElementById('consolidated-menu-items');
+    const btn = document.getElementById('consolidated-menu-button');
+    return menu.classList.contains('active') &&
+      menu.getAttribute('aria-hidden') === 'false' &&
+      btn.getAttribute('aria-expanded') === 'true' &&
+      menu.contains(document.activeElement);
+  });
   const open = await page.$eval('#consolidated-menu-items', el => el.classList.contains('active'));
   const ariaOpen = await page.$eval('#consolidated-menu-items', el => el.getAttribute('aria-hidden') === 'false');
   const btnExpanded = await page.$eval('#consolidated-menu-button', el => el.getAttribute('aria-expanded') === 'true');
@@ -21,7 +28,13 @@ const puppeteer = require('puppeteer');
     process.exit(1);
   }
   await page.keyboard.press('Escape');
-  await page.waitForTimeout(300);
+  await page.waitForFunction(() => {
+    const menu = document.getElementById('consolidated-menu-items');
+    const btn = document.getElementById('consolidated-menu-button');
+    return !menu.classList.contains('active') &&
+      menu.getAttribute('aria-hidden') === 'true' &&
+      btn.getAttribute('aria-expanded') === 'false';
+  });
   const closed = await page.$eval('#consolidated-menu-items', el => !el.classList.contains('active'));
   const ariaClosed = await page.$eval('#consolidated-menu-items', el => el.getAttribute('aria-hidden') === 'true');
   const btnCollapsed = await page.$eval('#consolidated-menu-button', el => el.getAttribute('aria-expanded') === 'false');

--- a/tests/muteToggleTest.js
+++ b/tests/muteToggleTest.js
@@ -7,7 +7,10 @@ const puppeteer = require('puppeteer');
   await page.waitForSelector('#mute-toggle');
   const initial = await page.$eval('#mute-toggle', el => el.getAttribute('aria-pressed'));
   await page.click('#mute-toggle');
-  await page.waitForTimeout(300);
+  await page.waitForFunction(initialValue => {
+    const btn = document.getElementById('mute-toggle');
+    return btn.getAttribute('aria-pressed') !== initialValue;
+  }, {}, initial);
   const afterClick = await page.$eval('#mute-toggle', el => el.getAttribute('aria-pressed'));
   if (initial === afterClick) {
     console.error('aria-pressed did not toggle');

--- a/tests/tailwindMobileMenuTest.js
+++ b/tests/tailwindMobileMenuTest.js
@@ -8,7 +8,7 @@ const puppeteer = require('puppeteer');
     await page.goto('http://localhost:8080/tailwind_index.php');
     await page.waitForSelector('#menu-toggle');
     await page.evaluate(() => document.getElementById('menu-toggle').click());
-    await page.waitForTimeout(300);
+    await page.waitForFunction(() => document.body.classList.contains('menu-open-left'));
     const hasClass = await page.evaluate(() => document.body.classList.contains('menu-open-left'));
     if (!hasClass) {
       console.error(`menu-open-left not added for viewport ${width}`);


### PR DESCRIPTION
## Summary
- use `page.waitForFunction` instead of fixed timeouts in keyboard menu, menu compression, language panel, mute toggle, Tailwind menu and manual tests

## Testing
- `npm test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685757ee14e88329a8913f4a834339cf