### PR TITLE
Introduce puppeteer helper for tests

### DIFF
--- a/tests/helpers/puppeteerSetup.js
+++ b/tests/helpers/puppeteerSetup.js
@@ -1,0 +1,11 @@
+const puppeteer = require('puppeteer');
+
+function launchBrowser() {
+  return puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
+}
+
+function closeBrowser(browser) {
+  return browser ? browser.close() : Promise.resolve();
+}
+
+module.exports = { launchBrowser, closeBrowser };

--- a/tests/interactiveMapTest.js
+++ b/tests/interactiveMapTest.js
@@ -1,7 +1,7 @@
-const puppeteer = require('puppeteer');
+const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
 
 (async () => {
-  const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/lugares/mapa_interactivo.php');
   await page.waitForSelector('#interactive-map');
@@ -9,9 +9,9 @@ const puppeteer = require('puppeteer');
   const count = await page.evaluate(() => document.querySelectorAll('#interactive-map .leaflet-marker-icon').length);
   if (count === 0) {
     console.error('No markers found on interactive map');
-    await browser.close();
+    await closeBrowser(browser);
     process.exit(1);
   }
   console.log('Interactive map loaded with markers');
-  await browser.close();
+  await closeBrowser(browser);
 })();

--- a/tests/languagePanelBodyClassTest.js
+++ b/tests/languagePanelBodyClassTest.js
@@ -1,7 +1,7 @@
-const puppeteer = require('puppeteer');
+const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
 
 (async () => {
-  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/tests/manual/test_language_panel.html');
   await page.waitForSelector('#flag-toggle');
@@ -11,7 +11,7 @@ const puppeteer = require('puppeteer');
   const hasClass = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
   if (!hasClass) {
     console.error('menu-open-right not added');
-    await browser.close();
+    await closeBrowser(browser);
     process.exit(1);
   }
   await page.click('#flag-toggle');
@@ -19,9 +19,9 @@ const puppeteer = require('puppeteer');
   const stillHas = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
   if (stillHas) {
     console.error('menu-open-right not removed');
-    await browser.close();
+    await closeBrowser(browser);
     process.exit(1);
   }
   console.log('Language panel body class toggled correctly');
-  await browser.close();
+  await closeBrowser(browser);
 })();

--- a/tests/linternaGradientTest.js
+++ b/tests/linternaGradientTest.js
@@ -1,16 +1,16 @@
-const puppeteer = require('puppeteer');
+const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
 
 (async () => {
-  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/galeria/galeria_colaborativa.php');
   await page.waitForSelector('#linterna-condado');
   const hasClass = await page.$eval('#linterna-condado', el => el.classList.contains('bg-linterna-gradient'));
   if (!hasClass) {
     console.error('#linterna-condado missing bg-linterna-gradient');
-    await browser.close();
+    await closeBrowser(browser);
     process.exit(1);
   }
   console.log('bg-linterna-gradient class found');
-  await browser.close();
+  await closeBrowser(browser);
 })();

--- a/tests/manual/langBarOffsetTest.js
+++ b/tests/manual/langBarOffsetTest.js
@@ -1,7 +1,7 @@
-const puppeteer = require('puppeteer');
+const { launchBrowser, closeBrowser } = require('../helpers/puppeteerSetup');
 
 (async () => {
-  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/tests/manual/test_lang.html');
   await page.waitForSelector('#flag-toggle');
@@ -19,10 +19,10 @@ const puppeteer = require('puppeteer');
   const offset = bodyStyles.marginTop || bodyStyles.paddingTop;
   if (offset !== 0) {
     console.error(`Expected no body offset but got ${offset}`);
-    await browser.close();
+    await closeBrowser(browser);
     process.exit(1);
   } else {
     console.log('Body offset is zero as expected');
   }
-  await browser.close();
+  await closeBrowser(browser);
 })();

--- a/tests/manual/languagePanelOffsetTest.js
+++ b/tests/manual/languagePanelOffsetTest.js
@@ -1,7 +1,7 @@
-const puppeteer = require('puppeteer');
+const { launchBrowser, closeBrowser } = require('../helpers/puppeteerSetup');
 
 (async () => {
-  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/tests/manual/test_language_panel.html');
   await page.waitForSelector('#flag-toggle');
@@ -15,9 +15,9 @@ const puppeteer = require('puppeteer');
   const isActive = await page.evaluate(() => document.getElementById('language-panel').classList.contains('active'));
   if (isActive) {
     console.error('Panel did not close');
-    await browser.close();
+    await closeBrowser(browser);
     process.exit(1);
   }
   console.log('Panel toggled correctly');
-  await browser.close();
+  await closeBrowser(browser);
 })();

--- a/tests/manual/test_translation.js
+++ b/tests/manual/test_translation.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
+const { launchBrowser, closeBrowser } = require('../helpers/puppeteerSetup');
 (async () => {
-  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/tests/manual/test_lang.html?lang=en');
   await page.waitForSelector('#google_translate_element');
@@ -12,5 +12,5 @@ const puppeteer = require('puppeteer');
   const textFr = await page.$eval('#text', el => el.innerText);
   console.log('Text EN:', textEn);
   console.log('Text FR:', textFr);
-  await browser.close();
+  await closeBrowser(browser);
 })();

--- a/tests/menuCompressionTest.js
+++ b/tests/menuCompressionTest.js
@@ -1,7 +1,7 @@
-const puppeteer = require('puppeteer');
+const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
 
 (async () => {
-  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/index.php');
   await page.waitForSelector('#consolidated-menu-button');
@@ -10,7 +10,7 @@ const puppeteer = require('puppeteer');
   const hasClass = await page.evaluate(() => document.body.classList.contains('menu-compressed'));
   if (!hasClass) {
     console.error('menu-compressed class not added');
-    await browser.close();
+    await closeBrowser(browser);
     process.exit(1);
   }
   await page.click('#consolidated-menu-button');
@@ -18,9 +18,9 @@ const puppeteer = require('puppeteer');
   const stillHasClass = await page.evaluate(() => document.body.classList.contains('menu-compressed'));
   if (stillHasClass) {
     console.error('menu-compressed class not removed');
-    await browser.close();
+    await closeBrowser(browser);
     process.exit(1);
   }
   console.log('Menu compression class toggled correctly');
-  await browser.close();
+  await closeBrowser(browser);
 })();

--- a/tests/menuKeyboardNavigationTest.js
+++ b/tests/menuKeyboardNavigationTest.js
@@ -1,7 +1,7 @@
-const puppeteer = require('puppeteer');
+const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
 
 (async () => {
-  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/index.php');
   await page.waitForSelector('#consolidated-menu-button');
@@ -17,7 +17,7 @@ const puppeteer = require('puppeteer');
   });
   if (!open || !ariaOpen || !btnExpanded || !focusedInside) {
     console.error('Menu did not open via keyboard');
-    await browser.close();
+    await closeBrowser(browser);
     process.exit(1);
   }
   await page.keyboard.press('Escape');
@@ -27,9 +27,9 @@ const puppeteer = require('puppeteer');
   const btnCollapsed = await page.$eval('#consolidated-menu-button', el => el.getAttribute('aria-expanded') === 'false');
   if (!closed || !ariaClosed || !btnCollapsed) {
     console.error('Menu did not close via Escape');
-    await browser.close();
+    await closeBrowser(browser);
     process.exit(1);
   }
   console.log('Keyboard navigation for menu works');
-  await browser.close();
+  await closeBrowser(browser);
 })();

--- a/tests/muteToggleTest.js
+++ b/tests/muteToggleTest.js
@@ -1,7 +1,7 @@
-const puppeteer = require('puppeteer');
+const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
 
 (async () => {
-  const browser = await puppeteer.launch({headless: 'new', args: ['--no-sandbox']});
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/index.php');
   await page.waitForSelector('#mute-toggle');
@@ -11,9 +11,9 @@ const puppeteer = require('puppeteer');
   const afterClick = await page.$eval('#mute-toggle', el => el.getAttribute('aria-pressed'));
   if (initial === afterClick) {
     console.error('aria-pressed did not toggle');
-    await browser.close();
+    await closeBrowser(browser);
     process.exit(1);
   }
   console.log('Mute button toggled correctly');
-  await browser.close();
+  await closeBrowser(browser);
 })();

--- a/tests/tailwindMobileMenuTest.js
+++ b/tests/tailwindMobileMenuTest.js
@@ -1,7 +1,7 @@
-const puppeteer = require('puppeteer');
+const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
 
 (async () => {
-  const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
+  const browser = await launchBrowser();
   for (const width of [1200, 375]) {
     const page = await browser.newPage();
     await page.setViewport({ width, height: 800 });
@@ -12,11 +12,11 @@ const puppeteer = require('puppeteer');
     const hasClass = await page.evaluate(() => document.body.classList.contains('menu-open-left'));
     if (!hasClass) {
       console.error(`menu-open-left not added for viewport ${width}`);
-      await browser.close();
+      await closeBrowser(browser);
       process.exit(1);
     }
     await page.close();
   }
   console.log('Tailwind mobile menu adds menu-open-left correctly');
-  await browser.close();
+  await closeBrowser(browser);
 })();


### PR DESCRIPTION
## Summary
- add `tests/helpers/puppeteerSetup.js`
- refactor puppeteer tests to use the new helper

## Testing
- `npm run test:puppeteer` *(fails: Waiting for selector `#google_translate_element` failed)*

------
https://chatgpt.com/codex/tasks/task_e_685757efc40c83298573a4309e7b2685