### PR TITLE
Add PHP server startup helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@astrojs/tailwind": "^6.0.2"
   },
   "scripts": {
-    "start:php": "sh -c 'php -S localhost:8080 >/dev/null 2>&1 & echo $! > .php_server.pid'",
+    "start:php": "sh scripts/start_php_server.sh",
     "stop:php": "sh -c 'if [ -f .php_server.pid ]; then kill $(cat .php_server.pid); rm .php_server.pid; fi'",
     "test:puppeteer": "node tests/manual/langBarOffsetTest.js && node tests/menuCompressionTest.js && node tests/muteToggleTest.js && node tests/manual/languagePanelOffsetTest.js && node tests/languagePanelBodyClassTest.js && node tests/moonToggleTest.js && node tests/linternaGradientTest.js && node tests/menuKeyboardNavigationTest.js && node tests/timelineDataTest.js && node tests/interactiveMapTest.js",
     "test:playwright": "playwright test tests/phpRoutes.spec.js",

--- a/scripts/start_php_server.sh
+++ b/scripts/start_php_server.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Simple helper to start PHP built-in server if php is available.
+
+if ! command -v php >/dev/null 2>&1; then
+  echo "Warning: php executable not found; skipping PHP server startup." >&2
+  exit 0
+fi
+
+php -S localhost:8080 >/dev/null 2>&1 &
+echo $! > .php_server.pid
+


### PR DESCRIPTION
## Summary
- add a helper script to start the PHP server if PHP exists
- update `start:php` npm script to use the helper

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68575b086d148329acc77e290d92c7ad