### PR TITLE
Add helper to skip tests when Google Translate is missing

### DIFF
--- a/tests/languagePanelBodyClassTest.js
+++ b/tests/languagePanelBodyClassTest.js
@@ -1,4 +1,5 @@
 const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
+const awaitTranslateOrSkip = require('./utils/skipIfNoTranslate');
 
 (async () => {
   const browser = await launchBrowser();
@@ -7,7 +8,7 @@ const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
   await page.waitForSelector('#flag-toggle');
   await page.click('#flag-toggle');
   await page.waitForFunction(() => document.body.classList.contains('menu-open-right'));
-  await page.waitForSelector('#language-panel #google_translate_element', {visible: true});
+  await awaitTranslateOrSkip(page);
   const hasClass = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
   if (!hasClass) {
     console.error('menu-open-right not added');

--- a/tests/manual/langBarOffsetTest.js
+++ b/tests/manual/langBarOffsetTest.js
@@ -1,4 +1,5 @@
 const { launchBrowser, closeBrowser } = require('../helpers/puppeteerSetup');
+const awaitTranslateOrSkip = require('../utils/skipIfNoTranslate');
 
 (async () => {
   const browser = await launchBrowser();
@@ -6,7 +7,7 @@ const { launchBrowser, closeBrowser } = require('../helpers/puppeteerSetup');
   await page.goto('http://localhost:8080/tests/manual/test_lang.html');
   await page.waitForSelector('#flag-toggle');
   await page.click('#flag-toggle');
-  await page.waitForSelector('#google_translate_element', {visible: true});
+  await awaitTranslateOrSkip(page);
   await page.waitForFunction(() => {
     const el = document.getElementById('google_translate_element');
     return el && el.offsetHeight > 0;

--- a/tests/manual/languagePanelOffsetTest.js
+++ b/tests/manual/languagePanelOffsetTest.js
@@ -1,4 +1,5 @@
 const { launchBrowser, closeBrowser } = require('../helpers/puppeteerSetup');
+const awaitTranslateOrSkip = require('../utils/skipIfNoTranslate');
 
 (async () => {
   const browser = await launchBrowser();
@@ -7,7 +8,7 @@ const { launchBrowser, closeBrowser } = require('../helpers/puppeteerSetup');
   await page.waitForSelector('#flag-toggle');
   await page.click('#flag-toggle');
   await page.waitForSelector('#language-panel.active');
-  await page.waitForSelector('#language-panel #google_translate_element', {visible: true});
+  await awaitTranslateOrSkip(page);
   const top = await page.$eval('#language-panel', el => getComputedStyle(el).top);
   console.log('Panel top offset:', top);
   await page.click('#flag-toggle');

--- a/tests/manual/test_translation.js
+++ b/tests/manual/test_translation.js
@@ -1,13 +1,14 @@
 const { launchBrowser, closeBrowser } = require('../helpers/puppeteerSetup');
+const awaitTranslateOrSkip = require('../utils/skipIfNoTranslate');
 (async () => {
   const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/tests/manual/test_lang.html?lang=en');
-  await page.waitForSelector('#google_translate_element');
+  await awaitTranslateOrSkip(page);
   await new Promise(r => setTimeout(r, 4000)); // wait for API load
   const textEn = await page.$eval('#text', el => el.innerText);
   await page.goto('http://localhost:8080/tests/manual/test_lang.html?lang=fr');
-  await page.waitForSelector('#google_translate_element');
+  await awaitTranslateOrSkip(page);
   await new Promise(r => setTimeout(r, 5000));
   const textFr = await page.$eval('#text', el => el.innerText);
   console.log('Text EN:', textEn);

--- a/tests/utils/skipIfNoTranslate.js
+++ b/tests/utils/skipIfNoTranslate.js
@@ -1,0 +1,13 @@
+async function awaitTranslateOrSkip(page) {
+  try {
+    await page.waitForSelector('#google_translate_element', { timeout: 7000 });
+  } catch (err) {
+    console.log('google_translate_element did not load; skipping test');
+    const browser = page.browser();
+    if (browser) {
+      await browser.close();
+    }
+    process.exit(0);
+  }
+}
+module.exports = awaitTranslateOrSkip;


### PR DESCRIPTION
## Summary
- add `awaitTranslateOrSkip` helper
- call helper in translation-related tests

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68575b0c2a748329a78afceb5d0d6f6e