### PR TITLE
Fix translation fallback logic

### DIFF
--- a/includes/i18n.php
+++ b/includes/i18n.php
@@ -64,13 +64,15 @@ function t(string $key, ?string $lang = null): string {
     }
 
     // Usar $active_lang_for_path para la búsqueda en el catálogo
+    $default_language = $default_lang ?? 'es';
+
     if (array_key_exists($key, $catalogs[$active_lang_for_path] ?? [])) {
         $result = $catalogs[$active_lang_for_path][$key];
+    } elseif (array_key_exists($key, $catalogs[$default_language] ?? [])) {
+        mark_untranslated($key, $active_lang_for_path);
+        $result = $catalogs[$default_language][$key];
     } else {
         mark_untranslated($key, $active_lang_for_path);
-        $result = $catalogs[$lang][$key];
-    } else {
-        mark_untranslated($key, $lang);
         $result = $key;
     }
 


### PR DESCRIPTION
## Summary
- fix logic in translation helper to avoid double `else`

## Testing
- `python -m unittest discover -s tests` *(fails: ImportError: Failed to import test module)*

------
https://chatgpt.com/codex/tasks/task_e_68575ca839dc83299d24bfb6cb3e4389