### PR TITLE
Add database troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ El proyecto emplea PHP y Python con Flask. Para nuevos módulos se aconseja usar
 
 2. Sustituye los valores de ejemplo por tus credenciales locales (base de datos, claves de API y ajustes de depuración).
 
+### Solución de problemas de base de datos
+
+Si la aplicación no puede conectarse a PostgreSQL:
+
+1. Verifica que las variables de conexión en tu archivo `.env` sean correctas.
+2. Ejecuta `scripts/check_db.sh` para comprobar la disponibilidad de la base de datos y detectar valores faltantes.
+3. Asegúrate de que el servicio de PostgreSQL esté ejecutándose y accesible desde la dirección configurada.
+4. Algunas pruebas necesitan la extensión **pdo_pgsql**; consulta [docs/testing.md](docs/testing.md) para instalarla en caso de errores de conexión.
+
 
 ## Puesta en marcha rápida
 


### PR DESCRIPTION
## Summary
- document `.env` variables and database connectivity check

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `./scripts/setup_environment.sh` *(fails: PHP 8.1 or higher is required but not found)*

------
https://chatgpt.com/codex/tasks/task_e_68575cbb6efc8329a358cd092a264683