### PR TITLE
Add DB help page and links in templates

### DIFF
--- a/dashboard/login.php
+++ b/dashboard/login.php
@@ -122,6 +122,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             </div>
             <button type="submit" class="btn-primary">Entrar</button>
         </form>
+        <p class="help-link"><a href="/docs/db-help.md">¿Necesitas ayuda con la base de datos?</a></p>
     </div>
 </body>
 </html>

--- a/docs/db-help.md
+++ b/docs/db-help.md
@@ -1,0 +1,19 @@
+# Ayuda de Base de Datos
+
+Este documento resume los problemas más habituales al conectarse a la base de datos.
+
+## Comprobar variables de entorno
+
+Asegúrate de que las variables `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PORT` y `CONDADO_DB_PASSWORD` estén definidas en tu entorno o en el archivo `.env`. Sin ellas `includes/db_connect.php` no podrá crear la conexión. Usa `APP_DEBUG` para activar mensajes de error en desarrollo.
+
+## Revisar extensiones de PHP
+
+Habilita las extensiones `pdo_pgsql` y `pgsql` para trabajar con PostgreSQL. Para pruebas con SQLite necesitarás `pdo_sqlite`.
+
+## Errores frecuentes
+
+- **Fallo de conexión**: verifica que el servidor de base de datos esté activo y que los datos de host y puerto sean correctos.
+- **Credenciales incorrectas**: actualiza `CONDADO_DB_PASSWORD` y vuelve a iniciar el servicio PHP.
+- **Extensión faltante**: ejecuta `php -m` y comprueba que las extensiones requeridas aparezcan en la lista.
+
+Consulta `includes/db_connect.php` para más detalles sobre la configuración.

--- a/index.php
+++ b/index.php
@@ -39,6 +39,7 @@ require_once __DIR__ . '/fragments/header.php';
         <a href="#personajes" class="cta-button-small">Personajes</a>
         <a href="#timeline" class="cta-button-small">Historia</a>
         <a href="#inmersion" class="cta-button-small">Cultura Viva</a>
+        <a href="/docs/db-help.md" class="cta-button-small">Ayuda BD</a>
     </nav>
 
     <section id="video" class="video-section section spotlight-active py-12 sm:py-16 lg:py-20" data-aos="fade-up">


### PR DESCRIPTION
## Summary
- link to DB help page from `index.php`
- add DB help note in `dashboard/login.php`
- document common database issues in `docs/db-help.md`

## Testing
- `scripts/run_tests.sh` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68575cb9fab88329bc746d70c11affcb