### PR TITLE
Add extension check for Postgres PDO

### DIFF
--- a/includes/db_connect.php
+++ b/includes/db_connect.php
@@ -29,8 +29,14 @@ if ($app_debug) {
     error_reporting(E_ALL);
 }
 // --- Fin de manejo de modo debug ---
-
 // Configuración de la base de datos PostgreSQL
+$pdo = null; // Inicializar $pdo
+if (!extension_loaded('pdo_pgsql')) {
+    error_log('pdo_pgsql extension not loaded');
+    echo "<p>La extensión <code>pdo_pgsql</code> no está instalada. Instale el paquete <code>php-pgsql</code> vía apt o en su imagen Docker.</p>";
+    $pdo = null;
+    return;
+}
 $db_host = getenv('DB_HOST');
 if ($db_host === false) {
     error_log('DB_HOST not set');


### PR DESCRIPTION
## Summary
- warn if `pdo_pgsql` extension is missing and keep `$pdo` null

## Testing
- `python -m unittest discover -s tests`
- `vendor/bin/phpunit tests/SoundAssetsTest.php`
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_68575cbc95788329a30014f4f67a5be7