### PR TITLE
Add CONTRIBUTING with setup steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Guía de contribución
+
+Gracias por tu interés en colaborar en **condadodecastilla.com**. Esta guía resume los pasos básicos para preparar el entorno de desarrollo e instalar las dependencias necesarias.
+
+## Requisitos previos
+
+Asegúrate de contar con:
+
+- PHP 8.1 o superior y [Composer](https://getcomposer.org/).
+- Node.js 18 o superior con `npm`.
+- Python 3.10 o superior con `pip`.
+
+## Instalación rápida
+
+Desde la raíz del proyecto ejecuta:
+
+```bash
+./scripts/setup_environment.sh
+```
+
+El script descarga las dependencias de PHP con `composer install`, instala los paquetes de Python listados en `requirements.txt` y ejecuta `npm install` para preparar las bibliotecas de Node. Si algún runtime no está disponible, intentará instalarlo de forma automática.
+
+## Procedimiento manual
+
+Si prefieres controlar cada paso por separado puedes lanzar manualmente:
+
+```bash
+composer install
+pip install -r requirements.txt
+npm install
+```
+
+Con esto tendrás listo el entorno para ejecutar las pruebas descritas en [docs/testing.md](docs/testing.md).

--- a/README.md
+++ b/README.md
@@ -214,3 +214,13 @@ Para verificar la accesibilidad del sitio ejecuta `scripts/run_accessibility_aud
 Utiliza títulos breves en modo imperativo que describan el cambio, p.ej. `Add GSAP page transitions with overlay and tests`. Si añades un cuerpo opcional, explica _qué_ y _por qué_. Consulta [docs/commit-style.md](docs/commit-style.md) para ver la guía completa.
 
 Se incluye `.gitmessage.txt` como plantilla de ejemplo. Puedes activarla con `git config commit.template .gitmessage.txt` para redactar mensajes consistentes.
+
+## Cómo contribuir
+
+Para instalar las dependencias y preparar tu entorno ejecuta:
+
+```bash
+./scripts/setup_environment.sh
+```
+
+El script se encarga de lanzar `composer install`, `pip install -r requirements.txt` y `npm install`. Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para detalles adicionales.


### PR DESCRIPTION
## Summary
- document setup steps in README
- create CONTRIBUTING.md with instructions

## Testing
- `./scripts/run_tests.sh` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68575d6ebee88329b392fd2d9ddc25e6