### PR TITLE
Refactor sliding menu overlay

### DIFF
--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -46,7 +46,7 @@
     background-color: rgba(var(--epic-purple-emperor-rgb), 0.5); /* Increased transparency */
     backdrop-filter: blur(5px); /* Blur effect for transparency */
     box-shadow: 0 0 15px rgba(0,0,0,0.2);
-    z-index: 1000;
+    z-index: 11000; /* keep panels above header */
     overflow-y: hidden; /* STRICT NO-SCROLL as per user feedback refinement */
     display: flex; /* Added for flex-direction */
     flex-direction: column; /* Added to manage content flow */

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -62,29 +62,17 @@ body {
 .slide-menu.right { right: 0; transform: translateX(100%); }
 .slide-menu.open { transform: translateX(0); }
 
-/* Slightly scale down the page when any slide menu is active */
+/* Body class retained for backwards compatibility but no scaling */
 body.menu-compressed {
-    transition: transform 0.3s ease;
-    transform: scale(0.96);
-    transform-origin: center;
+    transition: none;
 }
 
 body.menu-open-left,
 body.menu-open-right {
-    transition: transform 0.3s ease;
-}
-body.menu-open-left {
-    transform: translateX(260px) scale(0.96);
-    transform-origin: left center;
-}
-body.menu-open-right {
-    transform: translateX(-260px) scale(0.96);
-    transform-origin: right center;
+    transition: none;
 }
 
 body.sidebar-active {
-    transform: translateX(260px) scale(0.96);
-    transform-origin: left center;
     margin-left: 0 !important;
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -72,9 +72,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const btn = triggerButton || document.querySelector(`[data-menu-target="${menu.id}"]`);
         updateAria(btn, menu, false);
         if (btn && triggerButton) btn.focus(); // Only focus if we passed the button explicitly
-        const side = menu.classList.contains('left-panel') ? 'left'
-                    : (menu.classList.contains('right-panel') ? 'right' : '');
-        if (side) document.body.classList.remove(`menu-open-${side}`);
         // Recalculate anyOpen and update body classes
         updateGlobalMenuState();
         vibrateFeedback();
@@ -98,12 +95,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (m !== menu) closeMenu(m, document.querySelector(`[data-menu-target="${m.id}"]`));
         });
 
-        const side = menu.classList.contains('left-panel') ? 'left'
-                    : (menu.classList.contains('right-panel') ? 'right' : '');
         const open = !menu.classList.contains('active');
         menu.classList.toggle('active', open);
         updateAria(btn, menu, open);
-        if (side) document.body.classList.toggle(`menu-open-${side}`, open);
 
         if (open && menu.id === 'language-panel' && typeof primeTranslateLoad === 'function') {
             primeTranslateLoad();
@@ -128,8 +122,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const anyPanelOpen = document.querySelectorAll('.menu-panel.active').length > 0;
         const sidebarOpen = document.getElementById(sidebarMenuId)?.classList.contains('sidebar-visible');
         const anyOpen = anyPanelOpen || sidebarOpen;
-
-        document.body.classList.toggle('menu-compressed', anyOpen);
 
         if (window.audioController && typeof window.audioController.handleMenuToggle === 'function') {
             window.audioController.handleMenuToggle(anyOpen);
@@ -238,7 +230,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         // Reset body classes that might persist if not handled by individual close functions
-        document.body.classList.remove('menu-compressed', 'sidebar-active', 'menu-open-left', 'menu-open-right');
+        document.body.classList.remove('sidebar-active');
         updateGlobalMenuState(); // Final state update
     };
 
@@ -250,7 +242,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const panel = document.getElementById('ai-chat-panel');
             if (panel && panel.classList.contains('active')) { // Ensure panel is active before closing
                 const btn = document.querySelector(`[data-menu-target="ai-chat-panel"]`);
-                closeMenu(panel, btn); // Pass button for focus, menu-compressed handled by updateGlobalMenuState
+                closeMenu(panel, btn); // Pass button for focus
             }
         });
     }

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -40,37 +40,21 @@ El panel también incluye `admin-menu.php` y `social-menu.html` dentro de bloque
 - **Comportamiento**: `assets/js/main.js` gestiona la apertura y cierre con el atributo `data-menu-target`.
 - **Añadir páginas**: edita `fragments/menus/main-menu.php` para crear nuevos enlaces y añade el archivo correspondiente en el directorio del proyecto.
 
-### Clase `menu-compressed` y transformación de la página
+### Apertura del panel y superposición
 
-Al pulsar un botón con el atributo `data-menu-target="id-del-panel"`,
-`assets/js/main.js` abre el panel de menú indicado y añade la clase
-`menu-compressed` al elemento `<body>` para escalar la página. También se aplica
-`menu-open-left` o `menu-open-right` según el lado del que se despliegue
-el panel. Estas clases están definidas en
-`assets/css/sliding_menu.css`:
+Al pulsar un botón con `data-menu-target="id-del-panel"`,
+`assets/js/main.js` abre el panel de menú indicado. A diferencia de versiones
+anteriores, el contenido de la página ya no se desplaza ni se escala. El panel
+`.menu-panel` se posiciona de forma fija y con un `z-index` alto para superponerse
+al resto de elementos.
 
-```css
-body.menu-compressed {
-  transition: transform 0.3s ease;
-  transform: scale(0.96);
-}
-body.menu-open-left {
-  transform: translateX(260px) scale(0.96);
-}
-body.menu-open-right {
-  transform: translateX(-260px) scale(0.96);
-}
-```
+El cuerpo de la página no recibe ya las clases `menu-compressed`,
+`menu-open-left` ni `menu-open-right`. Todo el comportamiento de
+apertura y cierre se gestiona mediante la propia clase `active` en el
+panel correspondiente.
 
-`assets/js/main.js` actualiza los atributos `aria-expanded` y `aria-hidden`
-de los botones y paneles cada vez que se abre o cierra un menú, y
-añade o quita la clase `menu-compressed` para aplicar la animación de
-escala.
-
-El contenido de la página se desplaza y se escala horizontalmente,
-comprimiéndose hacia el lado opuesto al menú abierto. Al cerrar todos
-los paneles, el script elimina estas clases y la vista vuelve a su
-posición original.
+`assets/js/main.js` sigue actualizando los atributos `aria-expanded` y
+`aria-hidden` de los botones y paneles para mantener la accesibilidad.
 
 Tras cualquier modificacion consulta la [Guia de Testing](testing.md) para ejecutar las pruebas.
 

--- a/fragments/admin_header.php
+++ b/fragments/admin_header.php
@@ -55,20 +55,17 @@ document.addEventListener('DOMContentLoaded', function() {
         e.preventDefault();
         const open = menu.classList.toggle('active');
         btn.setAttribute('aria-expanded', open);
-        document.body.classList.toggle('menu-open-left', open);
     });
     document.addEventListener('click', function(e) {
         if (!menu.contains(e.target) && !btn.contains(e.target)) {
             menu.classList.remove('active');
             btn.setAttribute('aria-expanded', 'false');
-            document.body.classList.remove('menu-open-left');
         }
     });
     document.addEventListener('keydown', function(e) {
         if (e.key === 'Escape') {
             menu.classList.remove('active');
             btn.setAttribute('aria-expanded', 'false');
-            document.body.classList.remove('menu-open-left');
         }
     });
 });

--- a/nuevaweb/dist/assets/main.js
+++ b/nuevaweb/dist/assets/main.js
@@ -1,1 +1,1 @@
-document.addEventListener("DOMContentLoaded",()=>{const e=document.getElementById("menu-toggle"),t=document.getElementById("menu");!e||!t||e.addEventListener("click",()=>{const n=t.classList.toggle("open");document.body.classList.toggle("menu-compressed",n),e.setAttribute("aria-expanded",n)})});
+document.addEventListener("DOMContentLoaded",()=>{const e=document.getElementById("menu-toggle"),t=document.getElementById("menu");!e||!t||e.addEventListener("click",()=>{const n=t.classList.toggle("open");e.setAttribute("aria-expanded",n)})});

--- a/nuevaweb/src/js/menu.js
+++ b/nuevaweb/src/js/menu.js
@@ -4,7 +4,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!btn || !menu) return;
     btn.addEventListener('click', () => {
         const open = menu.classList.toggle('open');
-        document.body.classList.toggle('menu-compressed', open);
         btn.setAttribute('aria-expanded', open);
     });
 });

--- a/tailwind_index.php
+++ b/tailwind_index.php
@@ -64,8 +64,7 @@
             const menu = document.getElementById('mobile-menu');
             if (!toggle || !menu) return;
             toggle.addEventListener('click', function () {
-                const open = menu.classList.toggle('open');
-                document.body.classList.toggle('menu-open-left', open);
+                menu.classList.toggle('open');
             });
         });
     </script>

--- a/tests/menuCompressionTest.js
+++ b/tests/menuCompressionTest.js
@@ -6,21 +6,21 @@ const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
   await page.goto('http://localhost:8080/index.php');
   await page.waitForSelector('#consolidated-menu-button');
   await page.click('#consolidated-menu-button');
-  await page.waitForFunction(() => document.body.classList.contains('menu-compressed'));
+  await page.waitForTimeout(500);
   const hasClass = await page.evaluate(() => document.body.classList.contains('menu-compressed'));
-  if (!hasClass) {
-    console.error('menu-compressed class not added');
+  if (hasClass) {
+    console.error('menu-compressed class should not be present');
     await closeBrowser(browser);
     process.exit(1);
   }
   await page.click('#consolidated-menu-button');
-  await page.waitForFunction(() => !document.body.classList.contains('menu-compressed'));
+  await page.waitForTimeout(500);
   const stillHasClass = await page.evaluate(() => document.body.classList.contains('menu-compressed'));
   if (stillHasClass) {
-    console.error('menu-compressed class not removed');
+    console.error('menu-compressed class still present after closing');
     await closeBrowser(browser);
     process.exit(1);
   }
-  console.log('Menu compression class toggled correctly');
+  console.log('Menu opens without adding menu-compressed');
   await closeBrowser(browser);
 })();

--- a/tests/menuJsToggle.spec.js
+++ b/tests/menuJsToggle.spec.js
@@ -21,7 +21,7 @@ describe('menu.js toggle behavior', () => {
 
     btn.click()
     expect(menu.classList.contains('open')).toBe(true)
-    expect(window.document.body.classList.contains('menu-compressed')).toBe(true)
+    expect(window.document.body.classList.contains('menu-compressed')).toBe(false)
     expect(btn.getAttribute('aria-expanded')).toBe('true')
 
     btn.click()

--- a/tests/tailwindMobileMenuTest.js
+++ b/tests/tailwindMobileMenuTest.js
@@ -8,15 +8,15 @@ const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
     await page.goto('http://localhost:8080/tailwind_index.php');
     await page.waitForSelector('#menu-toggle');
     await page.evaluate(() => document.getElementById('menu-toggle').click());
-    await page.waitForFunction(() => document.body.classList.contains('menu-open-left'));
+    await page.waitForTimeout(300);
     const hasClass = await page.evaluate(() => document.body.classList.contains('menu-open-left'));
-    if (!hasClass) {
-      console.error(`menu-open-left not added for viewport ${width}`);
+    if (hasClass) {
+      console.error(`menu-open-left should not be added for viewport ${width}`);
       await closeBrowser(browser);
       process.exit(1);
     }
     await page.close();
   }
-  console.log('Tailwind mobile menu adds menu-open-left correctly');
+  console.log('Tailwind mobile menu opens without body class');
   await closeBrowser(browser);
 })();


### PR DESCRIPTION
## Summary
- revise sliding menu CSS to drop scale/translate effects
- boost z-index on menu-panel
- overlay menus without body classes in main.js
- update examples and admin header scripts
- document new behaviour for sliding menus
- adjust related Puppeteer and Vitest tests

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68575d72146c83298be664ed066263eb