### PR TITLE
Fix redundant saved flag

### DIFF
--- a/backend/php/admin/forum_agents_admin.php
+++ b/backend/php/admin/forum_agents_admin.php
@@ -65,7 +65,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $agents = $updatedAgents; // Actualizar la variable local $agents
         $saved = true;
     }
-    $saved = true;
 }
 ?>
 <!DOCTYPE html>
@@ -96,3 +95,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </form>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- remove extra assignment from `forum_agents_admin.php`

## Testing
- `python -m unittest discover -s tests` *(fails: No module named 'flask')*
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68575f0fd9fc8329b10e498597cc8eb7