### PR TITLE
Fix homonexus toggle ARIA handling

### DIFF
--- a/assets/css/header/nav.css
+++ b/assets/css/header/nav.css
@@ -392,6 +392,21 @@ body.sidebar-active {
     transition: background-color 0.3s ease;
 }
 
+#homonexus-toggle {
+    padding: 6px 10px;
+    background-color: var(--epic-purple-emperor);
+    color: var(--epic-gold-main);
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 0.9em;
+    transition: background-color 0.3s ease;
+}
+
+#homonexus-toggle:hover {
+    background-color: var(--epic-gold-main);
+    color: var(--epic-purple-emperor);
+}
 #mute-toggle:hover {
     background-color: var(--epic-purple-emperor);
     color: var(--epic-gold-main);

--- a/assets/js/homonexus-toggle.js
+++ b/assets/js/homonexus-toggle.js
@@ -4,12 +4,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const updateState = (active) => {
     document.body.classList.toggle('homonexus-active', active);
-    toggle.setAttribute('aria-expanded', active);
+    toggle.setAttribute('aria-pressed', active);
     document.cookie = `homonexus=${active ? 'on' : 'off'};path=/;max-age=31536000`;
   };
 
-  // Set initial aria-expanded from body class
-  toggle.setAttribute('aria-expanded', document.body.classList.contains('homonexus-active'));
+  // Set initial aria-pressed from body class
+  toggle.setAttribute('aria-pressed', document.body.classList.contains('homonexus-active'));
 
   toggle.addEventListener('click', () => {
     const active = !document.body.classList.contains('homonexus-active');


### PR DESCRIPTION
## Summary
- correct aria attribute handling for `homonexus-toggle`
- style homonexus toggle button with purple and old gold palette

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68580275e4d08329abf0c682c462ed3e