### PR TITLE
Add minimal Web Nueva example

### DIFF
--- a/webnueva/README.md
+++ b/webnueva/README.md
@@ -1,0 +1,9 @@
+# Web Nueva
+
+Esta carpeta contiene una versión minimalista de la web basada en la paleta de colores oficial.
+Se utilizan morados y oro viejo sobre fondos de alabastro, tal como se detalla en `docs/style-guide.md`.
+Incluye un menú deslizante que comprime la página y un efecto de texto degradado.
+
+- `index.php` – página principal de ejemplo.
+- `assets/css/simple.css` – estilos simplificados.
+- `assets/js/menu.js` – lógica para abrir y cerrar el menú.

--- a/webnueva/assets/css/simple.css
+++ b/webnueva/assets/css/simple.css
@@ -1,0 +1,47 @@
+body {
+    background: var(--epic-alabaster-bg);
+    color: var(--epic-text-color);
+    font-family: var(--font-body);
+    margin: 0;
+}
+
+.gradient-text {
+    background: linear-gradient(45deg, var(--epic-purple-emperor), var(--epic-gold-main));
+    -webkit-background-clip: text;
+    color: transparent;
+    text-shadow: 1px 1px 2px rgba(var(--epic-alabaster-bg-rgb), 0.8);
+}
+
+.slider-menu {
+    position: relative;
+}
+
+.slider-menu ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: fixed;
+    top: 0;
+    left: -220px;
+    width: 200px;
+    height: 100%;
+    background: rgba(var(--epic-purple-emperor-rgb), 0.9);
+    backdrop-filter: blur(4px);
+    transition: left 0.3s ease;
+}
+
+.slider-menu ul.open {
+    left: 0;
+}
+
+.slider-menu a {
+    display: block;
+    padding: 1rem;
+    color: var(--epic-gold-main);
+    text-decoration: none;
+    font-weight: bold;
+}
+
+body.menu-compressed {
+    overflow: hidden;
+}

--- a/webnueva/assets/js/menu.js
+++ b/webnueva/assets/js/menu.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('menu-toggle');
+    const menu = document.getElementById('menu');
+    if (!toggle || !menu) return;
+    toggle.addEventListener('click', () => {
+        const opened = menu.classList.toggle('open');
+        toggle.setAttribute('aria-expanded', opened);
+        document.body.classList.toggle('menu-compressed', opened);
+    });
+});

--- a/webnueva/index.php
+++ b/webnueva/index.php
@@ -1,0 +1,17 @@
+<?php require_once __DIR__ . '/../fragments/header.php'; ?>
+<link rel="stylesheet" href="/assets/css/epic_theme.css">
+<link rel="stylesheet" href="/webnueva/assets/css/simple.css">
+<main class="container-epic px-4 py-8">
+    <h1 class="gradient-text text-3xl font-headings mb-4">Bienvenido a Cerezo de Río Tirón</h1>
+    <p class="font-body mb-6">Promocionamos el turismo y gestionamos su patrimonio cultural.</p>
+    <nav class="slider-menu">
+        <button id="menu-toggle" aria-expanded="false" class="cta-button">Menú</button>
+        <ul id="menu">
+            <li><a href="#mision">Misión</a></li>
+            <li><a href="#patrimonio">Patrimonio</a></li>
+            <li><a href="#foro">Foro</a></li>
+        </ul>
+    </nav>
+</main>
+<script src="/webnueva/assets/js/menu.js"></script>
+<?php require_once __DIR__ . '/../fragments/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add `webnueva` folder with a minimal demo site
- implement sliding menu and gradient text using the project's color palette

## Testing
- `python3 -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858087c4a5c83299af85405e821bc7d