### PR TITLE
fix: responsive size for Nueva Web button

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -1218,6 +1218,12 @@ body.dark-mode .footer .social-links a:focus-visible {
     /* Inherits from .cta-button hover */
 }
 
+.header-action-buttons .cta-button-small {
+    margin-top: 0;
+    padding: clamp(4px, 1vh, 8px) clamp(12px, 4vw, 18px);
+    font-size: clamp(0.8em, 2vw, 1em);
+}
+
 
 /* --- Sección de Video --- */
 .video-section {


### PR DESCRIPTION
## Summary
- tweak `.cta-button-small` style rules in `epic_theme.css`
- add `.header-action-buttons .cta-button-small` to keep the button height within header bounds

## Testing
- `npm run build` within `nuevaweb`
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68580f8aab348329a336f0249d8d23f1