### PR TITLE
Add server setup runner to dashboard

### DIFF
--- a/assets/css/admin_theme.css
+++ b/assets/css/admin_theme.css
@@ -175,3 +175,31 @@ body.edit-pieza-page th {
     font-family: monospace;
     max-width: 100%;
 }
+
+.server-setup-btn {
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.85);
+    color: var(--epic-gold-main);
+    border: 1px solid var(--epic-gold-main);
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    display: block;
+    margin: 20px auto;
+    transition: background-color var(--global-transition-speed);
+}
+
+.server-setup-btn:hover {
+    background-color: rgba(var(--epic-purple-emperor-rgb), 0.95);
+}
+
+.server-setup-output {
+    display: none;
+    background-color: rgba(var(--epic-alabaster-bg-rgb), 0.8);
+    color: var(--epic-purple-emperor);
+    border: 1px solid var(--epic-purple-emperor);
+    padding: 10px;
+    margin: 10px auto;
+    white-space: pre-wrap;
+    border-radius: 4px;
+    max-width: 90%;
+}

--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -30,11 +30,32 @@ require_admin_login();
         <canvas id="visitsChart"></canvas>
     </div>
     <div id="errorMessage"></div>
+    <div class="server-setup-block">
+        <button id="runSetupBtn" class="server-setup-btn">Configurar servidor</button>
+        <pre id="setupOutput" class="server-setup-output"></pre>
+    </div>
 
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             const canvas = document.getElementById('visitsChart');
             const errorMessageDiv = document.getElementById('errorMessage');
+            const runSetupBtn = document.getElementById('runSetupBtn');
+            const setupOutput = document.getElementById('setupOutput');
+
+            if (runSetupBtn) {
+                runSetupBtn.addEventListener('click', () => {
+                    setupOutput.textContent = 'Ejecutando configuración...';
+                    setupOutput.style.display = 'block';
+                    fetch('run_server_setup.php', { method: 'POST' })
+                        .then(resp => resp.json())
+                        .then(data => {
+                            setupOutput.textContent = data.output || data.message;
+                        })
+                        .catch(err => {
+                            setupOutput.textContent = 'Error al ejecutar: ' + err.message;
+                        });
+                });
+            }
 
             if (!canvas) {
                 console.error('Canvas element "visitsChart" not found!');

--- a/dashboard/run_server_setup.php
+++ b/dashboard/run_server_setup.php
@@ -1,0 +1,50 @@
+<?php
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
+require_once __DIR__ . '/../includes/auth.php';
+require_admin_login();
+
+header('Content-Type: application/json');
+
+$setupScript = __DIR__ . '/../scripts/setup_project.sh';
+if (!is_file($setupScript)) {
+    $setupScript = __DIR__ . '/../scripts/setup_environment.sh';
+}
+
+$response = [
+    'success' => false,
+    'message' => '',
+    'output'  => '',
+    'exit_code' => 1,
+];
+
+if (!is_file($setupScript)) {
+    $response['message'] = 'Script de configuración no encontrado.';
+    echo json_encode($response);
+    exit;
+}
+
+$descriptorSpec = [
+    1 => ['pipe', 'w'],
+    2 => ['pipe', 'w'],
+];
+
+$process = proc_open($setupScript, $descriptorSpec, $pipes);
+if (is_resource($process)) {
+    $output = stream_get_contents($pipes[1]);
+    $errorOutput = stream_get_contents($pipes[2]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    $exitCode = proc_close($process);
+
+    $response['success'] = ($exitCode === 0);
+    $response['exit_code'] = $exitCode;
+    $response['output'] = $output . $errorOutput;
+    $response['message'] = $response['success']
+        ? 'Configuración completada.'
+        : 'El script terminó con errores.';
+} else {
+    $response['message'] = 'No se pudo ejecutar el script.';
+}
+
+echo json_encode($response);


### PR DESCRIPTION
## Summary
- add script runner `run_server_setup.php` to execute setup scripts
- show server setup button in dashboard and display result
- style new elements with purple/gold palette

## Testing
- `./scripts/run_tests.sh` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_685812bc6c0c8329b7f7791e8d6ec467