### PR TITLE
Add tools menu and scripts index

### DIFF
--- a/fragments/menus/tools-menu.html
+++ b/fragments/menus/tools-menu.html
@@ -1,0 +1,5 @@
+<div id="tools-menu" class="tools-menu nav-links">
+    <a href="/scripts/index.php">Scripts</a>
+    <a href="/docs/fullstack-tools-2025.md">Fullstack 2025</a>
+    <a href="/docs/testing.md">Testing</a>
+</div>

--- a/scripts/index.php
+++ b/scripts/index.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . '/../includes/session.php';
+ensure_session_started();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <title>Scripts Disponibles</title>
+    <?php require_once __DIR__ . '/../includes/head_common.php'; ?>
+</head>
+<body class="alabaster-bg">
+<?php require_once __DIR__ . '/../fragments/header.php'; ?>
+<main class="container-epic page-content-block">
+    <h1 class="gradient-text">Listado de Scripts</h1>
+    <ul>
+        <?php
+        $dir = __DIR__;
+        $files = array_filter(scandir($dir), function ($f) {
+            return is_file(__DIR__ . '/' . $f) && $f !== 'index.php';
+        });
+        foreach ($files as $f): ?>
+            <li><a href="<?php echo htmlspecialchars($f); ?>"><?php echo htmlspecialchars($f); ?></a></li>
+        <?php endforeach; ?>
+    </ul>
+    <p><a class="cta-button" href="/">Volver al inicio</a></p>
+</main>
+<?php require_once __DIR__ . '/../fragments/footer.php'; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `tools-menu.html` fragment with links to internal tools
- create `/scripts/index.php` listing available scripts

## Testing
- `composer install` *(fails: command not found)*
- `npm run test:puppeteer` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685812d6a4b4832986a540cf695ca8eb