### PR TITLE
Add menu catalogo scripts translations

### DIFF
--- a/config/main_menu.php
+++ b/config/main_menu.php
@@ -34,4 +34,7 @@ return [
         ['label' => 'menu_documentacion', 'url' => 'docs/index.php'],
         ['label' => 'menu_contacto', 'url' => 'contacto/contacto.php'],
     ],
+    'group_herramientas' => [
+        ['label' => 'menu_catalogo_scripts', 'url' => 'scripts_admin.php'],
+    ],
 ];

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -25,8 +25,10 @@
   "menu_mapa_interactivo": "Mapa Interactivo",
   "menu_documentacion": "Documentación",
   "menu_nueva_web": "New Website",
+  "menu_catalogo_scripts": "Scripts Catalog",
   "group_historia_cultura": "Historia y Cultura",
   "group_lugares_patrimonio": "Lugares y Patrimonio",
   "group_servicios_visitante": "Servicios al Visitante",
-  "group_comunidad": "Comunidad"
+  "group_comunidad": "Comunidad",
+  "group_herramientas": "Tools"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -25,8 +25,10 @@
   "menu_mapa_interactivo": "Mapa Interactivo",
   "menu_documentacion": "Documentación",
   "menu_nueva_web": "Nueva Web",
+  "menu_catalogo_scripts": "Catálogo de Scripts",
   "group_historia_cultura": "Historia y Cultura",
   "group_lugares_patrimonio": "Lugares y Patrimonio",
   "group_servicios_visitante": "Servicios al Visitante",
-  "group_comunidad": "Comunidad"
+  "group_comunidad": "Comunidad",
+  "group_herramientas": "Herramientas"
 }

--- a/i18n/gl.json
+++ b/i18n/gl.json
@@ -25,8 +25,10 @@
   "menu_mapa_interactivo": "Mapa Interactivo",
   "menu_documentacion": "Documentación",
   "menu_nueva_web": "Nova Web",
+  "menu_catalogo_scripts": "Catálogo de Scripts",
   "group_historia_cultura": "Historia y Cultura",
   "group_lugares_patrimonio": "Lugares y Patrimonio",
   "group_servicios_visitante": "Servicios al Visitante",
-  "group_comunidad": "Comunidad"
+  "group_comunidad": "Comunidad",
+  "group_herramientas": "Ferramentas"
 }


### PR DESCRIPTION
## Summary
- add `menu_catalogo_scripts` and `group_herramientas` translations
- include new catalog in main menu

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685812d8acf4832985756883a1528a40