### PR TITLE
Add scripts link and help section

### DIFF
--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -24,6 +24,9 @@ require_admin_login();
     <header class="admin-header">
         <h1>Panel de Estadísticas de Visitas</h1>
     </header>
+    <nav class="admin-nav">
+        <a href="/scripts_admin.php" class="cta-button">Scripts</a>
+    </nav>
 
     
     <div class="chart-container">

--- a/scripts_admin.php
+++ b/scripts_admin.php
@@ -39,6 +39,9 @@ if (is_dir($scriptsDir)) {
     <?php require_once __DIR__ . '/fragments/admin_header.php'; ?>
     <main class="container-epic">
         <h1 class="gradient-text">Gestión de Scripts</h1>
+        <section class="help-link">
+            <p>Antes de ejecutar, revisa el <a href="/docs/script_catalog.md">catálogo de scripts</a> para conocer la función de cada uno.</p>
+        </section>
         <p style="color: var(--epic-purple-emperor);">Lista de scripts disponibles en el sistema.</p>
         <?php if ($scripts): ?>
             <ul>


### PR DESCRIPTION
## Summary
- link `Scripts` from main dashboard to `scripts_admin.php`
- explain script usage in `scripts_admin.php` with a help section

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit tests/SoundAssetsTest.php` *(not run: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685812da2f888329b77f1ddfd0a9b956