### PR TITLE
Add script catalog page and menu entry

### DIFF
--- a/config/main_menu.php
+++ b/config/main_menu.php
@@ -27,6 +27,9 @@ return [
         ['label' => 'menu_planifica_visita', 'url' => 'visitas/visitas.php'],
         ['label' => 'menu_programa_citas', 'url' => 'citas/agenda.php'],
     ],
+    'group_herramientas' => [
+        ['label' => 'menu_catalogo_scripts', 'url' => 'scripts/index.php'],
+    ],
     'group_comunidad' => [
         ['label' => 'menu_gestion_yacimientos', 'url' => 'empresa/index.php'],
         ['label' => 'menu_foro', 'url' => 'foro/index.php'],

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -25,8 +25,10 @@
   "menu_mapa_interactivo": "Mapa Interactivo",
   "menu_documentacion": "Documentación",
   "menu_nueva_web": "New Website",
+  "menu_catalogo_scripts": "Script Catalog",
   "group_historia_cultura": "Historia y Cultura",
   "group_lugares_patrimonio": "Lugares y Patrimonio",
   "group_servicios_visitante": "Servicios al Visitante",
+  "group_herramientas": "Tools",
   "group_comunidad": "Comunidad"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -25,8 +25,10 @@
   "menu_mapa_interactivo": "Mapa Interactivo",
   "menu_documentacion": "Documentación",
   "menu_nueva_web": "Nueva Web",
+  "menu_catalogo_scripts": "Catálogo de Scripts",
   "group_historia_cultura": "Historia y Cultura",
   "group_lugares_patrimonio": "Lugares y Patrimonio",
   "group_servicios_visitante": "Servicios al Visitante",
+  "group_herramientas": "Herramientas",
   "group_comunidad": "Comunidad"
 }

--- a/i18n/gl.json
+++ b/i18n/gl.json
@@ -25,8 +25,10 @@
   "menu_mapa_interactivo": "Mapa Interactivo",
   "menu_documentacion": "Documentación",
   "menu_nueva_web": "Nova Web",
+  "menu_catalogo_scripts": "Catálogo de Scripts",
   "group_historia_cultura": "Historia y Cultura",
   "group_lugares_patrimonio": "Lugares y Patrimonio",
   "group_servicios_visitante": "Servicios al Visitante",
+  "group_herramientas": "Ferramentas",
   "group_comunidad": "Comunidad"
 }

--- a/scripts/index.php
+++ b/scripts/index.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../includes/head_common.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+}
+use League\CommonMark\CommonMarkConverter;
+
+function render_markdown(string $file): string {
+    static $converter = null;
+    if ($converter === null) {
+        $converter = new CommonMarkConverter();
+    }
+    return $converter->convert(file_get_contents($file))->getContent();
+}
+
+$catalog = __DIR__ . '/../docs/script_catalog.md';
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <title>Catálogo de Scripts</title>
+    <link rel="stylesheet" href="/assets/css/custom.css">
+</head>
+<body class="alabaster-bg">
+<?php require_once __DIR__ . '/../fragments/header.php'; ?>
+<main class="container page-content-block">
+    <h1 class="gradient-text">Catálogo de Scripts</h1>
+    <section class="section">
+        <?php if (file_exists($catalog)) echo render_markdown($catalog); ?>
+    </section>
+</main>
+<?php require_once __DIR__ . '/../fragments/footer.php'; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `scripts/index.php` using CommonMark to render docs script catalog
- add `group_herramientas` with `menu_catalogo_scripts` to main menu
- translate keys in en/es/gl catalogs

## Testing
- `vendor/bin/phpunit --dont-report-useless-tests` *(fails: missing environment)*

------
https://chatgpt.com/codex/tasks/task_e_685812dbe720832983f7dfe7576a039d