### PR TITLE
Strip HTML in CommonMarkConverter

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -22,7 +22,9 @@ use League\CommonMark\CommonMarkConverter;
 function render_markdown(string $markdown): string {
     static $converter = null;
     if ($converter === null) {
-        $converter = new CommonMarkConverter();
+        $converter = new CommonMarkConverter([
+            'html_input' => 'strip'
+        ]);
     }
 
     return $converter->convert($markdown)->getContent();

--- a/docs/README.md
+++ b/docs/README.md
@@ -168,6 +168,7 @@ Los estilos coinciden con `assets/css/pages/historia_subpaginas_auca_patricia_ub
 - [Guía Fullstack 2025](fullstack-tools-2025.md)
 - [Agentes del Foro](forum_agents.md)
 - [Guía de mensajes de commit](commit-style.md)
+- [Seguridad de Markdown](security.md)
 
 ## Demos
 

--- a/docs/index.php
+++ b/docs/index.php
@@ -8,7 +8,9 @@ use League\CommonMark\CommonMarkConverter;
 function render_markdown_file(string $path): string {
     static $converter = null;
     if ($converter === null) {
-        $converter = new CommonMarkConverter();
+        $converter = new CommonMarkConverter([
+            'html_input' => 'strip'
+        ]);
     }
     $markdown = file_get_contents($path);
     return $converter->convert($markdown)->getContent();

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,11 @@
+# Seguridad de Markdown
+
+A partir de la versión actual se ha configurado el convertidor de Markdown para eliminar cualquier HTML incrustado. Todas las instancias de `CommonMarkConverter` se crean con la opción:
+
+```php
+new CommonMarkConverter([
+    'html_input' => 'strip'
+]);
+```
+
+Esta medida evita que se inyecte código HTML malicioso en los textos procesados. Consulta el código fuente para ver el cambio aplicado en los distintos archivos PHP.

--- a/historia/historia_ampliada.php
+++ b/historia/historia_ampliada.php
@@ -6,7 +6,9 @@ use League\CommonMark\CommonMarkConverter;
 function render_markdown_file(string $path): string {
     static $converter = null;
     if ($converter === null) {
-        $converter = new CommonMarkConverter();
+        $converter = new CommonMarkConverter([
+            'html_input' => 'strip'
+        ]);
     }
     $markdown = file_get_contents($path);
     return $converter->convert($markdown)->getContent();

--- a/scripts/generar_json_historia.php
+++ b/scripts/generar_json_historia.php
@@ -538,7 +538,9 @@ $ruta_json_escritura_nuestra_historia = DIR_OUTPUT . $id_tema_nuestra_historia .
 
 if (file_exists($ruta_nuestra_historia_html)) {
     $markdown_nh = file_get_contents($ruta_nuestra_historia_html);
-    $converter_nh = new CommonMarkConverter();
+    $converter_nh = new CommonMarkConverter([
+        'html_input' => 'strip'
+    ]);
     $html_nh = $converter_nh->convert($markdown_nh)->getContent();
 
     $doc_nh = new DOMDocument();


### PR DESCRIPTION
## Summary
- sanitize markdown input by passing `'html_input' => 'strip'` when creating `CommonMarkConverter`
- document the new setting in `docs/security.md`
- reference the doc from `docs/README.md`

## Testing
- `scripts/run_tests.sh` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859361b1034832998bec3ef0ea1a551