### PR TITLE
Add catalog file check

### DIFF
--- a/scripts/index.php
+++ b/scripts/index.php
@@ -1,6 +1,24 @@
 <?php
 require_once __DIR__ . '/../includes/session.php';
 ensure_session_started();
+
+// Optional catalog file listing scripts. Falls back to directory scan
+$catalog = __DIR__ . '/scripts_catalog.json';
+$catalog_missing = false;
+$files = [];
+if (file_exists($catalog)) {
+    $json = file_get_contents($catalog);
+    $decoded = json_decode($json, true);
+    if (is_array($decoded)) {
+        $files = $decoded;
+    }
+} else {
+    $catalog_missing = true;
+    $dir = __DIR__;
+    $files = array_filter(scandir($dir), function ($f) {
+        return is_file(__DIR__ . '/' . $f) && $f !== 'index.php';
+    });
+}
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -12,13 +30,11 @@ ensure_session_started();
 <?php require_once __DIR__ . '/../fragments/header.php'; ?>
 <main class="container-epic page-content-block">
     <h1 class="gradient-text">Listado de Scripts</h1>
+    <?php if ($catalog_missing): ?>
+        <p class="warning">Archivo de catálogo no encontrado.</p>
+    <?php endif; ?>
     <ul>
-        <?php
-        $dir = __DIR__;
-        $files = array_filter(scandir($dir), function ($f) {
-            return is_file(__DIR__ . '/' . $f) && $f !== 'index.php';
-        });
-        foreach ($files as $f): ?>
+        <?php foreach ($files as $f): ?>
             <li><a href="<?php echo htmlspecialchars($f); ?>"><?php echo htmlspecialchars($f); ?></a></li>
         <?php endforeach; ?>
     </ul>

--- a/tests/ScriptsCatalogMissingTest.php
+++ b/tests/ScriptsCatalogMissingTest.php
@@ -1,0 +1,32 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ScriptsCatalogMissingTest extends TestCase {
+    private function runPage(string $script): array {
+        $prepend = realpath(__DIR__.'/fixtures/page_prepend.php');
+        $cmd = sprintf('php-cgi -d auto_prepend_file=%s %s',
+            escapeshellarg($prepend),
+            escapeshellarg($script)
+        );
+        $env = [
+            'PATH' => getenv('PATH'),
+            'REDIRECT_STATUS' => '1',
+            'SCRIPT_FILENAME' => $script
+        ];
+        $proc = proc_open($cmd, [1=>['pipe','w'], 2=>['pipe','w']], $pipes, null, $env);
+        $out = stream_get_contents($pipes[1]);
+        $err = stream_get_contents($pipes[2]);
+        $status = proc_close($proc);
+        return [$status, $out, $err];
+    }
+
+    public function testCatalogMissingShowsMessage(): void {
+        $page = realpath(__DIR__.'/../scripts/index.php');
+        $this->assertFileExists($page);
+        $this->assertFileDoesNotExist(__DIR__.'/../scripts/scripts_catalog.json');
+        [$status, $out, $err] = $this->runPage($page);
+        $this->assertSame(0, $status, $err);
+        $this->assertStringContainsString('Archivo de catálogo no encontrado.', $out);
+    }
+}
+


### PR DESCRIPTION
## Summary
- verify scripts catalog file exists before loading
- show helpful message when missing
- add test for missing catalog message

## Testing
- `phpunit --configuration phpunit.xml --dont-report-useless-tests --colors=never` *(fails: could not find PDO driver)*

------
https://chatgpt.com/codex/tasks/task_e_6859361d295483298df8387d9ae54a3b