### PR TITLE
Ensure PYTHONPATH in CI and setup scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Set PYTHONPATH
+        run: echo "PYTHONPATH=${{ github.workspace }}" >> $GITHUB_ENV
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Set PYTHONPATH
+        run: echo "PYTHONPATH=${{ github.workspace }}" >> $GITHUB_ENV
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,6 +4,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
+# Ensure PYTHONPATH includes project root for module resolution
+export PYTHONPATH="$PROJECT_ROOT:${PYTHONPATH:-}"
+
 if ! command -v composer >/dev/null 2>&1; then
     echo "Composer not found. Installing..." >&2
     if apt-get update -y >/dev/null 2>&1 && apt-get install -y composer >/dev/null 2>&1; then

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -22,6 +22,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
+# Ensure project root is on PYTHONPATH so modules can be imported in tests
+export PYTHONPATH="$PROJECT_ROOT:${PYTHONPATH:-}"
+
 # Required tool versions
 REQUIRED_PHP_VERSION="8.1"
 REQUIRED_NODE_VERSION="18"


### PR DESCRIPTION
## Summary
- add PYTHONPATH export in setup scripts
- set PYTHONPATH in CI workflows
- keep local run_tests.sh in sync

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_flask_api.py tests/test_graph_db_interface.py`

------
https://chatgpt.com/codex/tasks/task_e_6859361d53788329aae7c7f620a61938