### PR TITLE
Add shared markdown rendering utility

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -1,8 +1,6 @@
 <?php
 require_once __DIR__ . '/includes/head_common.php';
-if (file_exists(__DIR__ . '/vendor/autoload.php')) {
-    require_once __DIR__ . '/vendor/autoload.php';
-}
+require_once __DIR__ . '/includes/markdown_utils.php';
 
 function get_blog_posts() {
     $posts = [];
@@ -17,16 +15,6 @@ function get_blog_posts() {
     return $posts;
 }
 
-use League\CommonMark\CommonMarkConverter;
-
-function render_markdown(string $markdown): string {
-    static $converter = null;
-    if ($converter === null) {
-        $converter = new CommonMarkConverter();
-    }
-
-    return $converter->convert($markdown)->getContent();
-}
 
 $posts = get_blog_posts();
 $post_slug_raw = isset($_GET['post']) ? $_GET['post'] : null;
@@ -58,7 +46,7 @@ if ($post_slug_raw) {
 <?php if ($post_slug && isset($posts[$post_slug])): ?>
     <article class="blog-post">
         <h1><?php echo htmlspecialchars($posts[$post_slug]['title']); ?></h1>
-        <?php echo render_markdown(file_get_contents($posts[$post_slug]['file'])); ?>
+        <?php echo render_markdown_file($posts[$post_slug]['file']); ?>
         <p><a href="blog.php">&larr; Volver al listado</a></p>
     </article>
 <?php else: ?>

--- a/composer.json
+++ b/composer.json
@@ -12,4 +12,10 @@
     },
     "minimum-stability": "stable",
     "prefer-stable": true
+,
+    "autoload": {
+        "files": [
+            "includes/markdown_utils.php"
+        ]
+    }
 }

--- a/docs/index.php
+++ b/docs/index.php
@@ -1,18 +1,6 @@
 <?php
 require_once __DIR__ . '/../includes/head_common.php';
-if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    require_once __DIR__ . '/../vendor/autoload.php';
-}
-use League\CommonMark\CommonMarkConverter;
-
-function render_markdown_file(string $path): string {
-    static $converter = null;
-    if ($converter === null) {
-        $converter = new CommonMarkConverter();
-    }
-    $markdown = file_get_contents($path);
-    return $converter->convert($markdown)->getContent();
-}
+require_once __DIR__ . '/../includes/markdown_utils.php';
 
 $readme = __DIR__ . '/README.md';
 $docs = array_filter(glob(__DIR__ . '/*.md'), function($f) use ($readme) { return $f !== $readme; });

--- a/includes/markdown_utils.php
+++ b/includes/markdown_utils.php
@@ -1,0 +1,25 @@
+<?php
+// includes/markdown_utils.php
+// Shared utility to render markdown files using League/CommonMark
+
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+}
+
+use League\CommonMark\CommonMarkConverter;
+
+if (!function_exists('render_markdown_file')) {
+    /**
+     * Render the markdown file at the given path and return HTML.
+     */
+    function render_markdown_file(string $path): string {
+        static $converter = null;
+        if ($converter === null) {
+            $converter = new CommonMarkConverter();
+        }
+        $markdown = file_get_contents($path);
+        return $converter->convert($markdown)->getContent();
+    }
+}
+
+?>


### PR DESCRIPTION
## Summary
- create `includes/markdown_utils.php` with `render_markdown_file()` helper
- centralize markdown rendering in `docs/index.php` and `blog.php`
- autoload markdown helper via Composer

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68593620396083299f3339074e0a7453