### PR TITLE
Style gradient text in menus

### DIFF
--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -110,6 +110,17 @@
     text-align: center;
 }
 
+/* Gradient text for button labels */
+.menu-panel .menu-item-button span {
+    background-image: linear-gradient(45deg, var(--epic-purple-emperor), var(--epic-gold-main));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: var(--epic-purple-emperor);
+    color: transparent;
+    font-weight: 700;
+    text-shadow: 2px 2px 4px rgba(var(--color-negro-contraste-rgb), 0.8);
+}
+
 .menu-panel .menu-section {
     margin-top: 10px; /* Compacted */
     padding-top: 10px; /* Compacted */
@@ -157,6 +168,10 @@
     padding: 8px 12px; /* Compacted */
     text-decoration: none;
     color: var(--epic-purple-emperor);
+    background-image: linear-gradient(45deg, var(--epic-purple-emperor), var(--epic-gold-main));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
     border-radius: 3px;
     font-size: 0.85em; /* Compacted */
     transition: background-color 0.2s ease, color 0.2s ease;
@@ -312,6 +327,17 @@ body.homonexus-active #sidebar {
     background: linear-gradient(135deg,
                 rgba(var(--epic-purple-emperor-rgb),0.85),
                 rgba(var(--epic-gold-secondary-rgb),0.85));
+}
+
+/* Gradient text for sidebar links */
+#sidebar .nav-links a {
+    background-image: linear-gradient(45deg, var(--epic-purple-emperor), var(--epic-gold-main));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: var(--epic-purple-emperor);
+    color: transparent;
+    font-weight: 700;
+    text-shadow: 2px 2px 4px rgba(var(--color-negro-contraste-rgb), 0.8);
 }
 body.homonexus-active #sidebar .nav-links a {
     color: var(--epic-text-light);

--- a/assets/css/mobile_contrast.css
+++ b/assets/css/mobile_contrast.css
@@ -12,6 +12,16 @@
     text-shadow: 1px 1px 2px rgba(var(--color-negro-contraste-rgb), 0.6);
   }
 
+  /* Ensure menu button and sidebar links remain legible */
+  .menu-item-button span,
+  #sidebar .nav-links a {
+    background-image: none;
+    color: var(--epic-purple-emperor);
+    -webkit-background-clip: initial;
+    background-clip: initial;
+    text-shadow: 1px 1px 2px rgba(var(--color-negro-contraste-rgb), 0.6);
+  }
+
   /* Slightly stronger background for tagline ribbons */
   .tagline-background {
     background-color: rgba(var(--epic-purple-emperor-rgb), 0.5);


### PR DESCRIPTION
## Summary
- use purple/gold gradient in menu-item-button labels
- apply same gradient on sidebar links
- provide mobile fallbacks for gradient text

## Testing
- `bash scripts/run_tests.sh` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859382b365c8329926af8a309fd6deb