### PR TITLE
Implement body classes for sliding panels

### DIFF
--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -110,6 +110,14 @@
     text-align: center;
 }
 
+body.menu-open-left {
+    transform: translateX(250px);
+}
+
+body.menu-open-right {
+    transform: translateX(-250px);
+}
+
 .menu-panel .menu-section {
     margin-top: 10px; /* Compacted */
     padding-top: 10px; /* Compacted */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -72,6 +72,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const btn = triggerButton || document.querySelector(`[data-menu-target="${menu.id}"]`);
         updateAria(btn, menu, false);
         if (btn && triggerButton) btn.focus(); // Only focus if we passed the button explicitly
+        if (menu.classList.contains('left-panel')) {
+            document.body.classList.remove('menu-open-left');
+        } else if (menu.classList.contains('right-panel')) {
+            document.body.classList.remove('menu-open-right');
+        }
         // Recalculate anyOpen and update body classes
         updateGlobalMenuState();
         vibrateFeedback();
@@ -98,6 +103,20 @@ document.addEventListener('DOMContentLoaded', () => {
         const open = !menu.classList.contains('active');
         menu.classList.toggle('active', open);
         updateAria(btn, menu, open);
+
+        if (open) {
+            if (menu.classList.contains('left-panel')) {
+                document.body.classList.add('menu-open-left');
+            } else if (menu.classList.contains('right-panel')) {
+                document.body.classList.add('menu-open-right');
+            }
+        } else {
+            if (menu.classList.contains('left-panel')) {
+                document.body.classList.remove('menu-open-left');
+            } else if (menu.classList.contains('right-panel')) {
+                document.body.classList.remove('menu-open-right');
+            }
+        }
 
         if (open && menu.id === 'language-panel' && typeof primeTranslateLoad === 'function') {
             primeTranslateLoad();

--- a/tests/menuCompressionTest.js
+++ b/tests/menuCompressionTest.js
@@ -6,21 +6,21 @@ const { launchBrowser, closeBrowser } = require('./helpers/puppeteerSetup');
   await page.goto('http://localhost:8080/index.php');
   await page.waitForSelector('#consolidated-menu-button');
   await page.click('#consolidated-menu-button');
-  await page.waitForTimeout(500);
-  const hasClass = await page.evaluate(() => document.body.classList.contains('menu-compressed'));
-  if (hasClass) {
-    console.error('menu-compressed class should not be present');
+  await page.waitForFunction(() => document.body.classList.contains('menu-open-left'));
+  const hasClass = await page.evaluate(() => document.body.classList.contains('menu-open-left'));
+  if (!hasClass) {
+    console.error('menu-open-left not added');
     await closeBrowser(browser);
     process.exit(1);
   }
   await page.click('#consolidated-menu-button');
-  await page.waitForTimeout(500);
-  const stillHasClass = await page.evaluate(() => document.body.classList.contains('menu-compressed'));
+  await page.waitForFunction(() => !document.body.classList.contains('menu-open-left'));
+  const stillHasClass = await page.evaluate(() => document.body.classList.contains('menu-open-left'));
   if (stillHasClass) {
-    console.error('menu-compressed class still present after closing');
+    console.error('menu-open-left not removed');
     await closeBrowser(browser);
     process.exit(1);
   }
-  console.log('Menu opens without adding menu-compressed');
+  console.log('Menu toggles body class correctly');
   await closeBrowser(browser);
 })();


### PR DESCRIPTION
## Summary
- add body class manipulation to `toggleMenu` and `closeMenu`
- shift page content when panel body classes are present
- check for `menu-open-left` in menu compression test

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6859382c35b083299dd8ee07c5acfbba