### PR TITLE
Fix manual tests to use new lang-bar path

### DIFF
--- a/tests/manual/test_lang.html
+++ b/tests/manual/test_lang.html
@@ -9,7 +9,7 @@
 <div id="google_translate_element"></div>
 <button id="flag-toggle">Traducir</button>
 <p id="text">Hola Mundo</p>
-<script src="/assets/js/lang-bar.js"></script>
+<script src="/js/lang-bar.js"></script>
 </body>
 </html>
 

--- a/tests/manual/test_language_panel.html
+++ b/tests/manual/test_language_panel.html
@@ -16,6 +16,6 @@
         <img loading="lazy" src="/assets/flags/gb.svg" alt="EN" data-lang="en">
     </div>
 </div>
-<script src="/assets/js/lang-bar.js"></script>
+<script src="/js/lang-bar.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `lang-bar.js` from `/js` rather than `/assets/js`
- confirm test HTML files show the correct path

## Testing
- `npm test` *(fails: cannot find module 'puppeteer')*
- `python3 -m http.server 8000` and `curl http://127.0.0.1:8000/tests/manual/test_lang.html`

------
https://chatgpt.com/codex/tasks/task_e_6859383f481c8329b1c77715e1bdc825