### PR TITLE
Convert language flags to buttons

### DIFF
--- a/assets/css/language-panel.css
+++ b/assets/css/language-panel.css
@@ -44,16 +44,25 @@
     gap: 12px;
 }
 
-#language-panel .flag-list img {
+#language-panel .flag-list button {
+    background: none;
+    border: none;
+    padding: 0;
     width: 40px;
     cursor: pointer;
     filter: drop-shadow(0 0 3px rgba(var(--epic-purple-emperor-rgb,74,13,103),0.4));
     transition: transform 0.2s ease, filter 0.2s ease;
 }
 
-#language-panel .flag-list img:hover {
+#language-panel .flag-list button:hover {
     transform: scale(1.1);
     filter: drop-shadow(0 0 6px var(--epic-gold-main));
+}
+
+#language-panel .flag-list button img {
+    width: 100%;
+    height: auto;
+    display: block;
 }
 
 #flag-toggle {

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -363,13 +363,22 @@ body.homonexus-active #sidebar .nav-links a:hover {
     gap: 10px;
 }
 
-#language-panel .flag-list img {
+#language-panel .flag-list button {
+    background: none;
+    border: none;
+    padding: 0;
     width: 32px;
     cursor: pointer;
     transition: transform 0.2s ease;
 }
 
-#language-panel .flag-list img:hover {
+#language-panel .flag-list button:hover {
     transform: scale(1.1);
+}
+
+#language-panel .flag-list button img {
+    width: 100%;
+    height: auto;
+    display: block;
 }
 

--- a/fragments/header/language-flags.html
+++ b/fragments/header/language-flags.html
@@ -1,8 +1,14 @@
 <div id="language-panel" class="menu-panel right-panel" role="dialog" aria-labelledby="flag-toggle" tabindex="-1" aria-hidden="true">
     <div id="google_translate_element"></div>
     <div class="flag-list">
-        <img loading="lazy" src="/assets/flags/es.svg" alt="Español" data-lang="es">
-        <img loading="lazy" src="/assets/flags/gb.svg" alt="English" data-lang="en">
-        <img loading="lazy" src="/assets/flags/gl.svg" alt="Galego" data-lang="gl">
+        <button data-lang="es" aria-label="Español">
+            <img loading="lazy" src="/assets/flags/es.svg" alt="" aria-hidden="true">
+        </button>
+        <button data-lang="en" aria-label="English">
+            <img loading="lazy" src="/assets/flags/gb.svg" alt="" aria-hidden="true">
+        </button>
+        <button data-lang="gl" aria-label="Galego">
+            <img loading="lazy" src="/assets/flags/gl.svg" alt="" aria-hidden="true">
+        </button>
     </div>
 </div>

--- a/js/lang-bar.js
+++ b/js/lang-bar.js
@@ -33,9 +33,9 @@ function initFlagPanel() {
     if (btn) {
         btn.addEventListener('click', primeTranslateLoad);
     }
-    document.querySelectorAll('#language-panel img[data-lang]').forEach(flag => {
-        flag.addEventListener('click', () => {
-            const lang = flag.getAttribute('data-lang');
+    document.querySelectorAll('#language-panel button[data-lang]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const lang = btn.getAttribute('data-lang');
             const translate = () => {
                 document.cookie = 'googtrans=/es/' + lang + ';path=/';
                 location.reload();

--- a/tests/manual/test_language_panel.html
+++ b/tests/manual/test_language_panel.html
@@ -12,8 +12,12 @@
 <div id="language-panel" class="menu-panel right-panel">
     <div id="google_translate_element"></div>
     <div class="flag-list">
-        <img loading="lazy" src="/assets/flags/es.svg" alt="ES" data-lang="es">
-        <img loading="lazy" src="/assets/flags/gb.svg" alt="EN" data-lang="en">
+        <button data-lang="es" aria-label="Español">
+            <img loading="lazy" src="/assets/flags/es.svg" alt="" aria-hidden="true">
+        </button>
+        <button data-lang="en" aria-label="English">
+            <img loading="lazy" src="/assets/flags/gb.svg" alt="" aria-hidden="true">
+        </button>
     </div>
 </div>
 <script src="/assets/js/lang-bar.js"></script>


### PR DESCRIPTION
## Summary
- use buttons instead of images for the language panel
- add aria labels for accessibility
- update JavaScript handlers to target new buttons
- tweak styles so flags keep the same look
- adjust manual test markup

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68593842559483298bb13f109eb5d09c