### PR TITLE
Unify language bar offset variable

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -50,7 +50,7 @@
     /* Altura reservada para la barra de idiomas superior (no usada en el panel lateral) */
     --language-bar-height: 40px;
     /* Espacio superior aplicado al menú, ajustado dinámicamente */
-    --menu-top-offset: 0px;
+    --language-bar-offset: 0px;
     /* Additional theme variables for admin dashboard */
     --epic-purple-hover: #663399;
     --epic-gray: #6c757d;
@@ -89,7 +89,7 @@
 }
 
 body.lang-bar-visible {
-    --menu-top-offset: var(--language-bar-height);
+    --language-bar-offset: var(--language-bar-height);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -139,7 +139,7 @@ body {
     text-rendering: optimizeLegibility;
     overflow-x: hidden; /* Prevent side scrolling on narrow screens */
     animation: fadeInPage 0.7s ease-out forwards;
-    padding-top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
+    padding-top: calc(var(--menu-extra-offset) + var(--language-bar-offset));
 }
 
 body::before {
@@ -2548,7 +2548,7 @@ body.dark-mode {
     /* background-image is inherited from body::before via cascading */
     background-color: var(--epic-alabaster-bg); /* This will be the dark version of the variable */
     /* filter property is now on body.dark-mode::before */
-    padding-top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
+    padding-top: calc(var(--menu-extra-offset) + var(--language-bar-offset));
 }
 
 body.dark-mode::before {
@@ -2885,7 +2885,7 @@ body.luna {
     --global-box-shadow-medium: 0 5px 15px rgba(30, 58, 138, 0.5);
     --global-box-shadow-dark: 0 8px 25px rgba(30, 58, 138, 0.5);
     background-color: var(--epic-alabaster-bg);
-    padding-top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
+    padding-top: calc(var(--menu-extra-offset) + var(--language-bar-offset));
 }
 
 body.luna::before {

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -2,7 +2,7 @@
 
 #fixed-header-elements {
     position: fixed;
-    top: var(--menu-top-offset);
+    top: var(--language-bar-offset);
     left: 0;
     right: 0;
     z-index: 4000;
@@ -59,7 +59,7 @@
 
 .top-empty-bar {
     position: fixed;
-    top: var(--menu-top-offset);
+    top: var(--language-bar-offset);
     left: 0;
     right: 0;
     height: 48px;

--- a/assets/css/language-panel.css
+++ b/assets/css/language-panel.css
@@ -1,6 +1,6 @@
 #language-panel {
     position: fixed;
-    top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
+    top: calc(var(--menu-extra-offset) + var(--language-bar-offset));
     right: 0;
     bottom: 0;
     width: 260px;

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -38,7 +38,7 @@
 .menu-panel {
     position: fixed;
     /* Place panel below the header and language bar */
-    top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
+    top: calc(var(--menu-extra-offset) + var(--language-bar-offset));
     bottom: 0; /* Make panel full height */
     width: 250px; /* Adjust width as needed */
     max-width: 80%; /* Max width for smaller screens */
@@ -248,7 +248,7 @@
         width: 230px; /* Slightly narrower for mobile */
         padding: 10px; /* Compacted */
         padding-top: 45px; /* Compacted */
-        top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
+        top: calc(var(--menu-extra-offset) + var(--language-bar-offset));
     }
     #consolidated-menu-button {
         font-size: 1em; /* Compacted */
@@ -330,7 +330,7 @@ body.homonexus-active #sidebar .nav-links a:hover {
 #language-panel {
     position: fixed;
     /* Align panel just below the header and optional language bar */
-    top: calc(var(--menu-extra-offset) + var(--menu-top-offset));
+    top: calc(var(--menu-extra-offset) + var(--language-bar-offset));
     right: 0;
     width: 240px;
     max-width: 80%;

--- a/assets/css/pages/index.css
+++ b/assets/css/pages/index.css
@@ -15,5 +15,5 @@
 
 /* Align the hero title with the fixed menu button */
 .align-with-menu {
-    margin-top: var(--menu-top-offset);
+    margin-top: var(--language-bar-offset);
 }

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -81,6 +81,9 @@ Al añadir más elementos al contenedor puede ser necesario ajustar la posición
 }
 ```
 
+El valor de `--language-bar-offset` se actualiza automáticamente cuando el
+cuerpo tiene la clase `lang-bar-visible`. Por defecto equivale a `0px`.
+
 Esto evitará que los menús se oculten tras los botones fijos.
 
 ### Modificar la altura del contenedor

--- a/frontend/astro-components/SidebarMenu.svelte
+++ b/frontend/astro-components/SidebarMenu.svelte
@@ -57,7 +57,7 @@
 <style>
   nav {
     position: fixed;
-    top: var(--menu-top-offset, 0);
+    top: var(--language-bar-offset, 0);
     left: 0;
     height: 100%;
     width: 250px;


### PR DESCRIPTION
## Summary
- consolidate CSS offset variable to `--language-bar-offset`
- update header, language panel and page CSS references
- revise index guide to clarify how the offset variable works

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68593846cc1c8329931dc93dda2ded5c