### PR TITLE
Update testing docs for Puppeteer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Sigue la [Guía de Testing](docs/testing.md) para preparar el entorno y ejecutar
    ```bash
    python -m unittest discover -s tests
    ```
-5. Ejecuta las pruebas de Node (Puppeteer) tras instalar las dependencias con `npm install` (o usando `scripts/setup_environment.sh`):
+5. Instala el paquete **Puppeteer** si aún no lo tienes. Puedes hacerlo con `npm install` o ejecutando `scripts/setup_environment.sh`. Las pruebas de Node dependen de esta librería, de modo que asegúrate de instalarla antes de lanzar:
    ```bash
    npm run test:puppeteer
    ```


### PR DESCRIPTION
## Summary
- document installing Puppeteer for Node tests

## Testing
- `npm run test:puppeteer` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:8080/tests/manual/test_lang.html)*
- `python -m pytest tests`
- `composer install` *(fails: missing PHP dom extension)*

------
https://chatgpt.com/codex/tasks/task_e_68593c88629c83298853b0d46da0edf8