### PR TITLE
Add content compression when sliding panel opens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -659,6 +659,17 @@ html[data-theme="light"] .sliding-panel .sliding-panel-close {
     border-bottom: none;
 }
 
+body.panel-open .content {
+    transform: scale(0.96);
+    transition: transform var(--transition-speed) ease;
+}
+
+@media (min-width: 769px) {
+    body.panel-open .content {
+        margin-right: 320px; /* ancho del panel */
+    }
+}
+
 .sliding-panel ul li a:hover,
 .sliding-panel ul li a:focus {
     color: var(--accent-color);

--- a/js/main.js
+++ b/js/main.js
@@ -134,6 +134,7 @@ document.addEventListener('DOMContentLoaded', () => {
             previousActiveElement = document.activeElement;
             slidingPanel.classList.add('is-open');
             slidingPanel.setAttribute('aria-hidden', 'false');
+            document.body.classList.add('panel-open');
 
             setTimeout(() => closeSlidingPanelButton.focus(), 50);
 
@@ -154,6 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const closePanel = () => {
             slidingPanel.classList.remove('is-open'); // Oculta el panel
             slidingPanel.setAttribute('aria-hidden', 'true'); // Indica que está oculto
+            document.body.classList.remove('panel-open');
 
             // Devuelve el foco al elemento que lo tenía antes de abrir el panel
             if (previousActiveElement) {


### PR DESCRIPTION
## Summary
- apply compression effect on page content when sliding panel is active
- toggle new `panel-open` body class in main.js

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: 'flask', 'filelock')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593c897e5c832988ad018519efef66