### PR TITLE
Use CSS variable for panel width

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -46,6 +46,7 @@
     --global-box-shadow-dark: 0 8px 25px rgba(var(--epic-text-color-rgb), 0.2);
     --alabaster-background-image: url('/assets/img/alabastro.jpg');
     --menu-extra-offset: 60px;
+    --panel-width: 250px; /* default width for sliding panels */
     --header-footer-height: 60px;
     /* Altura reservada para la barra de idiomas superior (no usada en el panel lateral) */
     --language-bar-height: 40px;

--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -40,7 +40,7 @@
     /* Place panel below the header and language bar */
     top: calc(var(--menu-extra-offset) + var(--language-bar-offset));
     bottom: 0; /* Make panel full height */
-    width: 250px; /* Adjust width as needed */
+    width: var(--panel-width); /* Adjust width as needed */
     max-width: 80%; /* Max width for smaller screens */
     /* Purple translucent backdrop for the sliding menu */
     background-color: rgba(var(--epic-purple-emperor-rgb), 0.35); /* Lighter transparency */
@@ -280,8 +280,11 @@
 
 /* Responsive adjustments */
 @media (max-width: var(--breakpoint-md)) {
+    :root {
+        --panel-width: 230px;
+    }
     .menu-panel {
-        width: 230px; /* Slightly narrower for mobile */
+        width: var(--panel-width); /* Slightly narrower for mobile */
         padding: 10px; /* Compacted */
         padding-top: 45px; /* Compacted */
         top: calc(var(--menu-extra-offset) + var(--language-bar-offset));
@@ -297,8 +300,11 @@
 }
 
 @media (max-width: var(--breakpoint-lg)) {
+    :root {
+        --panel-width: 210px;
+    }
     .menu-panel {
-        width: 210px;
+        width: var(--panel-width);
     }
     #consolidated-menu-button {
         padding: 7px 11px;
@@ -306,8 +312,11 @@
 }
 
 @media (max-width: var(--breakpoint-xs)) {
+    :root {
+        --panel-width: 190px;
+    }
     .menu-panel {
-        width: 190px;
+        width: var(--panel-width);
         padding: 8px;
         padding-top: 40px;
     }

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -1,0 +1,12 @@
+/* assets/css/sliding_menu.css */
+
+/* Translate body by panel width when menu panels are open */
+body.menu-open-left {
+    transform: translateX(var(--panel-width));
+    transition: transform 0.4s ease-in-out;
+}
+
+body.menu-open-right {
+    transform: translateX(calc(-1 * var(--panel-width)));
+    transition: transform 0.4s ease-in-out;
+}


### PR DESCRIPTION
## Summary
- add `--panel-width` CSS variable in epic theme
- use the variable in consolidated-menu styles
- set responsive overrides of `--panel-width`
- define body translation styles in new `sliding_menu.css`

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68593c8cc6f48329bcf217105c4c7558