### PR TITLE
Add transition to sliding menu body classes

### DIFF
--- a/assets/css/menus/consolidated-menu.css
+++ b/assets/css/menus/consolidated-menu.css
@@ -429,3 +429,8 @@ body.homonexus-active #sidebar .nav-links a:hover {
     display: block;
 }
 
+
+body.menu-open-left,
+body.menu-open-right {
+    transition: transform 0.3s ease;
+}


### PR DESCRIPTION
## Summary
- apply `transform` transition to `<body>` when menu panels open

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68593c8f88e88329b993656281ce0fbc