### PR TITLE
Refactor markdown utils

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -1,8 +1,6 @@
 <?php
 require_once __DIR__ . '/includes/head_common.php';
-if (file_exists(__DIR__ . '/vendor/autoload.php')) {
-    require_once __DIR__ . '/vendor/autoload.php';
-}
+require_once __DIR__ . '/includes/markdown_utils.php';
 
 function get_blog_posts() {
     $posts = [];
@@ -17,18 +15,6 @@ function get_blog_posts() {
     return $posts;
 }
 
-use League\CommonMark\CommonMarkConverter;
-
-function render_markdown(string $markdown): string {
-    static $converter = null;
-    if ($converter === null) {
-        $converter = new CommonMarkConverter([
-            'html_input' => 'strip'
-        ]);
-    }
-
-    return $converter->convert($markdown)->getContent();
-}
 
 $posts = get_blog_posts();
 $post_slug_raw = isset($_GET['post']) ? $_GET['post'] : null;

--- a/docs/index.php
+++ b/docs/index.php
@@ -1,20 +1,6 @@
 <?php
 require_once __DIR__ . '/../includes/head_common.php';
-if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    require_once __DIR__ . '/../vendor/autoload.php';
-}
-use League\CommonMark\CommonMarkConverter;
-
-function render_markdown_file(string $path): string {
-    static $converter = null;
-    if ($converter === null) {
-        $converter = new CommonMarkConverter([
-            'html_input' => 'strip'
-        ]);
-    }
-    $markdown = file_get_contents($path);
-    return $converter->convert($markdown)->getContent();
-}
+require_once __DIR__ . '/../includes/markdown_utils.php';
 
 $readme = __DIR__ . '/README.md';
 $docs = array_filter(glob(__DIR__ . '/*.md'), function($f) use ($readme) { return $f !== $readme; });

--- a/historia/historia_ampliada.php
+++ b/historia/historia_ampliada.php
@@ -1,18 +1,6 @@
 <?php
 require_once __DIR__ . '/../includes/head_common.php';
-require_once __DIR__ . '/../vendor/autoload.php';
-use League\CommonMark\CommonMarkConverter;
-
-function render_markdown_file(string $path): string {
-    static $converter = null;
-    if ($converter === null) {
-        $converter = new CommonMarkConverter([
-            'html_input' => 'strip'
-        ]);
-    }
-    $markdown = file_get_contents($path);
-    return $converter->convert($markdown)->getContent();
-}
+require_once __DIR__ . '/../includes/markdown_utils.php';
 ?>
 <!DOCTYPE html>
 <html lang="es">

--- a/includes/markdown_utils.php
+++ b/includes/markdown_utils.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/env_loader.php';
+use League\CommonMark\CommonMarkConverter;
+
+function markdown_get_converter(): CommonMarkConverter {
+    static $converter = null;
+    if ($converter === null) {
+        $converter = new CommonMarkConverter([
+            'html_input' => 'strip'
+        ]);
+    }
+    return $converter;
+}
+
+function render_markdown(string $markdown): string {
+    return markdown_get_converter()->convert($markdown)->getContent();
+}
+
+function render_markdown_file(string $path): string {
+    if (!is_readable($path)) {
+        return '';
+    }
+    return render_markdown(file_get_contents($path));
+}


### PR DESCRIPTION
## Summary
- centralize markdown helper in `includes/markdown_utils.php`
- use new helper in blog, docs index and historia pages
- remove direct `vendor/autoload.php` requires

## Testing
- `scripts/run_tests.sh` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68593cad9b9083299fdb466cbadfda6d