### PR TITLE
Fix composer JSON autoload block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,10 @@
         "sort-packages": true
     },
     "minimum-stability": "stable",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add an autoload section under `prefer-stable` in `composer.json`

## Testing
- `python3 -m json.tool composer.json`
- `composer validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593caee344832981e6d7ca863eec32