### PR TITLE
Update docs menu behavior

### DIFF
--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -43,15 +43,12 @@ El panel también incluye `admin-menu.php` y `social-menu.html` dentro de bloque
 ### Apertura del panel y superposición
 
 Al pulsar un botón con `data-menu-target="id-del-panel"`,
-`assets/js/main.js` abre el panel de menú indicado. A diferencia de versiones
-anteriores, el contenido de la página ya no se desplaza ni se escala. El panel
-`.menu-panel` se posiciona de forma fija y con un `z-index` alto para superponerse
-al resto de elementos.
-
-El cuerpo de la página no recibe ya las clases `menu-compressed`,
-`menu-open-left` ni `menu-open-right`. Todo el comportamiento de
-apertura y cierre se gestiona mediante la propia clase `active` en el
-panel correspondiente.
+`assets/js/main.js` abre el panel correspondiente y añade al elemento
+`<body>` la clase `menu-open-left` o `menu-open-right`, según el
+lateral del menú. Estas clases aplican un `transform` que desplaza el
+contenido de la página para dejar espacio al panel, generando un efecto
+de deslizamiento fluido. El panel `.menu-panel` mantiene la clase
+`active` para mostrarse u ocultarse.
 
 `assets/js/main.js` sigue actualizando los atributos `aria-expanded` y
 `aria-hidden` de los botones y paneles para mantener la accesibilidad.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -147,8 +147,9 @@ secciones realicen una animación de desplazamiento fluida.
 ## Menú móvil
 
 Los paneles de menú deslizante utilizan la clase `.open` para mostrarse y
-desaparecer al quitársela. Al activarse, `assets/js/main.js` añade la clase
-`menu-compressed` al elemento `<body>` junto con `menu-open-left` o
-`menu-open-right` según el lateral. Esta combinación desplaza la página y aplica
-detalles en morado principal (`--color-primario-purpura`) con bordes en oro viejo
-(`--color-secundario-dorado`) para resaltar el estado activo.
+desaparecer al quitársela. Al activarse, `assets/js/main.js` añade al elemento
+`<body>` la clase `menu-open-left` o `menu-open-right`, según el lado desde el
+que se despliega el panel. Estas clases aplican un `transform` que desplaza el
+contenido central, resaltado con morado principal y bordes dorados
+(`--color-primario-purpura` y `--color-secundario-dorado`), para indicar el
+estado activo.


### PR DESCRIPTION
## Summary
- document new sliding menu classes
- highlight transform effect when menus are open
- explain purple/gold accenting in style guide

## Testing
- `scripts/run_tests.sh` *(fails: missing PHP DOM extension)*

------
https://chatgpt.com/codex/tasks/task_e_68593c90ec1c8329be25f6b1c131d4da