### PR TITLE
Add docs for updating forum agents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -166,7 +166,7 @@ Los estilos coinciden con `assets/css/pages/historia_subpaginas_auca_patricia_ub
 - [Relaciones de Parentesco](parent_child_pairs.md)
 - [Visualizador del Árbol Genealógico](../personajes/genealogia/index.html)
 - [Guía Fullstack 2025](fullstack-tools-2025.md)
-- [Agentes del Foro](forum_agents.md)
+- [Agentes del Foro](forum_agents.md) – incluye la sección [Cómo actualizar la lista](forum_agents.md#como-actualizar-la-lista-de-agentes)
 - [Guía de mensajes de commit](commit-style.md)
 - [Seguridad de Markdown](security.md)
 

--- a/docs/forum_agents.md
+++ b/docs/forum_agents.md
@@ -11,3 +11,13 @@ El archivo `config/forum_agents.php` define la lista de expertos que participan 
 | `role_icon` | Icono Font Awesome que identifica su rol y acompaña a su nombre en las respuestas.                           |
 
 Configurar correctamente estos campos respalda nuestra misión de **promocionar el turismo en Cerezo de Río Tirón y proteger su patrimonio arqueológico y cultural**. Los agentes actúan como guías temáticos que animan la participación y mantienen vivo el legado de Castilla.
+
+## Cómo actualizar la lista de agentes
+
+1. Edita los datos en `config/forum_agents.php` si deseas modificar los campos de un agente existente o añadir nuevos agentes manualmente.
+2. También puedes gestionar la lista desde la interfaz de administración en `backend/php/admin/forum_agents_admin.php`.
+   - Se requiere una cuenta con permisos de administrador.
+   - El formulario permite cambiar nombre, biografía y área de experiencia de cada agente y crear otros nuevos.
+3. Al guardar, el sistema actualiza el archivo `config/forum_agents.php` con los cambios introducidos.
+
+Esta funcionalidad ayuda a mantener la comunidad viva y siempre en crecimiento.


### PR DESCRIPTION
## Summary
- document how to update `config/forum_agents.php` and the admin interface
- link directly to the new guide from `docs/README.md`

## Testing
- `python -m unittest tests/test_graph_db_interface.py` *(fails: ModuleNotFoundError: No module named 'filelock')*
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68594dd5b3988329af4c81e14d90ba1d