### PR TITLE
Update docs README with dashboard link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ _proteger su patrimonio arqueológico y cultural_.
 - `museo/` – páginas del museo y fichas de piezas.
 - `foro/` – área gestionada por agentes expertos.
 - `backend/` – API en Flask e integración de IA.
+- `dashboard/` – panel de administración y estadísticas (ver [dashboard/README.html](../dashboard/README.html) para configuración y uso).
 - `docs/` – documentación completa.
 
 ## Árbol de directorios


### PR DESCRIPTION
## Summary
- link to dashboard/README.html for instructions on setting up and using the admin dashboard

## Testing
- `bash scripts/run_tests.sh` *(fails: missing PHP DOM extension)*

------
https://chatgpt.com/codex/tasks/task_e_68594dd69d50832980d2e8824ba3642b