### PR TITLE
Fix manual heading colors

### DIFF
--- a/fragments/header.php
+++ b/fragments/header.php
@@ -86,19 +86,19 @@
             <!-- El botón de Chat IA se clonará aquí para móvil por main.js -->
         </div>
         <div class="menu-section" style="margin-bottom: 15px;">
-            <h4 class="gradient-text" style="font-size: 0.9em; margin-bottom: 8px; text-transform: uppercase; color: var(--epic-purple-emperor);">Navegación</h4>
+            <h4 class="gradient-text" style="font-size: 0.9em; margin-bottom: 8px; text-transform: uppercase;">Navegación</h4>
             <div id="main-menu-placeholder">
                 <!-- El menú principal (ul#main-menu) se clonará aquí -->
             </div>
         </div>
         <div id="admin-menu-placeholder-container" class="menu-section" style="margin-bottom: 15px;">
-            <h4 class="gradient-text" style="font-size: 0.9em; margin-bottom: 8px; text-transform: uppercase; color: var(--epic-purple-emperor);">Admin</h4>
+            <h4 class="gradient-text" style="font-size: 0.9em; margin-bottom: 8px; text-transform: uppercase;">Admin</h4>
             <div id="admin-menu-placeholder">
                 <!-- El menú de admin (contenido de #admin-menu-source-content) se clonará aquí -->
             </div>
         </div>
         <div class="menu-section">
-            <h4 class="gradient-text" style="font-size: 0.9em; margin-bottom: 8px; text-transform: uppercase; color: var(--epic-purple-emperor);">Social</h4>
+            <h4 class="gradient-text" style="font-size: 0.9em; margin-bottom: 8px; text-transform: uppercase;">Social</h4>
             <div id="social-menu-placeholder">
                 <!-- Los enlaces sociales (contenido de #social-menu-source-content) se clonará aquí -->
             </div>

--- a/historia/subpaginas_indice.php
+++ b/historia/subpaginas_indice.php
@@ -58,7 +58,7 @@ load_page_css();
                                     <?php if (isset($tema['ruta_html_original'])): ?>
                                         <a href="/<?php echo htmlspecialchars(ltrim($tema['ruta_html_original'], '/')); ?>" class="read-more">Leer más...</a>
                                     <?php else: ?>
-                                        <span class="read-more" style="background-color: grey;">Enlace no disponible</span>
+                                        <span class="read-more" style="background-color: var(--epic-alabaster-medium);">Enlace no disponible</span>
                                     <?php endif; ?>
                                 </li>
                             <?php endforeach; ?>

--- a/lugares/alfozcerezolantaron/alfoz.php
+++ b/lugares/alfozcerezolantaron/alfoz.php
@@ -12,7 +12,7 @@
 
 
     <header class="page-header hero bg-[url('/assets/img/hero_alfoz_background.jpg')] bg-cover bg-center md:bg-center">
-        <div class="hero-content" style="background-color: rgba(var(--color-negro-contraste-rgb), 0.5); padding: clamp(30px, 5vw, 50px);">
+        <div class="hero-content" style="background-color: rgba(var(--epic-alabaster-medium-rgb), 0.5); padding: clamp(30px, 5vw, 50px);">
             <img loading="lazy" src="/assets/img/estrella.png" alt="Estrella de Venus decorativa" class="decorative-star-header" style="width: clamp(50px, 8vw, 70px); margin-bottom:15px;">
             <h1 class="gradient-text" style="font-size: clamp(2.6em, 6.5vw, 4.2em);">El Alfoz de Cerasio y Lantarón</h1>
             <p style="font-size: clamp(1.05em, 2.3vw, 1.45em); max-width: 70ch;">Cimientos de Castilla, Génesis de la Hispanidad.</p>

--- a/lugares/cerasio.php
+++ b/lugares/cerasio.php
@@ -11,7 +11,7 @@
     <?php require_once __DIR__ . '/../fragments/header.php'; ?>
 
     <header class="page-header hero bg-[url('/assets/img/hero_mis_tierras.jpg')] bg-cover bg-center md:bg-center">
-        <div class="hero-content" style="background-color: rgba(var(--color-negro-contraste-rgb), 0.5); padding: clamp(30px, 5vw, 50px);">
+        <div class="hero-content" style="background-color: rgba(var(--epic-alabaster-medium-rgb), 0.5); padding: clamp(30px, 5vw, 50px);">
             <h1 style="font-size: clamp(2.6em, 6.5vw, 4.2em);">Cerasio</h1>
             <p style="font-size: clamp(1.05em, 2.3vw, 1.45em); max-width: 70ch;">Reflexiones y fragmentos tomados de <code>nuevo4.md</code> sobre el origen de Castilla.</p>
         </div>

--- a/personajes/galeria_3d.html
+++ b/personajes/galeria_3d.html
@@ -83,7 +83,7 @@
 
         #character-info-overlay #info-whisper {
             font-style: italic;
-            background-color: rgba(0,0,0,0.3);
+            background-color: rgba(var(--epic-text-color-rgb), 0.3);
             padding: 12px;
             border-radius: 8px;
             margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- remove inline color styles from sidebar headings
- theme hero overlays with alabaster palette variables
- use palette colors for unavailable links and whisper overlay

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68595127501c83299a27841084df6d76