### PR TITLE
Add markdown utility autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "autoload": {
         "psr-4": {
             "App\\": "src/"
-        }
+        },
+        "files": [
+            "includes/markdown_utils.php"
+        ]
     }
 }


### PR DESCRIPTION
## Summary
- autoload `includes/markdown_utils.php` via Composer

## Testing
- `composer dump-autoload`
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6859512ac6fc832981fc7cfd97999e33