### PR TITLE
Add mission API endpoint

### DIFF
--- a/docs/forum_agents_api.md
+++ b/docs/forum_agents_api.md
@@ -21,3 +21,13 @@ Cada clave identifica al agente y su valor incluye nombre, biografía, especiali
 ```
 
 Este endpoint ayuda a construir interfaces dinámicas que muestran la información de los expertos sin duplicar datos en el frontend.
+
+## `GET /api/mission`
+
+Devuelve un JSON con la misión del proyecto. El texto se obtiene de `docs/README.md` (líneas 3‑7).
+
+```json
+{
+  "mission": "Este directorio reúne todas las guías del proyecto **Condado de Castilla**.\n\nLa misión principal es _promocionar el turismo en Cerezo de Río Tirón y_\n_proteger su patrimonio arqueológico y cultural_."
+}
+```

--- a/flask_app.py
+++ b/flask_app.py
@@ -126,6 +126,19 @@ def forum_comments_handler():
         except Exception as exc:
             return jsonify({'error': str(exc)}), 500
 
+
+@app.route('/api/mission', methods=['GET'])
+def mission_handler():
+    """Return mission text from docs/README.md lines 3-7."""
+    try:
+        readme_path = os.path.join(os.path.dirname(__file__), 'docs', 'README.md')
+        with open(readme_path, 'r', encoding='utf-8') as f:
+            lines = f.readlines()[2:7]
+        text = ''.join(lines).strip()
+        return jsonify({'mission': text})
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 500
+
 if __name__ == '__main__':
     debug_env = os.getenv('FLASK_DEBUG')
     debug_mode = str(debug_env).lower() in ('1', 'true')

--- a/tests/test_flask_api.py
+++ b/tests/test_flask_api.py
@@ -84,5 +84,12 @@ class FlaskApiTestCase(unittest.TestCase):
         self.assertIsInstance(data, dict)
         self.assertGreaterEqual(len(data), 5)
 
+    def test_mission_endpoint(self):
+        res = self.client.get('/api/mission')
+        self.assertEqual(res.status_code, 200)
+        data = res.get_json()
+        self.assertIn('mission', data)
+        self.assertIn('Cerezo de Río Tirón', data['mission'])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- expose mission lines via /api/mission
- document new endpoint
- test the mission route

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685951645b508329b7583305237c8c34