### PR TITLE
Remove legacy menu-toggle block

### DIFF
--- a/assets/js/slider_menu.js
+++ b/assets/js/slider_menu.js
@@ -1,10 +1,11 @@
-document.addEventListener('DOMContentLoaded', () => {
-    const btn = document.getElementById('menu-toggle');
-    const menu = document.getElementById('menu');
-    if (!btn || !menu) return;
-    btn.addEventListener('click', () => {
-        const open = menu.classList.toggle('open');
-        btn.setAttribute('aria-expanded', open);
-        document.body.classList.toggle('menu-compressed', open);
-    });
-});
+// Legacy slider menu functionality disabled
+// document.addEventListener('DOMContentLoaded', () => {
+//     const btn = document.getElementById('menu-toggle');
+//     const menu = document.getElementById('menu');
+//     if (!btn || !menu) return;
+//     btn.addEventListener('click', () => {
+//         const open = menu.classList.toggle('open');
+//         btn.setAttribute('aria-expanded', open);
+//         document.body.classList.toggle('menu-compressed', open);
+//     });
+// });

--- a/fragments/slider_menu.php
+++ b/fragments/slider_menu.php
@@ -1,3 +1,4 @@
+<!--
 <nav class="slider-menu">
     <button id="menu-toggle" aria-expanded="false" class="cta-button">Menú</button>
     <ul id="menu">
@@ -7,3 +8,4 @@
         <li><a href="#foro">Foro</a></li>
     </ul>
 </nav>
+-->


### PR DESCRIPTION
## Summary
- comment out old slider menu block in `fragments/slider_menu.php`
- disable unused logic in `assets/js/slider_menu.js`

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68598365866c832981948bd76d3fb41a