### PR TITLE
Remove old Nueva Web buttons

### DIFF
--- a/fragments/admin_header.php
+++ b/fragments/admin_header.php
@@ -14,7 +14,6 @@ if ($geminiNotice) {
         <img loading="lazy" src="/assets/icons/columna.svg" class="header-icon" alt="Roman column icon" />
         <button id="admin-menu-button" data-menu-target="admin-menu-items" aria-label="Abrir menú administrador" aria-expanded="false" role="button" aria-controls="admin-menu-items">☰</button>
         <button id="homonexus-toggle" aria-label="Activar Homonexus" aria-pressed="false">👥</button>
-        <a href="/nuevaweb/index.php" class="cta-button cta-button-small">Nueva Web</a>
     </div>
 </div>
 

--- a/fragments/header.php
+++ b/fragments/header.php
@@ -8,7 +8,6 @@
         <button id="flag-toggle" data-menu-target="language-panel" aria-label="Seleccionar idioma" aria-haspopup="true" aria-expanded="false" role="button" aria-controls="language-panel"><i class="fas fa-flag"></i></button>
         <button id="mute-toggle" aria-pressed="false" aria-label="Silenciar">🔊</button>
         <button id="homonexus-toggle" aria-label="Activar Homonexus" aria-pressed="false">👥</button>
-        <a href="/nuevaweb/index.php" class="cta-button cta-button-small">Nueva Web</a>
     </div>
 </div>
 <!-- Left Sliding Panel for Main Menu -->


### PR DESCRIPTION
## Summary
- clean up header buttons by removing `Nueva Web` CTA

## Testing
- `phpunit --configuration phpunit.xml` *(fails: session errors, php-cgi missing)*
- `pytest -q tests/test_nuevaweb_api.py`
- `npm test` *(fails: puppeteer TimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_685983662d5c8329ba80fe86e97d4668