### PR TITLE
Improve language panel with close button

### DIFF
--- a/assets/css/language-panel.css
+++ b/assets/css/language-panel.css
@@ -3,7 +3,7 @@
     top: calc(var(--menu-extra-offset) + var(--language-bar-offset));
     right: 0;
     bottom: 0;
-    width: 260px;
+    width: var(--language-panel-width, 320px);
     max-width: 80%;
     /* Purple translucent backdrop similar to other panels */
     background: rgba(var(--epic-purple-emperor-rgb, 74,13,103), 0.9);
@@ -36,6 +36,23 @@
 #language-panel.active {
     transform: translateX(0);
     opacity: 1;
+}
+
+/* Header container for the language panel */
+.language-panel-header {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+#close-language-panel {
+    background: none;
+    border: none;
+    font-size: 1.6em;
+    cursor: pointer;
+    color: inherit;
+    padding: 0.2rem 0.5rem;
 }
 
 #language-panel .flag-list {

--- a/assets/js/sliding-menu.js
+++ b/assets/js/sliding-menu.js
@@ -304,4 +304,15 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
+
+    const closeLanguagePanelButton = document.getElementById('close-language-panel');
+    if (closeLanguagePanelButton) {
+        closeLanguagePanelButton.addEventListener('click', () => {
+            const panel = document.getElementById('language-panel');
+            if (panel && panel.classList.contains('active')) {
+                const btn = document.querySelector('[data-menu-target="language-panel"]');
+                closeMenu(panel, btn);
+            }
+        });
+    }
 });

--- a/fragments/header/language-flags.html
+++ b/fragments/header/language-flags.html
@@ -1,4 +1,7 @@
 <div id="language-panel" class="menu-panel right-panel" role="dialog" aria-labelledby="flag-toggle" tabindex="-1" aria-hidden="true">
+    <div class="language-panel-header">
+        <button id="close-language-panel" aria-label="Cerrar">×</button>
+    </div>
     <div id="google_translate_element"></div>
     <div class="flag-list">
         <button data-lang="es" aria-label="Español">


### PR DESCRIPTION
## Summary
- enlarge language panel with new `--language-panel-width`
- add close button to language flag panel
- support closing language panel via button in sliding-menu.js

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6859838746148329b9a988beee63362a