### PR TITLE
Fix sliding menu shift

### DIFF
--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -7,6 +7,7 @@ body.menu-open-left {
 }
 
 body.menu-open-right {
-    transform: translateX(calc(-1 * var(--panel-width)));
-    transition: transform 0.4s ease-in-out;
+    /* Prevent shifting main content when right panels open */
+    transform: none;
+    transition: none;
 }

--- a/assets/js/sliding-menu.js
+++ b/assets/js/sliding-menu.js
@@ -14,7 +14,10 @@ document.addEventListener('DOMContentLoaded', () => {
         if (menu.classList.contains('left-panel')) {
             document.body.classList.toggle('menu-open-left', open);
         } else if (menu.classList.contains('right-panel')) {
-            document.body.classList.toggle('menu-open-right', open);
+            // menu-open-right previously shifted the body via CSS transform.
+            // The transform has been disabled, so toggling is no longer needed
+            // for layout. Preserve hook for other effects if required.
+            // document.body.classList.toggle('menu-open-right', open);
         }
     };
 

--- a/tests/languagePanelBodyClassTest.js
+++ b/tests/languagePanelBodyClassTest.js
@@ -7,22 +7,20 @@ const awaitTranslateOrSkip = require('./utils/skipIfNoTranslate');
   await page.goto('http://localhost:8080/tests/manual/test_language_panel.html');
   await page.waitForSelector('#flag-toggle');
   await page.click('#flag-toggle');
-  await page.waitForFunction(() => document.body.classList.contains('menu-open-right'));
   await awaitTranslateOrSkip(page);
-  const hasClass = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
-  if (!hasClass) {
-    console.error('menu-open-right not added');
+  const hasClassAfterOpen = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
+  if (hasClassAfterOpen) {
+    console.error('menu-open-right should not be added');
     await closeBrowser(browser);
     process.exit(1);
   }
   await page.click('#flag-toggle');
-  await page.waitForFunction(() => !document.body.classList.contains('menu-open-right'));
-  const stillHas = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
-  if (stillHas) {
-    console.error('menu-open-right not removed');
+  const hasClassAfterClose = await page.evaluate(() => document.body.classList.contains('menu-open-right'));
+  if (hasClassAfterClose) {
+    console.error('menu-open-right should remain absent after closing');
     await closeBrowser(browser);
     process.exit(1);
   }
-  console.log('Language panel body class toggled correctly');
+  console.log('Language panel no longer toggles body class');
   await closeBrowser(browser);
 })();

--- a/tests/mainHeader.test.js
+++ b/tests/mainHeader.test.js
@@ -126,6 +126,7 @@ async function runTests() {
         expect(await isElementVisible(aiChatTriggerSel), "Botón AI Chat no visible en panel consolidado").toBe(true);
         await page.click(aiChatTriggerSel); await delay(DELAY_MS);
         expect(await hasClass('#ai-chat-panel', 'active'), "Panel AI no activo").toBe(true);
+        expect(await hasClass('body', 'menu-open-right'), "Body class toggled for AI panel").toBe(false);
         await page.click('#ai-chat-panel #close-ai-drawer'); await delay(DELAY_MS);
         expect(await hasClass('#ai-chat-panel', 'active'), "Panel AI no cerrado por botón interno").toBe(false);
         await page.click('#consolidated-menu-button'); await delay(DELAY_MS); // Cerrar panel principal
@@ -134,6 +135,7 @@ async function runTests() {
         expect(await hasClass('#language-panel', 'active'), "Panel idioma activo al inicio").toBe(false);
         await page.click('#flag-toggle'); await delay(DELAY_MS);
         expect(await hasClass('#language-panel', 'active'), "Panel idioma no activo tras click").toBe(true);
+        expect(await hasClass('body', 'menu-open-right'), "Body class toggled for language panel").toBe(false);
         await page.click('body'); await delay(DELAY_MS); // Click fuera
         expect(await hasClass('#language-panel', 'active'), "Panel idioma no cerrado por click fuera").toBe(false);
 


### PR DESCRIPTION
## Summary
- disable body transform when right panels open
- stop toggling body class from JS
- update test for menu-open-right body class
- ensure header tests check body class isn't toggled

## Testing
- `npm test` *(fails: php executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598387c6d48329b3714460dd6cb139