### PR TITLE
Update sliding menu compression

### DIFF
--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -1,12 +1,28 @@
 /* assets/css/sliding_menu.css */
 
-/* Translate body by panel width when menu panels are open */
+:root {
+    --active-panel-width: var(--panel-width);
+}
+
+/* Smooth transitions for body adjustments */
+body {
+    transition: margin-left var(--global-transition-speed) ease-in-out,
+                margin-right var(--global-transition-speed) ease-in-out,
+                width var(--global-transition-speed) ease-in-out,
+                box-shadow var(--global-transition-speed) ease-in-out;
+}
+
+body.menu-open-left,
+body.menu-open-right {
+    width: calc(100% - var(--active-panel-width));
+}
+
 body.menu-open-left {
-    transform: translateX(var(--panel-width));
-    transition: transform 0.4s ease-in-out;
+    margin-left: var(--active-panel-width);
+    box-shadow: inset 0 0 0 3px var(--epic-purple-emperor);
 }
 
 body.menu-open-right {
-    transform: translateX(calc(-1 * var(--panel-width)));
-    transition: transform 0.4s ease-in-out;
+    margin-right: var(--active-panel-width);
+    box-shadow: inset 0 0 0 3px var(--epic-gold-main);
 }

--- a/assets/js/sliding-menu.js
+++ b/assets/js/sliding-menu.js
@@ -11,6 +11,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const updateBodyForPanel = (menu, open) => {
         if (!menu) return;
+
+        const root = document.documentElement;
+        if (open) {
+            root.style.setProperty('--active-panel-width', `${menu.offsetWidth}px`);
+        } else {
+            root.style.removeProperty('--active-panel-width');
+        }
+
         if (menu.classList.contains('left-panel')) {
             document.body.classList.toggle('menu-open-left', open);
         } else if (menu.classList.contains('right-panel')) {


### PR DESCRIPTION
## Summary
- compress main content when sliding panels open
- highlight left/right open state using purple and gold
- track panel width in JS via `--active-panel-width`

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6859838d481483298ffe470b2f860765