### PR TITLE
Add AI chat panel and trigger

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -2917,3 +2917,9 @@ body.luna .firefly {
     50% { opacity: 1; transform: translateY(-15px) scale(1); }
     100% { opacity: 0; transform: translateY(-30px) scale(0.5); }
 }
+
+/* AI Chat Panel */
+#ai-chat-panel {
+    background: rgba(var(--epic-purple-emperor-rgb), 0.75);
+    color: var(--epic-gold-main);
+}

--- a/assets/js/sliding-menu.js
+++ b/assets/js/sliding-menu.js
@@ -114,6 +114,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const anyPanelOpen = document.querySelectorAll('.menu-panel.active').length > 0;
         const sidebarOpen = document.getElementById(sidebarMenuId)?.classList.contains('sidebar-visible');
         const anyOpen = anyPanelOpen || sidebarOpen;
+        const leftPanelOpen = document.querySelector('.menu-panel.left-panel.active');
+        document.body.classList.toggle('menu-open-left', !!leftPanelOpen);
 
         if (window.audioController && typeof window.audioController.handleMenuToggle === 'function') {
             window.audioController.handleMenuToggle(anyOpen);

--- a/fragments/header.php
+++ b/fragments/header.php
@@ -13,9 +13,11 @@ require_once __DIR__ . '/../includes/auth.php'; // For is_admin_logged_in()
         </div>
 
         <div class="flex items-center space-x-3">
-            <!-- El botón de Chat IA separado se elimina -->
             <button id="open-unified-panel-button" aria-label="Abrir Menú y Herramientas" aria-expanded="false" aria-controls="unified-panel" class="text-old-gold hover:text-white transition-colors">
-                <i class="fas fa-bars text-2xl"></i> {/* O un icono más tipo "puntos verticales" o "engranaje" si se prefiere */}
+                <i class="fas fa-bars text-2xl"></i>
+            </button>
+            <button id="ai-chat-trigger" data-menu-target="ai-chat-panel" aria-label="Abrir chat IA" aria-haspopup="dialog" class="text-old-gold hover:text-white transition-colors">
+                <i class="fas fa-comments text-2xl"></i>
             </button>
         </div>
     </div>
@@ -67,22 +69,6 @@ require_once __DIR__ . '/../includes/auth.php'; // For is_admin_logged_in()
                 </ul>
             </div>
 
-            <!-- Chat IA -->
-            <div class="menu-section ai-chat-section mb-6">
-                <h3 class="text-sm font-semibold uppercase text-old-gold mb-2 border-b border-gray-700 pb-1">Asistente IA</h3>
-                <div class="p-2 rounded bg-gray-800"> {/* Contenedor para el chat */}
-                <?php
-                if (file_exists(__DIR__ . '/header/ai-drawer.html')) {
-                    // El contenido de ai-drawer.html puede necesitar ajustes de estilo para este nuevo contexto
-                    // Específicamente, el header dentro de ai-drawer.html y el botón de cierre podrían ser redundantes.
-                    // Por ahora, se incluye tal cual.
-                    echo file_get_contents(__DIR__ . '/header/ai-drawer.html');
-                } else {
-                    echo '<p class="text-xs text-gray-500">Interfaz de Chat IA no encontrada.</p>';
-                }
-                ?>
-                </div>
-            </div>
 
             <!-- Comunidad -->
             <div class="menu-section community-links-section mb-6">
@@ -118,6 +104,17 @@ require_once __DIR__ . '/../includes/auth.php'; // For is_admin_logged_in()
 
         </div> <!-- Fin de Panel Content Scrollable -->
     </div>
+</aside>
+
+<!-- AI Chat Sliding Panel (Left) -->
+<aside id="ai-chat-panel" class="menu-panel left-panel" role="dialog" aria-modal="true" aria-labelledby="ai-chat-title" tabindex="-1" aria-hidden="true">
+    <?php
+    if (file_exists(__DIR__ . '/header/ai-drawer.html')) {
+        echo file_get_contents(__DIR__ . '/header/ai-drawer.html');
+    } else {
+        echo '<p class="text-xs text-gray-500">Interfaz de Chat IA no encontrada.</p>';
+    }
+    ?>
 </aside>
 
 <!-- Overlay for modals/drawers (se mantiene igual) -->

--- a/tests/AiDrawerTest.php
+++ b/tests/AiDrawerTest.php
@@ -26,6 +26,8 @@ class AiDrawerTest extends TestCase {
         [$status, $out, $err] = $this->runPage(__DIR__.'/../index.php');
         $this->assertSame(0, $status, $err);
         $this->assertStringContainsString('id="ai-drawer"', $out);
+        $this->assertStringContainsString('id="ai-chat-panel"', $out);
+        $this->assertStringContainsString('id="ai-chat-trigger"', $out);
     }
 }
 ?>

--- a/tests/mainHeader.test.js
+++ b/tests/mainHeader.test.js
@@ -119,17 +119,15 @@ async function runTests() {
         await page.click('#consolidated-menu-button'); await delay(DELAY_MS);
         expect(await hasClass('#consolidated-menu-items', 'active'), "Panel cons. no oculto tras 2do click (desktop)").toBe(false);
 
-        console.log("TEST: Panel AI Chat (#ai-chat-panel) debe abrir desde panel consolidado y cerrar");
-        await page.click('#consolidated-menu-button'); await delay(DELAY_MS);
-        const aiChatTriggerSel = '#consolidated-menu-items #ai-chat-trigger';
+        console.log("TEST: Panel AI Chat (#ai-chat-panel) debe abrirse y cerrarse");
+        const aiChatTriggerSel = '#ai-chat-trigger';
         await page.waitForSelector(aiChatTriggerSel, { visible: true });
-        expect(await isElementVisible(aiChatTriggerSel), "Botón AI Chat no visible en panel consolidado").toBe(true);
+        expect(await isElementVisible(aiChatTriggerSel), "Botón AI Chat no visible").toBe(true);
         await page.click(aiChatTriggerSel); await delay(DELAY_MS);
         expect(await hasClass('#ai-chat-panel', 'active'), "Panel AI no activo").toBe(true);
-        expect(await hasClass('body', 'menu-open-right'), "Body class toggled for AI panel").toBe(false);
+        expect(await hasClass('body', 'menu-open-left'), "Body class menu-open-left no aplicado").toBe(true);
         await page.click('#ai-chat-panel #close-ai-drawer'); await delay(DELAY_MS);
         expect(await hasClass('#ai-chat-panel', 'active'), "Panel AI no cerrado por botón interno").toBe(false);
-        await page.click('#consolidated-menu-button'); await delay(DELAY_MS); // Cerrar panel principal
 
         console.log("TEST: Panel Idioma (#language-panel) debe abrir con #flag-toggle y cerrar");
         expect(await hasClass('#language-panel', 'active'), "Panel idioma activo al inicio").toBe(false);


### PR DESCRIPTION
## Summary
- enable left-side AI chat panel
- tweak epic theme with AI panel colors
- adjust sliding-menu.js for left panel body class
- update tests for new AI chat trigger and panel

## Testing
- `vendor/bin/phpunit --filter AiDrawerTest` *(fails: command not found)*
- `npm run test:playwright` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad13b3620832997722492363d9ca8