### PR TITLE
Update language panel to slide from top

### DIFF
--- a/assets/css/language-panel.css
+++ b/assets/css/language-panel.css
@@ -1,18 +1,17 @@
 #language-panel {
     position: fixed;
-    top: calc(var(--menu-extra-offset) + var(--language-bar-offset));
+    top: 0;
+    left: 0;
     right: 0;
-    bottom: 0;
-    width: var(--language-panel-width, 320px);
-    max-width: 80%;
+    width: 100%;
     /* Purple translucent backdrop similar to other panels */
-    background: rgba(var(--epic-purple-emperor-rgb, 74,13,103), 0.9);
-    border-left: 2px solid var(--epic-gold-main);
-    box-shadow: -3px 0 15px rgba(var(--epic-purple-emperor-rgb, 74,13,103), 0.3);
+    background: rgba(var(--epic-purple-emperor-rgb, 74,13,103), 0.75);
+    border-bottom: 2px solid var(--epic-gold-main);
+    box-shadow: 0 3px 15px rgba(var(--epic-purple-emperor-rgb, 74,13,103), 0.3);
     padding: 20px;
     display: flex;
     flex-direction: column;
-    transform: translateX(100%);
+    transform: translateY(-100%);
     opacity: 0;
     transition: transform 0.3s ease, opacity 0.3s ease;
     z-index: 1000;
@@ -20,7 +19,7 @@
 
 @media (max-width: 480px) {
     #language-panel {
-        width: 90%;
+        width: 100%;
     }
 }
 
@@ -34,7 +33,7 @@
 }
 
 #language-panel.active {
-    transform: translateX(0);
+    transform: translateY(0);
     opacity: 1;
 }
 

--- a/assets/css/sliding_menu.css
+++ b/assets/css/sliding_menu.css
@@ -11,3 +11,8 @@ body.menu-open-right {
     transform: none;
     transition: none;
 }
+
+body.menu-open-top {
+    transform: translateY(var(--language-panel-height, 100px));
+    transition: transform 0.4s ease-in-out;
+}

--- a/assets/js/sliding-menu.js
+++ b/assets/js/sliding-menu.js
@@ -18,6 +18,8 @@ document.addEventListener('DOMContentLoaded', () => {
             // The transform has been disabled, so toggling is no longer needed
             // for layout. Preserve hook for other effects if required.
             // document.body.classList.toggle('menu-open-right', open);
+        } else if (menu.classList.contains('top-panel')) {
+            document.body.classList.toggle('menu-open-top', open);
         }
     };
 

--- a/fragments/header/language-flags.html
+++ b/fragments/header/language-flags.html
@@ -1,4 +1,4 @@
-<div id="language-panel" class="menu-panel right-panel" role="dialog" aria-labelledby="flag-toggle" tabindex="-1" aria-hidden="true">
+<div id="language-panel" class="menu-panel top-panel" role="dialog" aria-labelledby="flag-toggle" tabindex="-1" aria-hidden="true">
     <div class="language-panel-header">
         <button id="close-language-panel" aria-label="Cerrar">×</button>
     </div>

--- a/tests/mainHeader.test.js
+++ b/tests/mainHeader.test.js
@@ -135,7 +135,7 @@ async function runTests() {
         expect(await hasClass('#language-panel', 'active'), "Panel idioma activo al inicio").toBe(false);
         await page.click('#flag-toggle'); await delay(DELAY_MS);
         expect(await hasClass('#language-panel', 'active'), "Panel idioma no activo tras click").toBe(true);
-        expect(await hasClass('body', 'menu-open-right'), "Body class toggled for language panel").toBe(false);
+        expect(await hasClass('body', 'menu-open-top'), "Body class toggled for language panel").toBe(true);
         await page.click('body'); await delay(DELAY_MS); // Click fuera
         expect(await hasClass('#language-panel', 'active'), "Panel idioma no cerrado por click fuera").toBe(false);
 


### PR DESCRIPTION
## Summary
- move language panel to the top
- style width across the page
- add `menu-open-top` toggle in JS
- expect `menu-open-top` in header tests

## Testing
- `npm install`
- `npm test` *(fails: `php` server missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ad13b5d9883298e477a2edee450cb