### PR TITLE
Consolidate menu transitions

### DIFF
--- a/assets/css/components/menu.css
+++ b/assets/css/components/menu.css
@@ -1,0 +1,20 @@
+/* Shared sliding menu utilities */
+:root {
+    --menu-transition: transform var(--global-transition-speed) ease-in-out;
+}
+
+.menu-panel {
+    transition: var(--menu-transition);
+}
+
+.menu-panel.left-panel {
+    transform: translateX(-100%);
+}
+
+.menu-panel.right-panel {
+    transform: translateX(100%);
+}
+
+.menu-panel.open {
+    transform: translateX(0);
+}

--- a/assets/css/header/nav.css
+++ b/assets/css/header/nav.css
@@ -1,4 +1,5 @@
 @import url("../components/breakpoints.css");
+@import url("../components/menu.css");
 /* --- Navbar Styles ----------------------------------------------------- */
 /*
 .navbar {
@@ -155,24 +156,18 @@
 #sidebar {
     position: fixed;
     top: 0;
-    left: 0; /* Base position for transform */
+    left: 0;
     width: 280px;
     height: 100vh;
     background-color: rgba(var(--epic-alabaster-bg-rgb, 253, 250, 246), 0.55);
-    backdrop-filter: blur(7px); /* Optional: frosted glass effect */
-    padding: 25px 15px; /* Refined padding */
+    backdrop-filter: blur(7px);
+    padding: 25px 15px;
     box-shadow: 3px 0 15px rgba(var(--epic-text-color-rgb), 0.25);
-    transform: translateX(-100%); /* Hidden off-screen */
-    transition: transform var(--global-transition-speed) ease-in-out;
     overflow-y: auto;
     z-index: 3000;
     display: flex;
     flex-direction: column;
     border-right: 2px solid var(--epic-gold-secondary);
-}
-
-#sidebar.sidebar-visible {
-    transform: translateX(0); /* Shown on-screen */
 }
 
 #sidebar-toggle {

--- a/assets/js/menu-toggle.js
+++ b/assets/js/menu-toggle.js
@@ -1,0 +1,6 @@
+export function toggleMenu(button, panel) {
+    if (!button || !panel) return;
+    const isOpen = panel.classList.toggle('open');
+    button.setAttribute('aria-expanded', isOpen);
+    panel.setAttribute('aria-hidden', !isOpen);
+}

--- a/assets/js/sliding-menu.js
+++ b/assets/js/sliding-menu.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const closeMobileSidebar = (menu, btn) => {
-        menu.classList.remove('sidebar-visible');
+        menu.classList.remove('open');
         document.body.classList.remove('sidebar-active');
         updateAria(btn, menu, false);
         if (btn) btn.focus();
@@ -41,10 +41,10 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!menu) return;
 
         // Close other panel menus
-        document.querySelectorAll('.menu-panel.active').forEach(m => closeMenu(m));
+        document.querySelectorAll('.menu-panel.open').forEach(m => closeMenu(m));
 
-        const open = !menu.classList.contains('sidebar-visible');
-        menu.classList.toggle('sidebar-visible', open);
+        const open = !menu.classList.contains('open');
+        menu.classList.toggle('open', open);
         document.body.classList.toggle('sidebar-active', open);
         updateAria(btn, menu, open);
 
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const closeMenu = (menu, triggerButton = null) => { // Added triggerButton for focus
-        menu.classList.remove('active');
+        menu.classList.remove('open');
         updateBodyForPanel(menu, false);
         const btn = triggerButton || document.querySelector(`[data-menu-target="${menu.id}"]`);
         updateAria(btn, menu, false);
@@ -76,18 +76,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Close sidebar if open
         const sidebar = document.getElementById(sidebarMenuId);
-        if (sidebar && sidebar.classList.contains('sidebar-visible')) {
+        if (sidebar && sidebar.classList.contains('open')) {
             const sidebarBtn = document.getElementById('consolidated-menu-button'); // Assuming this is the sidebar toggle
             closeMobileSidebar(sidebar, sidebarBtn);
         }
 
         // Close any other active panel menus to avoid overlap
-        document.querySelectorAll('.menu-panel.active').forEach(m => {
+        document.querySelectorAll('.menu-panel.open').forEach(m => {
             if (m !== menu) closeMenu(m, document.querySelector(`[data-menu-target="${m.id}"]`));
         });
 
-        const open = !menu.classList.contains('active');
-        menu.classList.toggle('active', open);
+        const open = !menu.classList.contains('open');
+        menu.classList.toggle('open', open);
         updateAria(btn, menu, open);
         updateBodyForPanel(menu, open);
 
@@ -111,8 +111,8 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const updateGlobalMenuState = () => {
-        const anyPanelOpen = document.querySelectorAll('.menu-panel.active').length > 0;
-        const sidebarOpen = document.getElementById(sidebarMenuId)?.classList.contains('sidebar-visible');
+        const anyPanelOpen = document.querySelectorAll('.menu-panel.open').length > 0;
+        const sidebarOpen = document.getElementById(sidebarMenuId)?.classList.contains('open');
         const anyOpen = anyPanelOpen || sidebarOpen;
 
         if (window.audioController && typeof window.audioController.handleMenuToggle === 'function') {
@@ -133,7 +133,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 // If #consolidated-menu-items is the target on desktop, ensure sidebar is closed
                 if (btn.id === 'consolidated-menu-button' && btn.getAttribute('data-menu-target') === 'consolidated-menu-items') {
                     const sidebar = document.getElementById(sidebarMenuId);
-                    if (sidebar && sidebar.classList.contains('sidebar-visible')) {
+                    if (sidebar && sidebar.classList.contains('open')) {
                         closeMobileSidebar(sidebar, btn);
                     }
                 }
@@ -174,7 +174,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         // Close panel menus if click is outside
-        document.querySelectorAll('.menu-panel.active').forEach(menu => {
+        document.querySelectorAll('.menu-panel.open').forEach(menu => {
             const btn = document.querySelector(`[data-menu-target="${menu.id}"]`);
             // If the click is outside the menu and not on its toggle button
             if (!menu.contains(e.target) && !(btn && btn.contains(e.target))) {
@@ -185,7 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Close sidebar if click is outside
         const sidebar = document.getElementById(sidebarMenuId);
         const consolidatedMenuButton = document.getElementById('consolidated-menu-button');
-        if (sidebar && sidebar.classList.contains('sidebar-visible')) {
+        if (sidebar && sidebar.classList.contains('open')) {
             // If the click is outside the sidebar and not on the consolidated menu button
             if (!sidebar.contains(e.target) && !(consolidatedMenuButton && consolidatedMenuButton.contains(e.target))) {
                 closeMobileSidebar(sidebar, consolidatedMenuButton);
@@ -195,11 +195,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.addEventListener('keydown', (e) => {
         if (e.key === 'Escape') {
-            document.querySelectorAll('.menu-panel.active').forEach(menu => {
+            document.querySelectorAll('.menu-panel.open').forEach(menu => {
                 closeMenu(menu, document.querySelector(`[data-menu-target="${menu.id}"]`));
             });
             const sidebar = document.getElementById(sidebarMenuId);
-            if (sidebar && sidebar.classList.contains('sidebar-visible')) {
+            if (sidebar && sidebar.classList.contains('open')) {
                 const sidebarBtn = document.getElementById('consolidated-menu-button');
                 closeMobileSidebar(sidebar, sidebarBtn);
             }
@@ -212,12 +212,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const consolidatedMenuButton = document.getElementById('consolidated-menu-button');
 
         // Close all panel menus
-        document.querySelectorAll('.menu-panel.active').forEach(menu => {
+        document.querySelectorAll('.menu-panel.open').forEach(menu => {
             closeMenu(menu, document.querySelector(`[data-menu-target="${menu.id}"]`));
         });
 
         // Close sidebar
-        if (sidebar && sidebar.classList.contains('sidebar-visible')) {
+        if (sidebar && sidebar.classList.contains('open')) {
             closeMobileSidebar(sidebar, consolidatedMenuButton);
         }
 
@@ -232,7 +232,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (closeDrawer) {
         closeDrawer.addEventListener('click', () => {
             const panel = document.getElementById('ai-chat-panel');
-            if (panel && panel.classList.contains('active')) { // Ensure panel is active before closing
+            if (panel && panel.classList.contains('open')) { // Ensure panel is open before closing
                 const btn = document.querySelector(`[data-menu-target="ai-chat-panel"]`);
                 closeMenu(panel, btn); // Pass button for focus
             }
@@ -302,7 +302,7 @@ document.addEventListener('DOMContentLoaded', () => {
         closeSidebarButton.addEventListener('click', () => {
             const sidebar = document.getElementById(sidebarMenuId); // sidebarMenuId is 'sidebar'
             const consolidatedMenuButton = document.getElementById('consolidated-menu-button');
-            if (sidebar && sidebar.classList.contains('sidebar-visible')) {
+            if (sidebar && sidebar.classList.contains('open')) {
                 closeMobileSidebar(sidebar, consolidatedMenuButton);
             }
         });
@@ -312,7 +312,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (closeLanguagePanelButton) {
         closeLanguagePanelButton.addEventListener('click', () => {
             const panel = document.getElementById('language-panel');
-            if (panel && panel.classList.contains('active')) {
+            if (panel && panel.classList.contains('open')) {
                 const btn = document.querySelector('[data-menu-target="language-panel"]');
                 closeMenu(panel, btn);
             }

--- a/nuevaweb/static/assets/css/modern.css
+++ b/nuevaweb/static/assets/css/modern.css
@@ -1,3 +1,5 @@
+@import url("../../../../assets/css/components/menu.css");
+
 /* Estilos generales */
 :root {
     --primary-color: #6a0dad; /* Morado principal */
@@ -232,11 +234,16 @@ footer a:hover {
     header ul {
         flex-direction: column;
         width: 100%;
-        display: none; /* Initially hidden on mobile */
+        position: absolute;
+        top: 100%;
+        right: 0;
+        transform: translateX(100%);
+        transition: var(--menu-transition);
+        background: var(--primary-color);
     }
 
-    header ul.active {
-        display: flex; /* Show when active */
+    header ul.open {
+        transform: translateX(0);
     }
 
     header ul li {

--- a/nuevaweb/static/assets/js/main.js
+++ b/nuevaweb/static/assets/js/main.js
@@ -1,13 +1,11 @@
+import { toggleMenu } from './menu-toggle.js';
+
 document.addEventListener('DOMContentLoaded', () => {
     const menuToggle = document.querySelector('.menu-toggle');
     const mainMenu = document.getElementById('main-menu');
 
     if (menuToggle && mainMenu) {
-        menuToggle.addEventListener('click', ()_ => {
-            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true' || false;
-            menuToggle.setAttribute('aria-expanded', !isExpanded);
-            mainMenu.classList.toggle('active');
-        });
+        menuToggle.addEventListener('click', () => toggleMenu(menuToggle, mainMenu));
     }
 
     // Smooth scroll for anchor links (optional, if you add internal page links)

--- a/nuevaweb/static/index.html
+++ b/nuevaweb/static/index.html
@@ -60,6 +60,6 @@
         <p><a href="/nuevaweb/README.md">Acerca de esta web</a></p>
     </footer>
 
-    <script src="assets/js/main.js"></script>
+    <script type="module" src="assets/js/main.js"></script>
 </body>
 </html>

--- a/tests/playwright/nuevaweb_static_index.spec.js
+++ b/tests/playwright/nuevaweb_static_index.spec.js
@@ -92,10 +92,12 @@ test.describe('Nueva Web - Página de Inicio (nuevaweb/static/index.html)', () =
     await expect(mainMenu).not.toBeVisible(); // El menú debe estar oculto inicialmente
 
     await menuToggle.click();
-    await expect(mainMenu).toBeVisible(); // El menú debe mostrarse después del clic
+    await expect(mainMenu).toHaveClass(/open/);
+    const transform = await mainMenu.evaluate(e => getComputedStyle(e).transform);
+    expect(transform).not.toBe('none');
 
     await menuToggle.click();
-    await expect(mainMenu).not.toBeVisible(); // El menú debe ocultarse de nuevo
+    await expect(mainMenu).not.toHaveClass(/open/);
   });
 
   test('No debe haber superposición de elementos importantes en vista móvil', async ({ page, isMobile }) => {


### PR DESCRIPTION
## Summary
- add menu transition utility CSS
- import utility and simplify sidebar styles
- create module for toggling menus and refactor main.js
- use `.open` class in sliding-menu and tests
- ensure index.html loads script as module

## Testing
- `npx playwright test tests/playwright/nuevaweb_static_index.spec.js` *(fails: Needs playwright install)*

------
https://chatgpt.com/codex/tasks/task_e_685ad140ca7c8329abdb450211d3344d