### PR TITLE
Add escudo banner container

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -2917,3 +2917,31 @@ body.luna .firefly {
     50% { opacity: 1; transform: translateY(-15px) scale(1); }
     100% { opacity: 0; transform: translateY(-30px) scale(0.5); }
 }
+
+/* Escudo banner styling */
+#escudo-banner {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 1rem 0;
+}
+
+#escudo-banner .hero-escudo {
+    width: clamp(200px, 45vw, 340px);
+    height: auto;
+    z-index: 2;
+}
+
+#escudo-banner .banner-iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+    opacity: 0.4;
+    pointer-events: none;
+    z-index: 1;
+}

--- a/assets/css/header/topbar.css
+++ b/assets/css/header/topbar.css
@@ -145,3 +145,31 @@ body.dark-mode #theme-toggle:hover i {
     50% { transform: translate(-50%, -50%) scale(1.2) rotate(5deg); }
     100% { transform: translate(-50%, -50%) scale(1) rotate(0deg); }
 }
+
+/* Escudo banner above navigation */
+#escudo-banner {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 1rem 0;
+}
+
+#escudo-banner .hero-escudo {
+    width: clamp(200px, 45vw, 340px);
+    height: auto;
+    z-index: 2;
+}
+
+#escudo-banner .banner-iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+    opacity: 0.4;
+    pointer-events: none;
+    z-index: 1;
+}

--- a/fragments/footer.php
+++ b/fragments/footer.php
@@ -62,6 +62,4 @@ if ('serviceWorker' in navigator) {
 // type="module" src="/assets/js/sliding-menu.js" -> Probablemente obsoleto por nuevo sistema de sidebar/drawers
 // defer src="/assets/js/slider_menu.js" -> Probablemente obsoleto
 // src="/assets/js/cave_mask.js" -> Relacionado con efectos visuales del header antiguo
-// src="/assets/js/escudo-reveal.js" -> Relacionado con efectos visuales del header antiguo
-// src="/assets/js/escudo-drag.js" -> Relacionado con efectos visuales del header antiguo
 </script>

--- a/fragments/header.php
+++ b/fragments/header.php
@@ -33,6 +33,11 @@ require_once __DIR__ . '/../includes/auth.php'; // For is_admin_logged_in()
         <!-- Panel Content (Scrollable) -->
         <div class="flex-grow p-4 overflow-y-auto">
 
+            <div id="escudo-banner">
+                <img src="/assets/img/escudo.jpg" alt="Escudo" class="hero-escudo">
+                <iframe src="BANNER_URL" class="banner-iframe" loading="lazy"></iframe>
+            </div>
+
             <!-- Navegación Principal -->
             <div class="menu-section mb-6">
                 <h3 class="text-sm font-semibold uppercase text-old-gold mb-2 border-b border-gray-700 pb-1">Navegación</h3>


### PR DESCRIPTION
## Summary
- show escudo banner above navigation
- style banner container and iframe background
- clean up obsolete escudo script references

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685ad14243608329a805e20f16385451