### PR TITLE
Remove unused mobile AI chat trigger cloning

### DIFF
--- a/assets/js/sliding-menu.js
+++ b/assets/js/sliding-menu.js
@@ -245,29 +245,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // IA chat toggle and Homonexus functionality removed
 
-    function setupMobileAIChatTrigger() {
-        if (window.innerWidth <= 768) {
-            const originalTrigger = document.getElementById('ai-chat-trigger');
-            const placeholderMobile = document.getElementById('ai-chat-trigger-placeholder-mobile');
-
-            if (originalTrigger && placeholderMobile && placeholderMobile.children.length === 0) {
-                const clonedTrigger = originalTrigger.cloneNode(true);
-                clonedTrigger.id = 'ai-chat-trigger-mobile';
-                // Ensure the data-menu-target is still correct for the cloned button.
-                // If event listeners were attached by ID, they might need re-attaching or using class based listeners.
-                // However, the current main click listener uses e.target.closest('[data-menu-target]'), which will work.
-                placeholderMobile.appendChild(clonedTrigger);
-            }
-        }
-    }
-    setupMobileAIChatTrigger(); // Call it on initial load
-
-    // Also consider calling setupMobileAIChatTrigger in handleResize if the trigger should be added/removed dynamically
-    // For now, it's only added if on mobile on load. If resizing from desktop to mobile, it won't be there.
-    // And if resizing from mobile to desktop, it will remain in the sidebar unless explicitly removed.
-    // The subtask asks for it to be cloned when mobile sidebar is initialized/opened or on DOMContentLoaded.
-    // For simplicity, DOMContentLoaded is chosen here. A more robust solution might involve the resize handler.
-
     function populateSidebarContents() {
         const mainMenuPlaceholder = document.getElementById('main-menu-placeholder');
         const adminMenuPlaceholder = document.getElementById('admin-menu-placeholder');

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -65,7 +65,7 @@ Estos son los accesos que incorpora por defecto:
 
 - `#consolidated-menu-button` abre el panel lateral con toda la navegación.
 - `#open-unified-panel-button` despliega el nuevo panel IA y la barra de idiomas.
-- `#ai-chat-trigger` abre directamente el antiguo cajón IA.
+- `#ai-chat-trigger` abre directamente el cajón IA. En móviles no se clona al panel lateral.
 - `#theme-toggle` alterna entre modo claro y oscuro.
 Al añadir más elementos al contenedor puede ser necesario ajustar la posición de los paneles deslizantes. Para ello define la variable `--menu-extra-offset` con la altura del contenedor y úsala junto a `--language-bar-offset` en `assets/css/menus/consolidated-menu.css`:
 

--- a/docs/js-modules-overview.md
+++ b/docs/js-modules-overview.md
@@ -4,7 +4,7 @@ This document summarizes the purpose of the main JavaScript files present in the
 
 | File                             | Description                                                                                                                                                                                                     |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `assets/js/sliding-menu.js`      | Handles sliding menu open/close logic and updates body classes `menu-open-left` and `menu-open-right`.
+| `assets/js/sliding-menu.js`      | Handles sliding menu open/close logic and updates body classes `menu-open-left` and `menu-open-right`. The previous mobile trigger cloning has been removed.
 | `assets/js/main.js`              | Manages theme toggles and other global helpers used across all pages.
 | `assets/js/homonexus-toggle.js`  | Toggles Homonexus mode, storing the preference in a cookie.                                                                                                                                                     |
 | `assets/js/foro.js`              | Simple toggling for the forum agents menu.                                                                                                                                                                      |


### PR DESCRIPTION
## Summary
- clean up sliding-menu.js by removing the mobile trigger cloning
- document that the AI chat button stays in the header
- note cloning removal in the JS modules overview

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_685b2b53c4548329b5c8239fd37aea15