### PR TITLE
Improve CONTRIBUTING instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,14 @@ npm install
 ```
 
 Con esto tendrás listo el entorno para ejecutar las pruebas descritas en [docs/testing.md](docs/testing.md).
+
+## Ejecutar pruebas
+
+1. Instala las dependencias con `npm install`, `pip install -r requirements.txt` y `composer install`.
+2. Usa `npm run test` para correr las pruebas de Node. Este comando ejecuta `scripts/start_php_server.sh` para iniciar un servidor PHP temporal en `localhost:8080`.
+3. Si lo prefieres, tambien puedes lanzar las pruebas de PHP y Python manualmente:
+   ```bash
+   vendor/bin/phpunit
+   python -m unittest discover -s tests
+   ```
+

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ ejecutando `npm install`. Esto descargará paquetes como `puppeteer` y
    ```bash
    php -S localhost:8080
    ```
+> **Nota:** `npm run test` lanza `scripts/start_php_server.sh` para iniciar este servidor de forma temporal.
 3. Ejecuta las pruebas de PHP:
    ```bash
    vendor/bin/phpunit


### PR DESCRIPTION
## Summary
- document running `npm install` and `pip install -r requirements.txt`
- note that `npm run test` starts a PHP server automatically
- add a short test section in CONTRIBUTING

## Testing
- `npm install`
- `pip install -r requirements.txt`
- `npm run test` *(fails: php not found)*
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_685b2b5129fc83298712c41560dc3c03