### PR TITLE
Add header chat and language docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Los colores predominantes son el morado principal, el oro viejo y el alabastro. 
 - `tests/` – pruebas automáticas.
 - `legacy/` – versiones antiguas conservadas por compatibilidad. La página principal anterior (`index.html`) ahora reside aquí y **`index.php`** es el punto de entrada actual.
 
+## Controles del encabezado
+
+La cabecera fija (`fragments/header.php`) incorpora accesos rápidos para el chat con IA y la selección de idioma. Cada botón emplea `data-menu-target` para abrir el panel correspondiente mediante `assets/js/sliding-menu.js`:
+
+```html
+<button id="open-unified-panel-button" data-menu-target="unified-panel"></button>
+<button id="ai-chat-trigger" data-menu-target="ai-chat-panel"></button>
+<button id="flag-toggle" data-menu-target="language-panel"></button>
+```
+
+Al pulsarlos, el script añade clases como `menu-open-left` o `menu-open-top` al `<body>` y muestra los paneles `#unified-panel`, `#ai-chat-panel` o `#language-panel`. Consulta [docs/index-guide.md](docs/index-guide.md) para más detalles.
+
 ## Tecnologías recomendadas
 
 El proyecto emplea PHP y Python con Flask. Para nuevos módulos se aconseja usar los frameworks modernos listados en [docs/fullstack-tools-2025.md](docs/fullstack-tools-2025.md): React, Next.js, Vue 3, Svelte/SvelteKit, Astro, SolidJS, Vite y TailwindCSS en el frontend, junto con FastAPI o NestJS para la capa de servicios. Se sugiere Docker y Docker Compose para un entorno reproducible.

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -185,12 +185,14 @@ Al enviar el formulario se regenerará `config/forum_agents.php` con la nueva in
 
 ## Nuevo panel IA
 
-El botón `#open-unified-panel-button` abre `#unified-panel`, un cajón lateral que integra navegación, herramientas del sitio y el asistente de inteligencia artificial. Dentro de este panel el chat se incrusta desde `fragments/header/ai-drawer.html` sin su cabecera original. Los eventos de apertura y cierre se gestionan en `assets/js/ui-drawers.js`.
+El botón `#open-unified-panel-button` (con `data-menu-target="unified-panel"`) abre `#unified-panel`, un cajón lateral que integra navegación, herramientas del sitio y el asistente de inteligencia artificial. Dentro de este panel el chat se incrusta desde `fragments/header/ai-drawer.html` sin su cabecera original. Los eventos de apertura y cierre se gestionan en `assets/js/ui-drawers.js`.
 
 Este nuevo panel, junto al de traducción superior, facilita el acceso inmediato a contenido multilingüe y al soporte conversacional. Su objetivo es reforzar nuestra misión de **promocionar el turismo en Cerezo de Río Tirón y proteger su patrimonio arqueológico y cultural**.
 
 ## Panel superior de traducción
 
 El archivo `fragments/header/language-flags.html` define `#language-panel` con los botones de idioma. Se puede abrir con `#flag-toggle` o desde el propio `#unified-panel`. Cuando está activo, `js/lang-bar.js` carga el widget de Google Translate y aplica la selección.
+
+Para invocarlo desde cualquier página basta con un botón con `data-menu-target="language-panel"`. `assets/js/sliding-menu.js` se ocupa de desplegarlo y de añadir la clase `menu-open-top` al `<body>`.
 
 Para que los menús se posicionen correctamente, ajusta `--language-bar-offset` según la altura de la barra y usa los estilos de `assets/css/language-panel.css`.


### PR DESCRIPTION
## Summary
- document new IA chat and language controls in the README
- note `data-menu-target` usage in the index guide

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError)*
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2b52b0048329ae85a462f8ba8b4d