### PR TITLE
Add test setup note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,13 @@ npm install
 ```
 
 Con esto tendrás listo el entorno para ejecutar las pruebas descritas en [docs/testing.md](docs/testing.md).
+
+## Pruebas
+
+Antes de ejecutar `npm test`, instala primero las dependencias de Node:
+
+```bash
+npm install
+```
+
+Las pruebas basadas en Node usan **puppeteer**, por lo que este paquete debe estar disponible para que la suite se ejecute correctamente.


### PR DESCRIPTION
## Summary
- add instructions about running `npm install` before `npm test`
- clarify Puppeteer requirement for Node-based tests

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b2bb173108329ba48a80e2035d318