### PR TITLE
Load banner URL from config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,5 @@ APP_DEBUG=false
 # Base URL del sitio utilizada por scripts como `generate_sitemap.py`
 # Modifícala para pruebas locales o entornos de staging.
 BASE_URL="https://condadodecastilla.com"
+# Imagen usada como banner/escudo en la cabecera
+HEADER_BANNER_URL="/assets/img/escudo.jpg"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ El proyecto emplea PHP y Python con Flask. Para nuevos módulos se aconseja usar
    ```
 
 2. Sustituye los valores de ejemplo por tus credenciales locales (base de datos, claves de API y ajustes de depuración).
+3. Opcionalmente define `HEADER_BANNER_URL` para personalizar la imagen del escudo que aparece en la cabecera.
 
 ### Solución de problemas de base de datos
 

--- a/fragments/header.php
+++ b/fragments/header.php
@@ -2,12 +2,13 @@
 // fragments/header.php
 // UNIFIED PANEL RIGHT STRUCTURE
 require_once __DIR__ . '/../includes/auth.php'; // For is_admin_logged_in()
+require_once __DIR__ . '/../includes/config.php';
 ?>
 <header class="site-header bg-imperial-purple text-old-gold shadow-md sticky top-0 z-50">
     <div class="container-epic mx-auto flex items-center justify-between p-4">
         <div class="flex items-center">
             <a href="/" class="logo-link flex items-center text-xl font-bold">
-                <img src="/assets/img/escudo.jpg" alt="Logo Condado de Castilla" class="h-10 w-10 mr-2 rounded-full border border-old-gold">
+                <img src="<?= htmlspecialchars(HEADER_BANNER_URL, ENT_QUOTES) ?>" alt="Logo Condado de Castilla" class="h-10 w-10 mr-2 rounded-full border border-old-gold">
                 <span class="hidden sm:inline site-title">Condado de Castilla</span>
             </a>
         </div>

--- a/includes/config.php
+++ b/includes/config.php
@@ -5,3 +5,8 @@ if (!defined('FORUM_COMMENT_COOLDOWN')) {
     $cooldown = getenv('FORUM_COMMENT_COOLDOWN');
     define('FORUM_COMMENT_COOLDOWN', $cooldown !== false ? (int)$cooldown : 60);
 }
+
+if (!defined('HEADER_BANNER_URL')) {
+    $banner = getenv('HEADER_BANNER_URL');
+    define('HEADER_BANNER_URL', $banner !== false ? $banner : '/assets/img/escudo.jpg');
+}


### PR DESCRIPTION
## Summary
- expose `HEADER_BANNER_URL` constant in `includes/config.php`
- use the constant in `fragments/header.php`
- document new setting in README
- include sample variable in `.env.example`

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*
- `composer exec phpunit -- --stop-on-failure` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2bb47a048329bee398f9ee7ef854