### PR TITLE
Update forum admin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Los colores predominantes son el morado principal, el oro viejo y el alabastro. 
 - `includes/` – fragmentos PHP reutilizables y conexión a la base de datos.
 - `museo/` – páginas del museo y fichas de piezas.
 - `foro/` – área de debate gestionada por cinco agentes expertos.
+- Mantén las biografías de los agentes alineadas con la misión: promocionar el turismo y proteger el patrimonio.
 - `backend/` – API en Python (Flask) y herramientas de IA.
 - `nuevaweb/` – rediseño experimental del sitio ([nuevaweb/README.md](nuevaweb/README.md)). Incluye un API Flask de demo (`flask_app.py`) independiente de la API principal.
 - `docs/` – documentación completa.

--- a/docs/forum_agents.md
+++ b/docs/forum_agents.md
@@ -20,4 +20,12 @@ Configurar correctamente estos campos respalda nuestra misión de **promocionar 
    - El formulario permite cambiar nombre, biografía y área de experiencia de cada agente y crear otros nuevos.
 3. Al guardar, el sistema actualiza el archivo `config/forum_agents.php` con los cambios introducidos.
 
+## Gestion desde la interfaz web
+
+1. Abre `backend/php/admin/forum_agents_admin.php` en tu navegador.
+2. Inicia sesión con una cuenta con permisos de **administrador**.
+3. Usa el formulario para editar los agentes o añadir uno nuevo.
+4. Pulsa **Guardar** y se generará de nuevo `config/forum_agents.php`.
+5. Encontrarás ese archivo en el directorio `config/` de la raíz del proyecto.
 Esta funcionalidad ayuda a mantener la comunidad viva y siempre en crecimiento.
+


### PR DESCRIPTION
## Summary
- expand docs/forum_agents with admin guide
- note about aligned biographies

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit --stop-on-failure` *(fails: phpunit not found)*
- `npm run test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_685c0d058c888329913dadead0305a7f