### PR TITLE
Update guides for menu compression layout

### DIFF
--- a/docs/fullstack-tools-2025.md
+++ b/docs/fullstack-tools-2025.md
@@ -115,3 +115,4 @@ Fullstack: Next.js + API en Python o Node (NestJS)
 ```
 
 Este proyecto sigue una estética basada en tonos morados y oro viejo sobre fondos de alabastro. Los menús son deslizantes, las letras presentan degradados de alto contraste y se emplea la versión más reciente de las bibliotecas JavaScript y las mejoras de CSS/HTML.
+La maquetación actual hace que los paneles laterales compriman el contenido desde el borde correspondiente para mostrar la navegación sin ocultar la página.

--- a/docs/index-guide.md
+++ b/docs/index-guide.md
@@ -44,11 +44,11 @@ El panel también incluye `admin-menu.php` y `social-menu.html` dentro de bloque
 
 Al pulsar un botón con `data-menu-target="id-del-panel"`,
 `assets/js/sliding-menu.js` abre el panel correspondiente y añade al elemento
-`<body>` la clase `menu-open-left` o `menu-open-right`, según el
-lateral del menú. Estas clases aplican un `transform` que desplaza el
-contenido de la página para dejar espacio al panel, generando un efecto
-de deslizamiento fluido. El panel `.menu-panel` mantiene la clase
-`active` para mostrarse u ocultarse.
+`<body>` la clase `menu-open-left` o `menu-open-right` dependiendo del lateral
+desde el que se muestre el panel. Con el nuevo diseño estas clases reducen el
+ancho del contenido central desde el borde activado en lugar de desplazarlo por
+completo, creando un efecto de compresión lateral. El panel `.menu-panel`
+mantiene la clase `active` para mostrarse u ocultarse.
 
 `assets/js/sliding-menu.js` sigue actualizando los atributos `aria-expanded` y
 `aria-hidden` de los botones y paneles para mantener la accesibilidad.
@@ -67,6 +67,9 @@ Estos son los accesos que incorpora por defecto:
 - `#open-unified-panel-button` despliega el nuevo panel IA y la barra de idiomas.
 - `#ai-chat-trigger` abre directamente el cajón IA. En móviles no se clona al panel lateral.
 - `#theme-toggle` alterna entre modo claro y oscuro.
+Los botones se sitúan en la parte superior: el de menú consolidado queda a la
+izquierda mientras que `#open-unified-panel-button` y `#ai-chat-trigger` se
+agrupan a la derecha para equilibrar la cabecera.
 Al añadir más elementos al contenedor puede ser necesario ajustar la posición de los paneles deslizantes. Para ello define la variable `--menu-extra-offset` con la altura del contenedor y úsala junto a `--language-bar-offset` en `assets/css/menus/consolidated-menu.css`:
 
 ```css

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -147,12 +147,13 @@ secciones realicen una animación de desplazamiento fluida.
 ## Menú móvil
 
 Los paneles de menú deslizante utilizan la clase `.open` para mostrarse y
-desaparecer al quitársela. Al activarse, `assets/js/sliding-menu.js` añade al elemento
-`<body>` la clase `menu-open-left` o `menu-open-right`, según el lado desde el
-que se despliega el panel. Estas clases aplican un `transform` que desplaza el
-contenido central, resaltado con morado principal y bordes dorados
-(`--color-primario-purpura` y `--color-secundario-dorado`), para indicar el
-estado activo.
+desaparecer al quitársela. Al activarse, `assets/js/sliding-menu.js` añade al
+elemento `<body>` la clase `menu-open-left` o `menu-open-right`, según el lado
+desde el que se despliega el panel. Con la nueva maquetación estas clases ya no
+empujan el contenido, sino que lo **comprimen lateralmente** para dejar espacio
+al menú. El fondo morado con bordes de oro viejo
+(`--color-primario-purpura` y `--color-secundario-dorado`) destaca así el estado
+activo sin desorientar al usuario.
 
 ## Estilo de los paneles IA y traducción
 


### PR DESCRIPTION
## Summary
- clarify lateral compression behaviour in style guide
- document sliding menu changes in index guide
- note new panel behaviour in fullstack tools guide

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: Cannot find module 'puppeteer')*


------
https://chatgpt.com/codex/tasks/task_e_685c0d089f048329b319134c8bbef86e