### PR TITLE
Add translations for group_explora and group_participa

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -30,5 +30,7 @@
   "group_lugares_patrimonio": "Lugares y Patrimonio",
   "group_servicios_visitante": "Servicios al Visitante",
   "group_comunidad": "Comunidad",
-  "group_herramientas": "Tools"
+  "group_herramientas": "Tools",
+  "group_explora": "Explore",
+  "group_participa": "Participate"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -30,5 +30,7 @@
   "group_lugares_patrimonio": "Lugares y Patrimonio",
   "group_servicios_visitante": "Servicios al Visitante",
   "group_comunidad": "Comunidad",
-  "group_herramientas": "Herramientas"
+  "group_herramientas": "Herramientas",
+  "group_explora": "Explora",
+  "group_participa": "Participa"
 }

--- a/i18n/gl.json
+++ b/i18n/gl.json
@@ -30,5 +30,7 @@
   "group_lugares_patrimonio": "Lugares y Patrimonio",
   "group_servicios_visitante": "Servicios al Visitante",
   "group_comunidad": "Comunidad",
-  "group_herramientas": "Ferramentas"
+  "group_herramientas": "Ferramentas",
+  "group_explora": "Explora",
+  "group_participa": "Participa"
 }


### PR DESCRIPTION
## Summary
- extend i18n files with labels for `group_explora` and `group_participa`

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'flask')*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d1574748329bc50432f253235ea