### PR TITLE
Use palette variables in CSS

### DIFF
--- a/assets/css/epic_theme.css
+++ b/assets/css/epic_theme.css
@@ -2390,7 +2390,7 @@ body.dark-mode .footer .social-links a:focus-visible {
     height: 60vh; /* Responsive height based on viewport height */
     max-height: 700px; /* Maximum height to prevent it from becoming too large on tall screens */
     margin: 20px auto; /* Center it if parent is wider */
-    background-color: #1a1a1a; /* Dark background for the canvas itself, can be overridden by renderer */
+    background-color: var(--color-negro-contraste); /* Dark background for the canvas itself, can be overridden by renderer */
     border-radius: var(--global-border-radius);
     box-shadow: inset 0 2px 8px rgba(0,0,0,0.5); /* Optional inner shadow */
     position: relative; /* For potential overlays or UI elements on top */
@@ -2788,7 +2788,7 @@ button, input[type="submit"], input[type="button"], .cta-button, .submit-button,
     width: 100%;
     height: 100%;
     background-color: rgba(var(--epic-purple-emperor-rgb), 0.85);
-    color: white;
+    color: var(--epic-text-light);
     display: flex;
     justify-content: center;
     align-items: center;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -31,7 +31,7 @@
     --current-text: var(--color-text-dark);
     --current-link-color: var(--color-primary);
     --current-link-hover-color: var(--color-secondary);
-    --current-card-bg: #ffffff;
+    --current-card-bg: var(--epic-alabaster-bg);
     --current-border-color: #e5e7eb; /* Gris claro para bordes */
     --current-icon-filter: none;
 }
@@ -400,9 +400,9 @@ main {
 
 /* DB Warning */
 .db-warning {
-    background-color: #ffdddd;
-    border-left: 6px solid #f44336;
-    color: #333;
+    background-color: var(--alert-bg);
+    border-left: 6px solid var(--alert-border);
+    color: var(--alert-text, var(--epic-text-color));
     padding: 1em;
     margin-bottom: 1em;
     text-align: center;


### PR DESCRIPTION
## Summary
- set current card background to use epic alabaster variable
- use alert variables in `.db-warning`
- tweak pointer lock instruction text color
- ensure 3D canvas background uses style guide variable

## Testing
- `python -m unittest discover -s tests`
- `npm run test`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d1663d88329ae8fa96f19117b65